### PR TITLE
Å-machine opcode debugging message

### DIFF
--- a/src/js/engine.js
+++ b/src/js/engine.js
@@ -915,6 +915,7 @@ function vm_run(e, param) {
 		while(true) {
 			a = deref(a);
 			b = deref(b);
+			//console.log('Unifying ' + tohex(a, 2) + ' and ' + tohex(b, 2));
 			if((a & 0xe000) == 0x8000 && (b & 0xe000) == 0x8000) {
 				if(e.trl <= e.aux) throw AUXFULL;
 				if(a < b) {


### PR DESCRIPTION
 I’ve changed the commented debug message to also include the opcode mnemonics, for easier reference. I’ve also included a commented debug message for the unify procedure in the next commit, but it’s still hard to read the raw word encoding for the values. The 2nd commit can be left out if the pretty-printing should be implemented first.