### PR TITLE
Fix problem with CSS variables evaluating too early

### DIFF
--- a/src/js/webfrontend.css
+++ b/src/js/webfrontend.css
@@ -38,6 +38,11 @@ html {
 	
 	--font-status: Geneva, sans-serif; /* Status bar and menus */
 	--font-body: Georgia, serif; /* Main body text */
+	
+	--night-scroll-fg: var(--theme-medium);
+	--night-scroll-bg: var(--theme-dark);
+	--day-scroll-fg: var(--theme-medium);
+	--day-scroll-bg: var(--theme-light);
 }
 
 #aadefaults {
@@ -47,7 +52,7 @@ html {
 	--link-hover: var(--day-link-hover);
 	background-color: var(--day-page);
 	color: var(--text);
-	scrollbar-color: var(--theme-medium) var(--theme-light);
+	scrollbar-color: var(--day-scroll-fg) var(--day-scroll-bg);
 }
 
 .night #aadefaults {
@@ -56,7 +61,7 @@ html {
 	--link: var(--night-link);
 	--link-hover: var(--night-link-hover);
 	background-color: var(--night-page);
-	scrollbar-color: var(--theme-medium) var(--theme-dark);
+	scrollbar-color: var(--night-scroll-fg) var(--night-scroll-bg);
 }
 
 html, body, #aabody1, #aabody2, #aadefaults {

--- a/src/js/webfrontend.css
+++ b/src/js/webfrontend.css
@@ -10,7 +10,9 @@ html {
 	--theme-lightest: #eeeeee;
 	--accent-dark: #875;
 	--accent-light: #aa8;
-	
+}
+
+#aadefaults {
 	--night-page: var(--theme-darkest); /* Night mode outside gameport */
 	--night-bg: inherit; /* Night mode background */
 	--night-fg: var(--theme-light); /* Night mode text */
@@ -38,7 +40,7 @@ html {
 	--font-body: Georgia, serif; /* Main body text */
 }
 
