### PR TITLE
Make aambundle emit interpreter_license.txt

### DIFF
--- a/src/6502/license.txt
+++ b/src/6502/license.txt
@@ -1,0 +1,24 @@
+Å-machine 6502 C64 Interpreter
+Copyright 2019-2026 Linus Åkesson and the Dialog Project
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright
+	notice, this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	notice, this list of conditions and the following disclaimer in the
+	documentation and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+	IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+	TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+	PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+	HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+	LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+	DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+	THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+	(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+	OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/Makefile
+++ b/src/Makefile
@@ -24,9 +24,11 @@ aamshow:		aamshow.c crc32.c aavm.c aavm.h crc32.h
 			${CC} ${CFLAGS} -o $@ aamshow.c crc32.c aavm.c
 
 aambundle:		aambundle.c bundle_web.c bundle_c64.c \
+				table_c64license.h \
 				table_c64drive.h \
 				table_c64load.h \
 				table_c64terp.h \
+				table_weblicense.h \
 				table_css.h \
 				table_engine.h \
 				table_front.h \
@@ -51,6 +53,9 @@ aambundle.exe:		aambundle.c bundle_web.c bundle_c64.c \
 				table_play.h
 			${MINGW32} ${CFLAGS} -o $@ aambundle.c bundle_web.c bundle_c64.c
 
+table_c64license.h:	6502/license.txt mkheader
+			./mkheader table_c64license <$< >$@
+
 table_c64drive.h:	6502/c64_drivecode.bin mkheader
 			./mkheader table_c64drive <$< >$@
 
@@ -59,6 +64,9 @@ table_c64load.h:	6502/c64_loader.prg mkheader
 
 table_c64terp.h:	6502/c64_crunched.bin mkheader
 			./mkheader table_c64terp <$< >$@
+
+table_weblicense.h:	js/license.txt mkheader
+			./mkheader table_weblicense <$< >$@
 
 table_css.h:		js/webfrontend.css mkheader
 			./mkheader table_css <$< >$@

--- a/src/bundle_c64.c
+++ b/src/bundle_c64.c
@@ -7,6 +7,7 @@
 
 #include "aambundle.h"
 
+#include "table_c64license.h"
 #include "table_c64drive.h"
 #include "table_c64load.h"
 #include "table_c64terp.h"
@@ -201,5 +202,17 @@ void bundle_c64(char *dirname) {
 		exit(1);
 	}
 	fwrite(image, 1, sizeof(image), outf);
+	fclose(outf);
+	
+	// Add the license
+	snprintf(filename, fnsize, "%s/interpreter_license.txt", dirname);
+	if(!(outf = fopen(filename, "wb"))) {
+		fprintf(stderr, "%s: %s\n", filename, strerror(errno));
+		exit(1);
+	}
+	if(1 != fwrite(table_c64license, sizeof(table_c64license), 1, outf)) {
+		fprintf(stderr, "%s: write error\n", filename);
+		exit(1);
+	}
 	fclose(outf);
 }

--- a/src/bundle_web.c
+++ b/src/bundle_web.c
@@ -8,6 +8,7 @@
 
 #include "aambundle.h"
 
+#include "table_weblicense.h"
 #include "table_css.h"
 #include "table_engine.h"
 #include "table_front.h"
@@ -24,6 +25,7 @@ static struct tabledef {
 	{table_jquery,	sizeof(table_jquery),	"/resources/jquery.js"},
 	{table_css,	sizeof(table_css),	"/resources/style.css"},
 	{table_play,	sizeof(table_play),	"/play.html"},
+	{table_weblicense,	sizeof(table_weblicense),	"/interpreter_license.txt"},
 };
 
 static const char *encode = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";

--- a/src/js/license.txt
+++ b/src/js/license.txt
@@ -1,3 +1,4 @@
+Å-machine Javascript Web Interpreter
 Copyright 2019-2026 Linus Åkesson and the Dialog Project
 
 Redistribution and use in source and binary forms, with or without
@@ -22,11 +23,7 @@ modification, are permitted provided that the following conditions are met:
 	(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 	OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Note that the aambundle tool will automatically insert a license file that
-complies with these requirements.
-
-The web frontend of the javascript interpreter depends on jquery, which is
-redistributed inside this archive in compliance with the MIT license:
+This interpreter includes jquery under the terms of the MIT license:
 
 	Copyright JS Foundation and other contributors
 
@@ -48,31 +45,3 @@ redistributed inside this archive in compliance with the MIT license:
 	CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 	TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 	SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-The node frontend of the javascript interpreter depends on minimist, which is
-redistributed inside this archive in compliance with the MIT license:
-
-	Copyright (c) 2013 James Halliday and contributors
-
-	Permission is hereby granted, free of charge, to any person obtaining a copy
-	of this software and associated documentation files (the "Software"), to deal
-	in the Software without restriction, including without limitation the rights
-	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-	copies of the Software, and to permit persons to whom the Software is
-	furnished to do so, subject to the following conditions:
-
-	The above copyright notice and this permission notice shall be included in all
-	copies or substantial portions of the Software.
-
-	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-	SOFTWARE.
-
-
-The commandline tool aambox6502, for testing the 6502 interpreter, makes use of
-a 6502 emulator by Mike Chambers called fake6502. This emulator is in the
-public domain.


### PR DESCRIPTION
The Å-machine interpreters are released under a BSD license, which means the license needs to be distributed along with the interpreters.

But most people will be distributing these interpreters as the output of aambundle, so why not just have aambundle emit an interpreter_license.txt file containing all the necessary information?