### PR TITLE
build: produce universal macOS binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
       run: make --directory=./src aamshow aambundle
     - uses: actions/upload-artifact@v4
       with:
-        name: macos-arm64
+        name: macos-universal
         path: |
           src/aamrun
           src/aamshow
@@ -107,7 +107,7 @@ jobs:
           # Create the bundle and add the prebuild binaries in
           mkdir -p "$BUNDLE/prebuilt"
           mv artifacts/linux-x86_64 "$BUNDLE/prebuilt/"
-          mv artifacts/macos-arm64 "$BUNDLE/prebuilt/"
+          mv artifacts/macos-universal "$BUNDLE/prebuilt/"
           mv artifacts/win32 "$BUNDLE/prebuilt/"
           chmod +x "$BUNDLE"/prebuilt/*/*
           cp --recursive src "$BUNDLE/"

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,6 +3,9 @@ VER_MAJOR=1
 VER_MINOR=0
 CC		= gcc
 CFLAGS		+= -Wall -O3 -DVERSION=$(VERSION) -DVER_MAJOR=$(VER_MAJOR) -DVER_MINOR=$(VER_MINOR)
+ifeq ($(shell uname -s),Darwin)
+CFLAGS		+= -arch x86_64 -arch arm64
+endif
 MINGW32		= i686-w64-mingw32-gcc
 INSTALLDIR	= /usr/local/bin
 
@@ -54,7 +57,10 @@ aamrun.linux:	js/nodefrontend.js js/engine.js
 	pkg -t linux -o aamrun.linux js/nodefrontend.js
 
 aamrun.mac:		js/nodefrontend.js js/engine.js
-	pkg -t macos-arm64 -o aamrun.mac js/nodefrontend.js
+	pkg -t macos-x64   -o aamrun.mac.x64   js/nodefrontend.js
+	pkg -t macos-arm64 -o aamrun.mac.arm64 js/nodefrontend.js
+	lipo -create -output aamrun.mac aamrun.mac.x64 aamrun.mac.arm64
+	rm -f aamrun.mac.x64 aamrun.mac.arm64
 
 aamrun.exe: js/nodefrontend.js js/engine.js
 	pkg -t win -o aamrun.exe js/nodefrontend.js


### PR DESCRIPTION
aamshow/aambundle build with -arch x86_64 -arch arm64 on Darwin;
aamrun.mac is lipo'd from x64+arm64 pkg outputs. CI artifact
renamed macos-arm64 -> macos-universal.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