-body {
+#aadefaults {
 	--bg: var(--day-bg);
 	--text: var(--day-fg);
 	--link: var(--day-link);
@@ -47,12 +49,18 @@ body {
 	color: var(--text);
 }
 
-body.night {
+.night #aadefaults {
 	--bg: var(--night-bg);
 	--text: var(--night-fg);
 	--link: var(--night-link);
 	--link-hover: var(--night-link-hover);
 	background-color: var(--night-page);
+}
+
+html, body, #aabody1, #aabody2, #aadefaults {
+	width: 100%;
+	height: 100%;
+	margin: 0;
 }
 
 body.enlarge {
@@ -173,10 +181,6 @@ h2 {
 
 .aamenuoption:hover {
 	color: var(--menu-hover);
-}
-
-#aabody { /* A wrapper with no existence of its own - only exists so that CSS rules can be nested correctly (inside `body` but outside `#aaform`) */
-	margin: 0;
 }
 
 #aaform {

--- a/src/js/webfrontend.css
+++ b/src/js/webfrontend.css
@@ -47,6 +47,7 @@ html {
 	--link-hover: var(--day-link-hover);
 	background-color: var(--day-page);
 	color: var(--text);
+	scrollbar-color: var(--theme-medium) var(--theme-light);
 }
 
 .night #aadefaults {
@@ -55,6 +56,7 @@ html {
 	--link: var(--night-link);
 	--link-hover: var(--night-link-hover);
 	background-color: var(--night-page);
+	scrollbar-color: var(--theme-medium) var(--theme-dark);
 }
 
 html, body, #aabody1, #aabody2, #aadefaults {

--- a/src/js/webfrontend.html
+++ b/src/js/webfrontend.html
@@ -20,54 +20,58 @@
 	</script>
 </head>
 <body> <!-- Where "night" and "enlarge" classes attach -->
-<div id="aabody"> <!-- Where (body style $) attaches -->
-	<div id="aacontainer"> <!-- Central (width-limited) column -->
-		<div id="aaouterstatus"> <!-- Top bar -->
-			<div id="aamenubutton"> <!-- Menu bottom (top right) -->
-				<div id="aamenulines"></div> <!-- Graphic -->
-				<div id="aamenu"> <!-- The menu itself -->
-					<div id="aamenulist"> <!-- List of options and links -->
-						<div id="aacheckboxes"></div> <!-- Filled in by JS -->
-						<hr /> <!-- Onclick for all of these is added by JS -->
-						<div id="aaviewscript" class="aamenuoption">View transcript</div>
-						<div id="aasavescript" class="aamenuoption">Save transcript</div>
-						<div id="aarestart" class="aamenuoption">Restart game</div>
-						<div id="aasavestory" class="aamenuoption">Download story file</div>
+<div id="aabody1"> <!-- Where (body style $) attaches, part 1 -->
+	<div id="aadefaults"> <!-- Where default values of CSS properties are evaluated -->
+		<div id="aabody2"> <!-- Where (body style $) attaches, part 2 -->
+			<div id="aacontainer"> <!-- Central (width-limited) column -->
+				<div id="aaouterstatus"> <!-- Top bar -->
+					<div id="aamenubutton"> <!-- Menu bottom (top right) -->
+						<div id="aamenulines"></div> <!-- Graphic -->
+						<div id="aamenu"> <!-- The menu itself -->
+							<div id="aamenulist"> <!-- List of options and links -->
+								<div id="aacheckboxes"></div> <!-- Filled in by JS -->
+								<hr /> <!-- Onclick for all of these is added by JS -->
+								<div id="aaviewscript" class="aamenuoption">View transcript</div>
+								<div id="aasavescript" class="aamenuoption">Save transcript</div>
+								<div id="aarestart" class="aamenuoption">Restart game</div>
+								<div id="aasavestory" class="aamenuoption">Download story file</div>
+								<hr />
+								<div id="aaaboutopen" class="aamenuoption">About</div>
+							</div>
+						</div>
+					</div>
+					<div id="aastatus"></div> <!-- Filled in by game -->
+				</div>
+				<div id="aastatusborder"></div> <!-- Bar between status and game -->
+				<div id="aaaboutouter"> <!-- "About" overlay -->
+					<div id="aaaboutinner">
+						<div id="aaaboutmeta" class="aaaboutline"></div> <!-- Filled in by JS -->
 						<hr />
-						<div id="aaaboutopen" class="aamenuoption">About</div>
+						<div class="aaaboutline">
+							<a id="aaaboutlink" target="_blank" href="https://github.com/Dialog-IF/aamachine/">&Aring;-machine web interpreter v1.0.0</a>
+						</div>
+						<hr />
+						<div class="aaaboutline">
+							<div id="aaaboutclose" class="aailink">Close</div>
+						</div>
 					</div>
 				</div>
-			</div>
-			<div id="aastatus"></div> <!-- Filled in by game -->
-		</div>
-		<div id="aastatusborder"></div> <!-- Bar between status and game -->
-		<div id="aaaboutouter"> <!-- "About" overlay -->
-			<div id="aaaboutinner">
-				<div id="aaaboutmeta" class="aaaboutline"></div> <!-- Filled in by JS -->
-				<hr />
-				<div class="aaaboutline">
-					<a id="aaaboutlink" target="_blank" href="https://github.com/Dialog-IF/aamachine/">&Aring;-machine web interpreter v1.0.0</a>
-				</div>
-				<hr />
-				<div class="aaaboutline">
-					<div id="aaaboutclose" class="aailink">Close</div>
-				</div>
-			</div>
-		</div>
-		<form id="aaform" autocomplete="off"> <!-- To handle keypresses etc -->
-			<div id="aamain" aria-live="polite"> <!-- Main body of the game -->
-				<input id="aainput" type="text" value="" autocomplete="off" spellcheck="false" autocorrect="off" aria-live="off" />
-			</div>
-			<div id="aascriptouter"> <!-- Transcript -->
-				<textarea id="aascriptinner" readonly></textarea>
-				<div id="aascriptclose">Close transcript</div>
-			</div>
-		</form>
-		<div id="aaerrorouter"> <!-- Error messages -->
-			<div id="aaerrorinner">
-				<div id="aaerrorlog"></div> <!-- Filled with .aaerrorline divs when an error happens -->
-				<div class="aaaboutline">
-					<div id="aaerrorclose" class="aailink">Close</div>
+				<form id="aaform" autocomplete="off"> <!-- To handle keypresses etc -->
+					<div id="aamain" aria-live="polite"> <!-- Main body of the game -->
+						<input id="aainput" type="text" value="" autocomplete="off" spellcheck="false" autocorrect="off" aria-live="off" />
+					</div>
+					<div id="aascriptouter"> <!-- Transcript -->
+						<textarea id="aascriptinner" readonly></textarea>
+						<div id="aascriptclose">Close transcript</div>
+					</div>
+				</form>
+				<div id="aaerrorouter"> <!-- Error messages -->
+					<div id="aaerrorinner">
+						<div id="aaerrorlog"></div> <!-- Filled with .aaerrorline divs when an error happens -->
+						<div class="aaaboutline">
+							<div id="aaerrorclose" class="aailink">Close</div>
+						</div>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/src/js/webfrontend.js
+++ b/src/js/webfrontend.js
@@ -654,10 +654,12 @@ window.run_game = function(story64, options) {
 			this.currarray.push({t: "us"});
 		},
 		set_body: function(id) {
-			$("#aabody").removeClass();
+			$("#aabody1").removeClass();
+			$("#aabody2").removeClass();
 			if(id !== null) { // Can be called with no id to reset
 				var cls = this.style_data[id].name;
-				$("#aabody").addClass(cls);
+				$("#aabody1").addClass(cls);
+				$("#aabody2").addClass(cls);
 				this.currarray.push({t: "sb", i: id});
 			}
 		},


### PR DESCRIPTION
This PR attaches the body style to the document twice rather than once: the first time right before the default variables are evaluated, the second time right after. This means you can override those variables either before or after the defaults kick in, depending which ones you change.