### PR TITLE
ignore 6502 build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ aamshow
 aambox6502
 **/*~
 **/#*#
+src/6502/cruncher
+src/6502/labels
+src/6502/mkfont


### PR DESCRIPTION
Add `cruncher`, `labels`, and `mkfont` to the .gitignore file.