### PR TITLE
Set SPC to line instead of par when leaving divs

### DIFF
--- a/docs/aam-specification-1.0.adoc
+++ b/docs/aam-specification-1.0.adoc
@@ -2661,8 +2661,13 @@ is nevertheless used by <<AUX_POP_LIST>>.
  	local variable style_class = last element of divList
  	remove last element from divList
  	output_leavediv(style_class)
- 	SPC = par
+ 	SPC = line
  }
+
+Previous versions of this specification erroneously said SPC
+should be set to "par" instead of "line". This is not meant to
+be a change between Aa-machine versions; ideally SPC should be
+set to "line" even when running version 0.5 story files.
 
 [[ENTER_SPAN]]
 === ENTER_SPAN

--- a/docs/aam-specification-1.0.txt
+++ b/docs/aam-specification-1.0.txt
@@ -2331,8 +2331,13 @@ Opcode semantics
 			local variable style_class = last element of divList
 			remove last element from divList
 			output_leavediv(style_class)
-			SPC = par
+			SPC = line
 		}
+		
+		Previous versions of this specification erroneously said SPC
+		should be set to "par" instead of "line". This is not meant to
+		be a change between Aa-machine versions; ideally SPC should be
+		set to "line" even when running version 0.5 story files.
 
 	ENTER_SPAN		INDEX
 

--- a/readme.txt
+++ b/readme.txt
@@ -133,6 +133,9 @@ Release notes:
 		Specification tentatively changed from plaintext to asciidoc.
 		The plaintext version is still included in this release, but
 		may not be in the future.
+		
+		Fixed error with SPC being set to "par" instead of "line" at a
+		LEAVE_DIV operation.
 	
 	1.0.2:
 	

--- a/src/js/engine.js
+++ b/src/js/engine.js
@@ -2275,7 +2275,7 @@ function vm_run(e, param) {
 				case 0xe6: // leave_div
 					if(!e.cwl) {
 						io.leave_div(e.divs.pop());
-						e.spc = e.SP_PAR;
+						e.spc = e.SP_LINE;
 					}
 					break;
 				case 0x67:

--- a/test/impossible/impossible.js.gold
+++ b/test/impossible/impossible.js.gold
@@ -910,6 +910,7 @@ Oh, sweet, it's your favorite: maple and brown sugar.
 
 > x
 (I only understood you as far as wanting to examine something.)
+
 > beans
 Nobody in the house likes yellow wax beans, but, on the other hand, no one wants
 to throw this out. Who knows how old this is now.


### PR DESCRIPTION
The specification of LEAVE_DIV previously said to set SPC to "par" when leaving a div, but this produces the wrong results (by comparison with the Z-machine, dgdebug, and even the 6502 Å-machine interpreter). It should instead be set to "line".