### PR TITLE
Improve spec 0.5 documentation

### DIFF
--- a/docs/aam-specification-0.5.txt
+++ b/docs/aam-specification-0.5.txt
@@ -159,13 +159,13 @@ Game state:
 		LONG (32-bit)	INST	Instruction pointer
 		LONG		CONT	Continuation pointer
 
-		WORD		TOP	Main heap top
-		WORD		ENV	Env frame pointer
-		WORD		CHO	Choice frame pointer
+		WORD		TOP	Main heap top (allocates upwards)
+		WORD		ENV	Env frame pointer (grows downwards)
+		WORD		CHO	Choice frame pointer (grows downwards)
 		WORD		SIM	Simple cut or null
 
-		WORD		AUX	Aux stack pointer
-		WORD		TRL	Trail stack pointer
+		WORD		AUX	Aux stack pointer (grows upwards)
+		WORD		TRL	Trail stack pointer (grows downwards)
 
 		WORD		STA	Stoppable aux pointer
 		WORD		STC	Stoppable choice pointer


### PR DESCRIPTION
From <https://intfiction.org/t/a-machine-spec-typos-confusing-parts-questions-and-other-comments/53581>, it would be great to clarify things in the spec. I've made some changes towards this goal, based on a few suggestions in that thread and from a bit of experience. I think documenting the rest of the opcodes (where needed) and other possible changes should be done at some point in the future.