### PR TITLE
Sync size after changing enlarge checkbox

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 This textfile uses UTF-8 encoding.
 
 This archive contains version 1.0 of the Å-machine specification, and version
-1.0.0 of the tools and official interpreters.
+1.0.2 of the tools and official interpreters.
 
 The following interpreters are included:
 
@@ -122,8 +122,13 @@ Project website:
 
 Release notes:
 
-    1.0.1:
+	1.0.2:
+	
+		Fixes bug with window size getting out of sync when enabling
+		or disabling "enlarge text" mode on web.
 
+	1.0.1:
+	
 		This release updates the build to produce universal OSX
 		binaries (Intel and ARM).
 

--- a/src/6502/Makefile
+++ b/src/6502/Makefile
@@ -1,4 +1,4 @@
-VERSION=\"1.0.1\"
+VERSION=\"1.0.2\"
 CFLAGS=-Wall -O2 -DVERSION=$(VERSION)
 
 all:			aambox6502 aambox_frontend.bin c64_crunched.bin c64_drivecode.bin c64_loader.prg

--- a/src/Makefile
+++ b/src/Makefile
@@ -41,7 +41,6 @@ aamshow: aamshow.c crc32.c aavm.c aavm.h crc32.h
 	${CC} ${CFLAGS} -o $@ aamshow.c crc32.c aavm.c
 
 aambundle: aambundle.c bundle_web.c bundle_c64.c \
-	6502 \
 	table_c64license.h \
 	table_c64drive.h \
 	table_c64load.h \
@@ -82,17 +81,17 @@ aambundle.exe: aambundle.c bundle_web.c bundle_c64.c \
 	table_play.h
 	${MINGW32} ${CFLAGS} -o $@ aambundle.c bundle_web.c bundle_c64.c
 
-table_c64license.h:	6502/license.txt mkheader
-			./mkheader table_c64license <$< >$@
+table_c64license.h:	6502 6502/license.txt mkheader
+			./mkheader table_c64license <6502/license.txt >$@
 
-table_c64drive.h:	6502/c64_drivecode.bin mkheader
-			./mkheader table_c64drive <$< >$@
+table_c64drive.h:	6502 6502/c64_drivecode.bin mkheader
+			./mkheader table_c64drive <6502/c64_drivecode.bin >$@
 
-table_c64load.h:	6502/c64_loader.prg mkheader
-			./mkheader table_c64load <$< >$@
+table_c64load.h:	6502 6502/c64_loader.prg mkheader
+			./mkheader table_c64load <6502/c64_loader.prg >$@
 
-table_c64terp.h:	6502/c64_crunched.bin mkheader
-			./mkheader table_c64terp <$< >$@
+table_c64terp.h:	6502 6502/c64_crunched.bin mkheader
+			./mkheader table_c64terp <6502/c64_crunched.bin >$@
 
 table_weblicense.h:	js/license.txt mkheader
 			./mkheader table_weblicense <$< >$@

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-VERSION=\"1.0.1\"
+VERSION=\"1.0.2\"
 VER_MAJOR=1
 VER_MINOR=0
 CC		= gcc

--- a/src/Makefile
+++ b/src/Makefile
@@ -41,6 +41,7 @@ aamshow: aamshow.c crc32.c aavm.c aavm.h crc32.h
 	${CC} ${CFLAGS} -o $@ aamshow.c crc32.c aavm.c
 
 aambundle: aambundle.c bundle_web.c bundle_c64.c \
+	6502 \
 	table_c64license.h \
 	table_c64drive.h \
 	table_c64load.h \
@@ -84,13 +85,13 @@ aambundle.exe: aambundle.c bundle_web.c bundle_c64.c \
 table_c64license.h:	6502/license.txt mkheader
 			./mkheader table_c64license <$< >$@
 
-table_c64drive.h:	6502 6502/c64_drivecode.bin mkheader
+table_c64drive.h:	6502/c64_drivecode.bin mkheader
 			./mkheader table_c64drive <$< >$@
 
-table_c64load.h:	6502 6502/c64_loader.prg mkheader
+table_c64load.h:	6502/c64_loader.prg mkheader
 			./mkheader table_c64load <$< >$@
 
-table_c64terp.h:	6502 6502/c64_crunched.bin mkheader
+table_c64terp.h:	6502/c64_crunched.bin mkheader
 			./mkheader table_c64terp <$< >$@
 
 table_weblicense.h:	js/license.txt mkheader

--- a/src/js/nodefrontend.js
+++ b/src/js/nodefrontend.js
@@ -1,6 +1,6 @@
 (function(){"use strict";
 
-const VERSION = "1.0.1";
+const VERSION = "1.0.2";
 
 const fs = require('fs');
 const readline = require('readline');

--- a/src/js/webfrontend.html
+++ b/src/js/webfrontend.html
@@ -50,7 +50,7 @@
 								<div id="aaaboutmeta" class="aaaboutline"></div> <!-- Filled in by JS -->
 								<hr />
 								<div class="aaaboutline">
-									<a id="aaaboutlink" target="_blank" href="https://github.com/Dialog-IF/aamachine/">&Aring;-machine web interpreter v1.0.1</a>
+									<a id="aaaboutlink" target="_blank" href="https://github.com/Dialog-IF/aamachine/">&Aring;-machine web interpreter v1.0.2</a>
 								</div>
 								<hr />
 								<div class="aaaboutline">

--- a/src/js/webfrontend.js
+++ b/src/js/webfrontend.js
@@ -1313,6 +1313,7 @@ window.run_game = function(story64, options) {
 		} else {
 			$("body").removeClass("nofont");
 		}
+		io.adjust_size();
 		io.maybe_focus();
 	}
 


### PR DESCRIPTION
Previously, enabling or disabling "large text" could leave a black or white bar at the bottom of the page, because it wasn't properly calling `io.adjust_size()` when changing the line height. This changes that.