### PR TITLE
Include built docs_html in the release bundle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,27 @@ jobs:
     - name: make test
       run: make test
   
+  build-manual:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: dialog
+      - uses: actions/checkout@v4
+        with:
+          repository: Dialog-IF/manual
+          path: manual
+      - name: build site with antora
+        run: |
+          cd manual
+          npm i @antora/lunr-extension@github:Randozart/dialog-antora-lunr-extension#dialog-punctuation-fix
+          npx antora@3.1.10 ./local-antora-playbook-aamachine.yml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: manual
+          path: |
+            manual/build/site/**/*
+  
   build-linux:
     runs-on: ubuntu-latest
     steps:
@@ -116,6 +137,7 @@ jobs:
           chmod +x "$BUNDLE"/prebuilt/*/*
           cp --recursive src "$BUNDLE/"
           cp --recursive docs "$BUNDLE/"
+          cp --recursive artifacts/manual "$BUNDLE"/docs_html
           cp --recursive example "$BUNDLE/"
           cp *.txt "$BUNDLE"/
           # Group them together in a single zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          path: dialog
+          path: aamachine
       - uses: actions/checkout@v4
         with:
           repository: Dialog-IF/manual

--- a/antora/antora.yml
+++ b/antora/antora.yml
@@ -1,6 +1,6 @@
 name: aamachine
 title: Å-machine
-version: 1.0
+version: '1.0'
 asciidoc:
   attributes:
     page-copyright: &copy; 2018-2026 Linus Åkesson and the Dialog Project

--- a/readme.txt
+++ b/readme.txt
@@ -124,7 +124,7 @@ Release notes:
 
 	1.0.3:
 	
-		Cleans up the specification and some dev tools.
+		Cleaned up the specification and some dev tools.
 		
 		Aamrun binary is no longer universal on OSX (caused crashes).
 		
@@ -133,6 +133,9 @@ Release notes:
 		Specification tentatively changed from plaintext to asciidoc.
 		The plaintext version is still included in this release, but
 		may not be in the future.
+		
+		An HTML version of the specs, generated from the asciidoc, is
+		now included in docs_html.
 		
 		Fixed error with SPC being set to "par" instead of "line" at a
 		LEAVE_DIV operation.


### PR DESCRIPTION
Now that we have Antora, we should include its output in the downloadable bundles