### PR TITLE
Add a Go and Lua-based interpreter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,16 +22,18 @@ make clean          # removes build outputs
 make install        # copies aamshow and aambundle to /usr/local/bin
 ```
 
-Building requires `gcc`, `make`, `node` (for tests and `aamrun.*` packaging), and `xa65` (the xa assembler for 6502 code). The `aamrun.*` targets in `src/Makefile` additionally need `@yao-pkg/pkg` installed globally via npm.
+Building requires `gcc`, `make`, `node` (for tests and `aamrun.*` packaging), `luajit` (for the Lua engine tests), and `xa65` (the xa assembler for 6502 code). The `aamrun.*` targets in `src/Makefile` additionally need `@yao-pkg/pkg` installed globally via npm. Building the Go engine requires `go`.
 
 ### Running a single test
 
-Each subdirectory under `test/` is an independent test case with its own `Makefile`. Each one runs the same story through both the JS engine (via `nodefrontend.js`) and the 6502 engine (via the `aambox6502` emulator), then diffs against gold files. To run just one:
+Each subdirectory under `test/` is an independent test case with its own `Makefile`. Each one runs the same story through the JS engine (via `nodefrontend.js`), the 6502 engine (via the `aambox6502` emulator), the Lua engine (via `frontend.lua`), and the Go engine (via `aamrun`), then diffs against gold files. To run just one:
 
 ```sh
-make -C test/gosling test          # both engines
+make -C test/gosling test          # all engines
 make -C test/gosling test.js       # only the JS engine
 make -C test/gosling test.6502     # only the 6502 engine
+make -C test/gosling test.lua      # only the Lua engine
+make -C test/gosling test.go       # only the Go engine
 make -C test/gosling DIFF=meld     # use meld for a visual diff on failure
 ```
 
@@ -47,23 +49,27 @@ x64sc -truedrive -drivesound -reu -reusize 256 example/cloak-rel2.d64    # C64 v
 
 ## Architecture
 
-The codebase implements **two independent VM engines** (JavaScript and 6502 assembler), each combined with one or more **frontends** that handle platform-specific I/O. Plus a set of **C tools** for inspecting and packaging story files.
+The codebase implements **four independent VM engines** (JavaScript, 6502 assembler, LuaJIT, and Go), each combined with one or more **frontends** that handle platform-specific I/O. Plus a set of **C tools** for inspecting and packaging story files.
 
 ### Story file format (`.aastory`)
 
-IFF-style file with a `FORM` header containing typed chunks (`META`, `WRIT`, `FILE`, etc.). The file format major/minor version is checked against `AAVM_FORMAT_MAJOR`/`MINOR` in `src/aavm.h` — older 0.x files must still load on 1.x engines (see `test/gosling` for the regression). Opcode constants (`AA_*`) and metadata tag IDs (`AAMETA_*`) live in `src/aavm.h` and are mirrored in `src/js/engine.js` and `src/6502/engine.s`. Any opcode change touches all three.
+IFF-style file with a `FORM` header containing typed chunks (`META`, `WRIT`, `FILE`, etc.). The file format major/minor version is checked against `AAVM_FORMAT_MAJOR`/`MINOR` in `src/aavm.h` — older 0.x files must still load on 1.x engines (see `test/gosling` for the regression). Opcode constants (`AA_*`) and metadata tag IDs (`AAMETA_*`) live in `src/aavm.h` and are mirrored in `src/js/engine.js`, `src/6502/engine.s`, `src/lua/engine.lua`, and `src/go/engine.go`. Any opcode change touches all four.
 
-### The two engines
+### The four engines
 
 - **`src/js/engine.js`** — the JavaScript VM. Pure ES5-ish, self-contained, exported via `module.exports` for Node and consumed directly by the browser. Shared by both the web and Node frontends.
 - **`src/6502/engine.s`** — the 6502 VM, written in xa65 assembler. Designed to be included from a platform frontend (`c64_frontend.s` or `aambox_frontend.s`). Generic 6502; no undocumented opcodes; can run from ROM. Zero-page register conventions are defined at the top of the file.
+- **`src/lua/engine.lua`** — the LuaJIT VM. Port of the JS engine, using LuaJIT FFI for performance where beneficial. Shared by the Lua terminal frontend.
+- **`src/go/engine.go`** (plus `vm.go`, `init.go`, `run.go`, `parse.go`) — the Go VM. Struct-based, with `int` for index/pointer variables and `uint16` for data values. Uses panic/recover for VM exceptions. Shared by the Go terminal frontend.
 
-When changing VM semantics, both engines must be updated in lock-step. The test suite catches divergence by diffing JS and 6502 transcripts against the same gold file (for `body_not_status` and `impossible`; `gosling` has separate `js.gold` and `6502.gold` files).
+When changing VM semantics, all four engines must be updated in lock-step. The test suite catches divergence by diffing transcripts from all engines against gold files (for `body_not_status` and `impossible`; `gosling` has separate `js.gold`, `6502.gold`, `lua.gold`, and `go.gold` files).
 
 ### Frontends
 
 - **`src/js/webfrontend.{js,html,css}`** — browser frontend. jQuery-based. Reads a story file and provides full UI including styling, hyperlinks, transcripts, embedded fonts/audio, and localStorage save state.
 - **`src/js/nodefrontend.js`** — Node text frontend. Used for automated tests and command-line play. Wraps `engine.js` and handles word-wrapped terminal I/O via `readline`.
+- **`src/lua/frontend.lua`** — LuaJIT text frontend. Port of `nodefrontend.js`. Wraps `engine.lua` and handles word-wrapped terminal I/O. Output is byte-for-byte compatible with the Node frontend.
+- **`src/go/main.go`** — Go text frontend. Port of `nodefrontend.js`. Wraps the Go engine and handles word-wrapped terminal I/O via `bufio.Scanner`.
 - **`src/6502/c64_frontend.s`** — Commodore 64 frontend with custom font and a 1541 floppy driver. The story is delivered on a `.d64` disk image with a loader (`c64_loader.s`) and drive code (`c64_drivecode.s`). The whole thing is run-length crunched by the `cruncher` tool into `c64_crunched.bin`.
 - **`src/6502/aambox_frontend.s`** + **`aambox6502.c`** — a synthetic 6502 platform for automated testing of the 6502 engine. `aambox6502.c` is the emulator (built on Mike Chambers's `fake6502.c`); the frontend assembles to `aambox_frontend.bin` and the emulator loads it plus a story file.
 

--- a/src/go/engine.go
+++ b/src/go/engine.go
@@ -1,0 +1,493 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Error codes matching JS engine
+const (
+	HeapFull    = 0x4001
+	AuxFull     = 0x4002
+	ExpectObj   = 0x4003
+	ExpectBound = 0x4004
+	LTSFull     = 0x4006
+	IOState     = 0x4007
+)
+
+// Spacing states
+const (
+	SPAuto    = 0
+	SPNoSpace = 1
+	SPNBSP    = 2
+	SPPending = 3
+	SPSpace   = 4
+	SPLine    = 5
+	SPPar     = 6
+)
+
+const (
+	VerMajor = 1
+	VerMinor = 0
+)
+
+// Keys
+var Keys = map[string]int{
+	"KEY_BACKSPACE": 8,
+	"KEY_RETURN":    13,
+	"KEY_UP":        16,
+	"KEY_DOWN":      17,
+	"KEY_LEFT":      18,
+	"KEY_RIGHT":     19,
+}
+
+// Status codes
+const (
+	StatusQuit    = 0
+	StatusGetInput = 1
+	StatusGetKey   = 2
+	StatusRestore  = 3
+)
+
+// IO interface for frontends
+type IO interface {
+	Reset()
+	Print(string)
+	Nbsp()
+	Space()
+	SpaceN(int)
+	Line()
+	Par()
+	Flush()
+	SetBody(int)
+	EnterDiv(int)
+	LeaveDiv(int)
+	EnterSpan(int)
+	LeaveSpan()
+	EnterStatus(int, int)
+	LeaveStatus()
+	SetStyle(int)
+	ResetStyle(int)
+	Unstyle()
+	Clear()
+	ClearAll()
+	ClearLinks()
+	ClearOld()
+	ClearDiv()
+	ClearStatus()
+	HaveLinks() bool
+	EnterLink(string)
+	LeaveLink()
+	EnterLinkRes(Resource)
+	LeaveLinkRes()
+	EnterSelfLink()
+	LeaveSelfLink()
+	LeaveAll()
+	EmbedRes(Resource)
+	CanEmbedRes(Resource) bool
+	ProgressBar(int, int)
+	Trace(string)
+	MeasureDims(int) int
+	ScriptOn() bool
+	ScriptOff()
+	ScriptActive() bool
+	Save([]byte) bool
+	Restore()
+	HaveStyles() bool
+	HaveColor() bool
+	HaveAlign() bool
+}
+
+type Resource struct {
+	URL     string
+	Alt     string
+	Options map[string]interface{}
+}
+
+// Encoded state for save/restore
+type EncodedState struct {
+	Data []byte
+	Regs []byte
+}
+
+// Engine is the VM engine state
+type Engine struct {
+	// Story file chunks
+	Head []byte
+	Code []byte
+	Dict []byte
+	Init []byte
+	Lang []byte
+	Maps []byte
+	Tags []byte
+	Writ []byte
+	Look []byte
+	Meta []byte
+	Urls []byte
+	Files map[string][]byte
+
+	// String decoding state
+	StrShift   int
+	ExtChars   int
+	EscBits    int
+	EscBoundary int
+
+	// Punctuation tables
+	StopChars  []byte
+	NospBefore []byte
+	NospAfter  []byte
+
+	// VM registers
+	Reg [64]uint16
+
+	// VM pointers (all int for clean indexing)
+	Inst int
+	Cont int
+	Top  int
+	Env  int
+	Cho  int
+	Sim  int
+	Aux  int
+	Trl  int
+	Sta  int
+	Stc  int
+	Cwl  int
+	Spc  int
+
+	// Object/heap limits
+	Nob int
+	Ltb int
+	Ltt int
+
+	// Memory arrays
+	HeapData []uint16
+	AuxData  []uint16
+	RamData  []uint16
+
+	// UI state
+	Upper    bool
+	Trace    bool
+	Divs     []int
+	InStatus bool
+	NSpan    int
+	NLink    int
+
+	// Undo
+	UndoData   []EncodedState
+	PrunedUndo bool
+
+	// Config
+	HaveQuit    bool
+	HaveTop     bool
+	HaveInline  bool
+	RandomSeed  uint32
+	RandomState uint32
+
+	// Initial state for restart/undo
+	InitState *EncodedState
+
+	// IO frontend
+	IO IO
+
+	// Temporary variable for LTS operations
+	Tmp int
+}
+
+// --- Low-level byte operations ---
+
+func get4(data []byte, off int) string {
+	return string(data[off : off+4])
+}
+
+func get16(data []byte, off int) int {
+	return int(data[off])<<8 | int(data[off+1])
+}
+
+func get32(data []byte, off int) int {
+	return int(data[off])<<24 | int(data[off+1])<<16 | int(data[off+2])<<8 | int(data[off+3])
+}
+
+func put4(data []byte, off int, s string) {
+	copy(data[off:], s)
+}
+
+func put16(data []byte, off int, v int) int {
+	data[off] = byte(v >> 8)
+	data[off+1] = byte(v)
+	return off + 2
+}
+
+func put32(data []byte, off int, v int) int {
+	data[off] = byte(v >> 24)
+	data[off+1] = byte(v >> 16)
+	data[off+2] = byte(v >> 8)
+	data[off+3] = byte(v)
+	return off + 4
+}
+
+// --- IFF chunk finding ---
+
+func findChunk(data []byte, name string) []byte {
+	size := get32(data, 4) + 8
+	pos := 12
+	for pos < size {
+		chname := get4(data, pos)
+		chsize := get32(data, pos+4)
+		if chname == name {
+			start := pos + 8
+			return data[start : start+chsize]
+		}
+		pos += 8 + ((chsize + 1) & ^1)
+	}
+	return nil
+}
+
+// findChunkIn searches for a chunk across multiple data sources
+func findChunkIn(name string, sources ...[]byte) []byte {
+	for _, src := range sources {
+		if src == nil {
+			continue
+		}
+		if chunk := findChunk(src, name); chunk != nil {
+			return chunk
+		}
+	}
+	return nil
+}
+
+func findFiles(fileArray []byte) map[string][]byte {
+	size := get32(fileArray, 4) + 8
+	list := make(map[string][]byte)
+	pos := 12
+	for pos < size {
+		chname := get4(fileArray, pos)
+		chsize := get32(fileArray, pos+4)
+		if chname == "FILE" {
+			i := 0
+			for fileArray[pos+8+i] != 0 {
+				i++
+			}
+			fname := string(fileArray[pos+8 : pos+8+i])
+			fdata := make([]byte, chsize-i-1)
+			copy(fdata, fileArray[pos+8+i+1:pos+8+chsize])
+			list[fname] = fdata
+		}
+		pos += 8 + ((chsize + 1) & ^1)
+	}
+	return list
+}
+
+// --- String decoding ---
+
+func (e *Engine) DecodeChar(aach int) string {
+	if e.Upper {
+		if aach >= 0x61 && aach <= 0x7a {
+			aach ^= 0x20
+		} else if aach >= 0x80 {
+			aach = int(e.Lang[e.ExtChars+1+(aach&0x7f)*5+1])
+		}
+		e.Upper = false
+	}
+	if aach < 0x80 {
+		return string(rune(aach))
+	}
+	aach &= 0x7f
+	if aach >= int(e.Lang[e.ExtChars]) {
+		e.Upper = false
+		return "??"
+	}
+	entry := e.ExtChars + 1 + aach*5
+	uchar := int(e.Lang[entry+2])<<16 | int(e.Lang[entry+3])<<8 | int(e.Lang[entry+4])
+	return string(rune(uchar))
+}
+
+func (e *Engine) DecodeStr(addr int) string {
+	decoder := get16(e.Lang, 0)
+	state := 0
+	bits := 0
+	nbit := 0
+	str := ""
+
+	for {
+		if nbit == 0 {
+			bits = int(e.Writ[addr])
+			addr++
+			nbit = 8
+		}
+		code := int(e.Lang[decoder+state*2])
+		if bits&0x80 != 0 {
+			code = int(e.Lang[decoder+state*2+1])
+		}
+		bits <<= 1
+		nbit--
+		if code >= 0x81 {
+			state = code & 0x7f
+		} else if code == 0x80 {
+			break
+		} else if code == 0x5f {
+			code = 0
+			for i := 0; i < e.EscBits; i++ {
+				if nbit == 0 {
+					bits = int(e.Writ[addr])
+					addr++
+					nbit = 8
+				}
+				code <<= 1
+				if bits&0x80 != 0 {
+					code |= 1
+				}
+				bits <<= 1
+				nbit--
+			}
+			if e.Head[0] == 0 && e.Head[1] < 4 {
+				str += e.DecodeChar(0x80 + code)
+			} else if code < e.EscBoundary {
+				str += e.DecodeChar(0xa0 + code)
+	} else {
+			str += " "
+				entry := 2 + (code-e.EscBoundary)*3
+				l := int(e.Dict[entry])
+				charAddr := get16(e.Dict, entry+1)
+				for i := 0; i < l; i++ {
+					str += e.DecodeChar(int(e.Dict[charAddr+i]))
+				}
+			}
+			state = 0
+		} else {
+			str += e.DecodeChar(code + 0x20)
+			state = 0
+		}
+	}
+	return str
+}
+
+// --- Styles and metadata ---
+
+func GetStyles(e *Engine) []map[string]string {
+	var styles []map[string]string
+	n := get16(e.Look, 0)
+	for i := 0; i < n; i++ {
+		offs := get16(e.Look, 2+i*2)
+		m := make(map[string]string)
+		for e.Look[offs] != 0 {
+			str := ""
+			for e.Look[offs] != 0 {
+				str += string(rune(e.Look[offs]))
+				offs++
+			}
+			colon := strings.Index(str, ":")
+			if colon > 0 {
+				key := str[:colon]
+				val := strings.TrimSpace(str[colon+1:])
+				m[key] = val
+			}
+		}
+		styles = append(styles, m)
+	}
+	return styles
+}
+
+func GetMetadata(e *Engine) map[string]interface{} {
+	result := map[string]interface{}{
+		"title":   "Untitled story",
+		"release": get16(e.Head, 4),
+	}
+	keynames := []string{"title", "author", "noun", "blurb", "date", "compiler"}
+	if e.Meta != nil {
+		offs := 1
+		for i := 0; i < int(e.Meta[0]); i++ {
+			key := int(e.Meta[offs])
+			offs++
+			value := ""
+			for e.Meta[offs] != 0 {
+				value += e.DecodeChar(int(e.Meta[offs]))
+				offs++
+			}
+			if key >= 1 && key <= len(keynames) {
+				result[keynames[key-1]] = value
+			}
+		}
+	}
+	return result
+}
+
+// --- Resource handling ---
+
+func (e *Engine) GetRes(id int) Resource {
+	obj := Resource{URL: "", Alt: "", Options: make(map[string]interface{})}
+	if e.Urls == nil {
+		return obj
+	}
+	n := get16(e.Urls, 0)
+	if id < n {
+		offs := get16(e.Urls, 2+id*2)
+		altAddr := int(e.Urls[offs])<<16 | int(e.Urls[offs+1])<<8 | int(e.Urls[offs+2])
+		obj.Alt = e.DecodeStr(altAddr << e.StrShift)
+		i := 3
+		for e.Urls[offs+i] != 0 {
+			obj.URL += string(rune(e.Urls[offs+i]))
+			i++
+		}
+		i++
+		opts := ""
+		for e.Urls[offs+i] != 0 {
+			opts += string(rune(e.Urls[offs+i]))
+			i++
+		}
+		for _, opt := range strings.Split(opts, ",") {
+			opt = strings.TrimSpace(opt)
+			if opt == "" {
+				continue
+			}
+			if idx := strings.Index(opt, ":"); idx > 0 {
+				k := strings.TrimSpace(opt[:idx])
+				v := strings.TrimSpace(opt[idx+1:])
+				if existing, ok := obj.Options[k]; ok {
+					if arr, ok := existing.([]string); ok {
+						obj.Options[k] = append(arr, v)
+					} else {
+						obj.Options[k] = []string{existing.(string), v}
+					}
+				} else {
+					obj.Options[k] = v
+				}
+			} else {
+				if _, ok := obj.Options[opt]; !ok {
+					obj.Options[opt] = true
+				}
+			}
+		}
+	}
+	return obj
+}
+
+func (e *Engine) GetResources() []Resource {
+	var ress []Resource
+	if e.Urls == nil {
+		return ress
+	}
+	n := get16(e.Urls, 0)
+	for i := 0; i < n; i++ {
+		ress = append(ress, e.GetRes(i))
+	}
+	return ress
+}
+
+func (e *Engine) GetStoryKey() string {
+	i := 0
+	meta := GetMetadata(e)
+	title, _ := meta["title"].(string)
+	str := strings.ReplaceAll(title, " ", "-")
+	str = strings.ReplaceAll(str, "'", "-")
+	str = strings.ReplaceAll(str, ",", "")
+	str += "-"
+	for i = 0; i < 6; i++ {
+		str += e.DecodeChar(int(e.Head[6+i]))
+	}
+	str += "-"
+	for i = 0; i < 4; i++ {
+		hex := fmt.Sprintf("%02x", e.Head[12+i])
+		str += hex
+	}
+	return str
+}

--- a/src/go/engine_test.go
+++ b/src/go/engine_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func loadStory(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to load %s: %v", path, err)
+	}
+	return data
+}
+
+func TestIFFParsing(t *testing.T) {
+	data := loadStory(t, "../../test/body_not_status/body_not_status.aastory")
+
+	// Check FORM header
+	if get4(data, 0) != "FORM" {
+		t.Fatal("Missing FORM header")
+	}
+	if get4(data, 8) != "AAVM" {
+		t.Fatal("Missing AAVM type")
+	}
+
+	// Find required chunks
+	chunks := []string{"HEAD", "CODE", "DICT", "INIT", "LANG", "MAPS", "WRIT", "LOOK"}
+	for _, name := range chunks {
+		ch := findChunk(data, name)
+		if ch == nil {
+			t.Errorf("Missing required chunk: %s", name)
+		} else {
+			t.Logf("Found chunk %s: %d bytes", name, len(ch))
+		}
+	}
+
+	// Verify HEAD format
+	head := findChunk(data, "HEAD")
+	if head == nil {
+		t.Fatal("HEAD chunk missing")
+	}
+	verMajor := int(head[0])
+	verMinor := int(head[1])
+	wordSize := int(head[2])
+	t.Logf("Story format: %d.%d, word size: %d", verMajor, verMinor, wordSize)
+	if wordSize != 2 {
+		t.Errorf("Expected word size 2, got %d", wordSize)
+	}
+
+	// Check heap/aux/ram sizes
+	heapSize := get16(head, 16)
+	auxSize := get16(head, 18)
+	ramSize := get16(head, 20)
+	t.Logf("Heap: %d, Aux: %d, RAM: %d", heapSize, auxSize, ramSize)
+	if heapSize == 0 || auxSize == 0 || ramSize == 0 {
+		t.Error("Invalid memory sizes")
+	}
+}
+
+func TestIFFParsingGosling(t *testing.T) {
+	data := loadStory(t, "../../test/gosling/gosling.aastory")
+
+	if get4(data, 0) != "FORM" {
+		t.Fatal("Missing FORM header")
+	}
+	if get4(data, 8) != "AAVM" {
+		t.Fatal("Missing AAVM type")
+	}
+
+	chunks := []string{"HEAD", "CODE", "DICT", "INIT", "LANG", "MAPS", "WRIT", "LOOK"}
+	for _, name := range chunks {
+		ch := findChunk(data, name)
+		if ch == nil {
+			t.Errorf("Missing required chunk: %s", name)
+		} else {
+			t.Logf("Found chunk %s: %d bytes", name, len(ch))
+		}
+	}
+
+	head := findChunk(data, "HEAD")
+	verMajor := int(head[0])
+	verMinor := int(head[1])
+	t.Logf("Gosling format: %d.%d", verMajor, verMinor)
+	// Gosling is a 0.x file
+	if verMajor != 0 {
+		t.Errorf("Expected gosling format 0.x, got %d.%d", verMajor, verMinor)
+	}
+}

--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -1,0 +1,3 @@
+module aamachine
+
+go 1.21

--- a/src/go/init.go
+++ b/src/go/init.go
@@ -1,0 +1,395 @@
+package main
+
+// Engine initialization and state management
+
+func NewEngine(fileArray []byte, io IO, seed uint32, quit, toparea, inlinearea bool) *Engine {
+	e := &Engine{}
+
+	if get4(fileArray, 0) != "FORM" || get4(fileArray, 8) != "AAVM" {
+		panic("Not an aastory file")
+	}
+
+	e.Head = findChunk(fileArray, "HEAD")
+	e.Code = findChunk(fileArray, "CODE")
+	e.Dict = findChunk(fileArray, "DICT")
+	e.Init = findChunk(fileArray, "INIT")
+	e.Lang = findChunk(fileArray, "LANG")
+	e.Maps = findChunk(fileArray, "MAPS")
+	e.Tags = findChunk(fileArray, "TAGS")
+	e.Writ = findChunk(fileArray, "WRIT")
+	e.Look = findChunk(fileArray, "LOOK")
+	e.Meta = findChunk(fileArray, "META")
+	e.Urls = findChunk(fileArray, "URLS")
+	e.Files = findFiles(fileArray)
+
+	if e.Head == nil || e.Code == nil || e.Dict == nil || e.Init == nil || e.Lang == nil || e.Maps == nil || e.Writ == nil || e.Look == nil {
+		panic("Missing required chunks")
+	}
+
+	e.RandomSeed = seed
+	e.StrShift = 0
+	e.ExtChars = 0
+	e.EscBits = 7
+	e.EscBoundary = 0
+	e.IO = io
+	e.HaveQuit = quit
+	e.HaveTop = toparea
+	e.HaveInline = inlinearea
+
+	if e.Head[0] > byte(VerMajor) || (e.Head[0] == byte(VerMajor) && e.Head[1] > byte(VerMinor)) {
+		panic("Unsupported aastory file format version")
+	}
+	if e.Head[2] != 2 {
+		panic("Unsupported word size")
+	}
+
+	e.HeapData = make([]uint16, get16(e.Head, 16)+128)
+	e.AuxData = make([]uint16, get16(e.Head, 18)+128)
+	e.RamData = make([]uint16, get16(e.Head, 20)+128)
+	e.StrShift = int(e.Head[3])
+	e.ExtChars = get16(e.Lang, 2)
+
+	if e.Head[0] > 0 || e.Head[1] >= 4 {
+		e.EscBoundary = int(e.Lang[e.ExtChars]) - 32
+		if e.EscBoundary < 0 {
+			e.EscBoundary = 0
+		}
+		i := e.EscBoundary + get16(e.Dict, 0) - 1
+		e.EscBits = 0
+		for i > 0 {
+			i >>= 1
+			e.EscBits++
+		}
+	}
+
+	stopptr := get16(e.Lang, 6)
+	stopend := stopptr
+	for e.Lang[stopend] != 0 {
+		stopend++
+	}
+	e.StopChars = make([]byte, stopend-stopptr)
+	copy(e.StopChars, e.Lang[stopptr:stopend])
+
+	if e.Head[0] > 0 || e.Head[1] >= 4 {
+		stopptr = stopend + 1
+		stopend = stopptr
+		for e.Lang[stopend] != 0 {
+			stopend++
+		}
+		e.NospBefore = make([]byte, stopend-stopptr)
+		copy(e.NospBefore, e.Lang[stopptr:stopend])
+
+		stopptr = stopend + 1
+		stopend = stopptr
+		for e.Lang[stopend] != 0 {
+			stopend++
+		}
+		e.NospAfter = make([]byte, stopend-stopptr)
+		copy(e.NospAfter, e.Lang[stopptr:stopend])
+	}
+
+	e.VMReinit()
+	e.VMReset(0, true)
+	e.InitState = e.VMCaptureState(1)
+	io.Reset()
+
+	return e
+}
+
+func (e *Engine) VMReinit() {
+	e.Nob = get16(e.Init, 0)
+	e.Ltb = get16(e.Init, 2)
+	e.Ltt = get16(e.Init, 4)
+	for i := range e.HeapData {
+		e.HeapData[i] = 0x3f3f
+	}
+	for i := range e.AuxData {
+		e.AuxData[i] = 0x3f3f
+	}
+	for i := (len(e.Init) - 6) >> 1; i < len(e.RamData); i++ {
+		e.RamData[i] = 0x3f3f
+	}
+	for i := 6; i < len(e.Init); i += 2 {
+		e.RamData[(i-6)>>1] = uint16(get16(e.Init, i))
+	}
+}
+
+func (e *Engine) VMReset(arg0 int, clearUndo bool) {
+	e.Reg[0] = uint16(arg0)
+	for i := 1; i < 64; i++ {
+		e.Reg[i] = 0
+	}
+	e.Inst = 1
+	e.Cont = 0
+	e.Top = 0
+	e.Env = len(e.HeapData)
+	e.Cho = len(e.HeapData)
+	e.Sim = 0xffff
+	e.Aux = 0
+	e.Trl = len(e.AuxData)
+	e.Sta = 0
+	e.Stc = 0
+	e.Cwl = 0
+	e.Spc = SPLine
+	e.Divs = []int{}
+	e.Upper = false
+	e.InStatus = false
+	e.NSpan = 0
+	e.NLink = 0
+	if clearUndo {
+		e.UndoData = nil
+		e.PrunedUndo = false
+	}
+	if e.RandomSeed != 0 {
+		e.RandomState = e.RandomSeed
+	}
+}
+
+func (e *Engine) VMCaptureState(newInst int) *EncodedState {
+	nword := 3 + len(e.RamData) + len(e.AuxData) + len(e.HeapData)
+	data := make([]byte, nword*2)
+	regs := make([]byte, 128+26+2+len(e.Divs)*2)
+
+	j := 0
+	j = put16(data, j, e.Nob)
+	j = put16(data, j, e.Ltb)
+	j = put16(data, j, e.Ltt)
+	for i := 0; i < len(e.RamData); i++ {
+		if i < e.Ltt {
+			j = put16(data, j, int(e.RamData[i]))
+		} else {
+			j = put16(data, j, 0x3f3f)
+		}
+	}
+	for i := 0; i < len(e.AuxData); i++ {
+		if i < e.Aux || i >= e.Trl {
+			j = put16(data, j, int(e.AuxData[i]))
+		} else {
+			j = put16(data, j, 0x3f3f)
+		}
+	}
+	for i := 0; i < len(e.HeapData); i++ {
+		if i < e.Top || i >= e.Env || i >= e.Cho {
+			j = put16(data, j, int(e.HeapData[i]))
+		} else {
+			j = put16(data, j, 0x3f3f)
+		}
+	}
+
+	j = 0
+	for i := 0; i < 64; i++ {
+		j = put16(regs, j, int(e.Reg[i]))
+	}
+	j = put32(regs, j, newInst)
+	j = put32(regs, j, e.Cont)
+	j = put16(regs, j, e.Top)
+	j = put16(regs, j, e.Env)
+	j = put16(regs, j, e.Cho)
+	j = put16(regs, j, e.Sim)
+	j = put16(regs, j, e.Aux)
+	j = put16(regs, j, e.Trl)
+	j = put16(regs, j, e.Sta)
+	j = put16(regs, j, e.Stc)
+	regs[j] = byte(e.Cwl)
+	j++
+	regs[j] = byte(e.Spc)
+	j++
+	j = put16(regs, j, len(e.Divs))
+	for i := 0; i < len(e.Divs); i++ {
+		j = put16(regs, j, e.Divs[i])
+	}
+
+	return &EncodedState{Data: data, Regs: regs}
+}
+
+func (e *Engine) VMClearDivs() {
+	e.IO.LeaveAll()
+	e.InStatus = false
+	e.NSpan = 0
+	e.NLink = 0
+	e.Divs = []int{}
+}
+
+func (e *Engine) VMRestoreState(state *EncodedState) {
+	data := state.Data
+	regs := state.Regs
+	j := 0
+
+	e.Nob = get16(data, j)
+	j += 2
+	e.Ltb = get16(data, j)
+	j += 2
+	e.Ltt = get16(data, j)
+	j += 2
+	for i := 0; i < len(e.RamData); i++ {
+		e.RamData[i] = uint16(get16(data, j))
+		j += 2
+	}
+	for i := 0; i < len(e.AuxData); i++ {
+		e.AuxData[i] = uint16(get16(data, j))
+		j += 2
+	}
+	for i := 0; i < len(e.HeapData); i++ {
+		e.HeapData[i] = uint16(get16(data, j))
+		j += 2
+	}
+
+	j = 0
+	for i := 0; i < 64; i++ {
+		e.Reg[i] = uint16(get16(regs, j))
+		j += 2
+	}
+	e.Inst = get32(regs, j)
+	j += 4
+	e.Cont = get32(regs, j)
+	j += 4
+	e.Top = get16(regs, j)
+	j += 2
+	e.Env = get16(regs, j)
+	j += 2
+	e.Cho = get16(regs, j)
+	j += 2
+	e.Sim = get16(regs, j)
+	j += 2
+	e.Aux = get16(regs, j)
+	j += 2
+	e.Trl = get16(regs, j)
+	j += 2
+	e.Sta = get16(regs, j)
+	j += 2
+	e.Stc = get16(regs, j)
+	j += 2
+	e.Cwl = int(regs[j])
+	j++
+	e.Spc = int(regs[j])
+	j++
+	ndiv := get16(regs, j)
+	j += 2
+	for i := 0; i < ndiv; i++ {
+		d := get16(regs, j)
+		j += 2
+		e.Divs = append(e.Divs, d)
+		e.IO.EnterDiv(d)
+	}
+}
+
+// RLE encoding/decoding for undo/save
+
+func VMRLEncState(reference, state *EncodedState) *EncodedState {
+	bytes := 0
+	nz := 0
+
+	for i := 0; i < len(reference.Data); i++ {
+		if reference.Data[i]^state.Data[i] != 0 {
+			bytes++
+			nz = 0
+		} else {
+			if nz != 0 && nz < 0x100 {
+				nz++
+			} else {
+				bytes += 2
+				nz = 1
+			}
+		}
+	}
+
+	encoded := make([]byte, bytes)
+	j := 0
+	nz = 0
+	for i := 0; i < len(reference.Data); i++ {
+		diff := reference.Data[i] ^ state.Data[i]
+		if diff != 0 {
+			encoded[j] = diff
+			j++
+		} else {
+			encoded[j] = 0
+			j++
+			nz = 1
+			for nz < 0x100 && i+nz < len(reference.Data) && reference.Data[i+nz]^state.Data[i+nz] == 0 {
+				nz++
+			}
+			encoded[j] = byte(nz - 1)
+			j++
+			i += nz - 1
+		}
+	}
+
+	return &EncodedState{Data: encoded, Regs: state.Regs}
+}
+
+func VMRLDecState(reference *EncodedState, encoded *EncodedState) *EncodedState {
+	array := make([]byte, len(reference.Data))
+	j := 0
+
+	for i := 0; i < len(encoded.Data); i++ {
+		diff := encoded.Data[i]
+		if diff != 0 {
+			array[j] = reference.Data[j] ^ diff
+			j++
+		} else {
+			i++
+			nz := int(encoded.Data[i]) + 1
+			for k := 0; k < nz; k++ {
+				array[j] = reference.Data[j]
+				j++
+			}
+		}
+	}
+
+	return &EncodedState{Data: array, Regs: encoded.Regs}
+}
+
+func VMWrapSavefile(e *Engine, encoded *EncodedState) []byte {
+	makechunk := func(tag string, array []byte) []byte {
+		size := (len(array) + 1) & ^1
+		result := make([]byte, 8+size)
+		put4(result, 0, tag)
+		put32(result, 4, len(array))
+		copy(result[8:], array)
+		return result
+	}
+
+	head := makechunk("HEAD", e.Head)
+	data := makechunk("DATA", encoded.Data)
+	regs := makechunk("REGS", encoded.Regs)
+	size := 4 + len(head) + len(data) + len(regs)
+	result := make([]byte, 8+size)
+
+	put4(result, 0, "FORM")
+	put32(result, 4, size)
+	put4(result, 8, "AASV")
+	copy(result[12:], head)
+	copy(result[12+len(head):], data)
+	copy(result[12+len(head)+len(data):], regs)
+
+	return result
+}
+
+func VMUnwrapSavefile(e *Engine, filedata []byte) *EncodedState {
+	if get4(filedata, 0) != "FORM" || get4(filedata, 8) != "AASV" {
+		e.IO.Print("Not an aasave file!")
+		e.IO.Line()
+		return nil
+	}
+	head := findChunk(filedata, "HEAD")
+	data := findChunk(filedata, "DATA")
+	regs := findChunk(filedata, "REGS")
+	if head == nil || data == nil || regs == nil {
+		e.IO.Print("Incomplete aasave file!")
+		e.IO.Line()
+		return nil
+	}
+	i := 0
+	for i < len(head) && i < len(e.Head) {
+		if head[i] != e.Head[i] {
+			break
+		}
+		i++
+	}
+	if i != len(head) || i != len(e.Head) {
+		e.IO.Print("This savefile is from another story (or another version of the present story).")
+		e.IO.Line()
+		return nil
+	}
+	return &EncodedState{Data: data, Regs: regs}
+}

--- a/src/go/init_test.go
+++ b/src/go/init_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"testing"
+)
+
+// MockIO for testing - captures all output
+type MockIO struct {
+	output   string
+	newlines int
+	xpos     int
+	width    int
+}
+
+func NewMockIO() *MockIO {
+	return &MockIO{width: 80}
+}
+
+func (io *MockIO) Reset()                                  { io.output = ""; io.newlines = 1; io.xpos = 0 }
+func (io *MockIO) Print(s string)                          { io.output += s; io.xpos += len(s) }
+func (io *MockIO) Nbsp()                                   { io.output += " "; io.xpos++ }
+func (io *MockIO) Space()                                  { io.Print(" ") }
+func (io *MockIO) SpaceN(n int)                            {}
+func (io *MockIO) Line()                                   { io.output += "\n"; io.newlines++; io.xpos = 0 }
+func (io *MockIO) Par()                                    { io.output += "\n\n"; io.newlines += 2; io.xpos = 0 }
+func (io *MockIO) Flush()                                  {}
+func (io *MockIO) SetBody(id int)                          {}
+func (io *MockIO) EnterDiv(id int)                         {}
+func (io *MockIO) LeaveDiv(id int)                         {}
+func (io *MockIO) EnterSpan(id int)                        {}
+func (io *MockIO) LeaveSpan()                              {}
+func (io *MockIO) EnterStatus(area, id int)                {}
+func (io *MockIO) LeaveStatus()                            {}
+func (io *MockIO) SetStyle(s int)                          {}
+func (io *MockIO) ResetStyle(s int)                        {}
+func (io *MockIO) Unstyle()                                {}
+func (io *MockIO) Clear()                                  {}
+func (io *MockIO) ClearAll()                               {}
+func (io *MockIO) ClearLinks()                             {}
+func (io *MockIO) ClearOld()                               {}
+func (io *MockIO) ClearDiv()                               {}
+func (io *MockIO) ClearStatus()                            {}
+func (io *MockIO) HaveLinks() bool                         { return false }
+func (io *MockIO) EnterLink(s string)                      {}
+func (io *MockIO) LeaveLink()                              {}
+func (io *MockIO) EnterLinkRes(r Resource)                 {}
+func (io *MockIO) LeaveLinkRes()                           {}
+func (io *MockIO) EnterSelfLink()                          {}
+func (io *MockIO) LeaveSelfLink()                          {}
+func (io *MockIO) LeaveAll()                               { io.Line() }
+func (io *MockIO) EmbedRes(r Resource)                     { io.Print("["); io.Print(r.Alt); io.Print("]") }
+func (io *MockIO) CanEmbedRes(r Resource) bool             { return false }
+func (io *MockIO) ProgressBar(p, total int)                {}
+func (io *MockIO) Trace(s string)                          {}
+func (io *MockIO) MeasureDims(which int) int               { return 0 }
+func (io *MockIO) ScriptOn() bool                          { return false }
+func (io *MockIO) ScriptOff()                              {}
+func (io *MockIO) ScriptActive() bool                      { return false }
+func (io *MockIO) Save(data []byte) bool                   { return true }
+func (io *MockIO) Restore()                                {}
+func (io *MockIO) HaveStyles() bool                        { return false }
+func (io *MockIO) HaveColor() bool                         { return false }
+func (io *MockIO) HaveAlign() bool                         { return false }
+
+func TestEngineInitBodyNotStatus(t *testing.T) {
+	data := loadStory(t, "../../test/body_not_status/body_not_status.aastory")
+	io := NewMockIO()
+
+	e := NewEngine(data, io, 1234, true, false, false)
+
+	// Verify memory allocation
+	if len(e.HeapData) != 1000+128 {
+		t.Errorf("HeapData size: got %d, want %d", len(e.HeapData), 1000+128)
+	}
+	if len(e.AuxData) != 500+128 {
+		t.Errorf("AuxData size: got %d, want %d", len(e.AuxData), 500+128)
+	}
+	if len(e.RamData) != 501+128 {
+		t.Errorf("RamData size: got %d, want %d", len(e.RamData), 501+128)
+	}
+
+	// Verify VM state after reset
+	if e.Inst != 1 {
+		t.Errorf("Inst: got %d, want 1", e.Inst)
+	}
+	if e.Cont != 0 {
+		t.Errorf("Cont: got %d, want 0", e.Cont)
+	}
+	if e.Top != 0 {
+		t.Errorf("Top: got %d, want 0", e.Top)
+	}
+	if e.Env != len(e.HeapData) {
+		t.Errorf("Env: got %d, want %d", e.Env, len(e.HeapData))
+	}
+	if e.Cho != len(e.HeapData) {
+		t.Errorf("Cho: got %d, want %d", e.Cho, len(e.HeapData))
+	}
+	if e.Sim != 0xffff {
+		t.Errorf("Sim: got %d, want 0xffff", e.Sim)
+	}
+	if e.Aux != 0 {
+		t.Errorf("Aux: got %d, want 0", e.Aux)
+	}
+	if e.Trl != len(e.AuxData) {
+		t.Errorf("Trl: got %d, want %d", e.Trl, len(e.AuxData))
+	}
+	if e.Nob != get16(e.Init, 0) {
+		t.Errorf("Nob: got %d, want %d", e.Nob, get16(e.Init, 0))
+	}
+
+	// Verify initial state was captured
+	if e.InitState == nil {
+		t.Fatal("InitState is nil")
+	}
+	if len(e.InitState.Data) == 0 {
+		t.Fatal("InitState.Data is empty")
+	}
+	if len(e.InitState.Regs) == 0 {
+		t.Fatal("InitState.Regs is empty")
+	}
+
+	t.Logf("Engine initialized: heap=%d, aux=%d, ram=%d, nob=%d",
+		len(e.HeapData), len(e.AuxData), len(e.RamData), e.Nob)
+}
+
+func TestEngineInitGosling(t *testing.T) {
+	data := loadStory(t, "../../test/gosling/gosling.aastory")
+	io := NewMockIO()
+
+	e := NewEngine(data, io, 1234, true, false, false)
+
+	if len(e.HeapData) == 0 {
+		t.Fatal("HeapData not allocated")
+	}
+	if len(e.AuxData) == 0 {
+		t.Fatal("AuxData not allocated")
+	}
+	if len(e.RamData) == 0 {
+		t.Fatal("RamData not allocated")
+	}
+
+	t.Logf("Gosling engine: heap=%d, aux=%d, ram=%d, nob=%d, format=%d.%d",
+		len(e.HeapData), len(e.AuxData), len(e.RamData), e.Nob,
+		e.Head[0], e.Head[1])
+}
+
+func TestVMStateCaptureRestore(t *testing.T) {
+	data := loadStory(t, "../../test/body_not_status/body_not_status.aastory")
+	io := NewMockIO()
+	e := NewEngine(data, io, 1234, true, false, false)
+
+	// Capture state
+	state := e.VMCaptureState(e.Inst)
+
+	// Verify we can restore
+	e.VMRestoreState(state)
+
+	// Verify state matches
+	if e.Inst != 1 {
+		t.Errorf("After restore, Inst: got %d, want 1", e.Inst)
+	}
+	if e.Nob != get16(e.Init, 0) {
+		t.Errorf("After restore, Nob: got %d, want %d", e.Nob, get16(e.Init, 0))
+	}
+}
+
+func TestRLEStateRoundTrip(t *testing.T) {
+	data := loadStory(t, "../../test/body_not_status/body_not_status.aastory")
+	io := NewMockIO()
+	e := NewEngine(data, io, 1234, true, false, false)
+
+	// Capture and RLE encode
+	state1 := e.VMCaptureState(e.Inst)
+	encoded := VMRLEncState(e.InitState, state1)
+
+	// RLE decode
+	decoded := VMRLDecState(e.InitState, encoded)
+
+	// Restore the decoded state
+	e.VMRestoreState(decoded)
+
+	// Verify key fields
+	if e.Inst != 1 {
+		t.Errorf("After RLE round-trip, Inst: got %d, want 1", e.Inst)
+	}
+}
+
+func TestDictLookup(t *testing.T) {
+	data := loadStory(t, "../../test/gosling/gosling.aastory")
+	io := NewMockIO()
+	e := NewEngine(data, io, 1234, true, false, false)
+
+	// The dictionary should have entries
+	numWords := get16(e.Dict, 0)
+	t.Logf("Dictionary has %d words", numWords)
+	if numWords == 0 {
+		t.Error("Dictionary has no words")
+	}
+
+	// Try to decode a word from the dictionary
+	entry := 2 // First word entry
+	wordLen := int(e.Dict[entry])
+	wordAddr := get16(e.Dict, entry+1)
+	t.Logf("First word: len=%d, addr=%d", wordLen, wordAddr)
+
+	if wordLen == 0 {
+		t.Error("First word has length 0")
+	}
+	if wordAddr == 0 {
+		t.Error("First word has address 0")
+	}
+}

--- a/src/go/main.go
+++ b/src/go/main.go
@@ -1,0 +1,390 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+const VERSION = "1.0.3"
+
+type TerminalIO struct {
+	hidden      bool
+	newlines    int
+	pendingSpc  int
+	pendingWord string
+	xpos        int
+	width       int
+	styles      []map[string]string
+	quirks      bool
+}
+
+func NewTerminalIO(width int, quirks bool) *TerminalIO {
+	return &TerminalIO{width: width, quirks: quirks}
+}
+
+func (io *TerminalIO) Reset() {
+	io.hidden = false
+	io.pendingWord = ""
+	io.pendingSpc = 0
+	io.xpos = 0
+	if io.quirks {
+		io.newlines = 999
+	} else {
+		io.newlines = 1
+	}
+}
+
+func (io *TerminalIO) vspaceN(n int) {
+	n++
+	for io.newlines < n {
+		fmt.Print("\n")
+		io.newlines++
+	}
+	io.xpos = 0
+	io.pendingSpc = 0
+}
+
+func (io *TerminalIO) Flush() {
+	if io.width > 0 && io.xpos+io.pendingSpc+utf8.RuneCountInString(io.pendingWord) > io.width {
+		io.vspaceN(0)
+	}
+	for io.pendingSpc > 0 {
+		if io.xpos > 0 {
+			fmt.Print(" ")
+			io.xpos++
+		}
+		io.pendingSpc--
+	}
+	if len(io.pendingWord) > 0 {
+		fmt.Print(io.pendingWord)
+		io.xpos += utf8.RuneCountInString(io.pendingWord)
+		io.newlines = 0
+		io.pendingWord = ""
+	}
+}
+
+func (io *TerminalIO) Print(str string) {
+	if !io.hidden {
+		for _, r := range str {
+			if r == ' ' {
+				io.Flush()
+				io.pendingSpc++
+			} else if r == '-' {
+				io.pendingWord += string(r)
+				io.Flush()
+			} else {
+				io.pendingWord += string(r)
+			}
+		}
+	}
+}
+
+func (io *TerminalIO) Nbsp() {
+	if !io.hidden {
+		io.pendingWord += " "
+	}
+}
+
+func (io *TerminalIO) Space() {
+	if !io.hidden {
+		io.Print(" ")
+	}
+}
+
+func (io *TerminalIO) SpaceN(n int) {
+	if !io.hidden {
+		io.Flush()
+		if io.width > 0 && n > io.width-io.xpos {
+			n = io.width - io.xpos
+		}
+		for i := 0; i < n; i++ {
+			fmt.Print(" ")
+			io.xpos++
+		}
+		io.newlines = 0
+	}
+}
+
+func (io *TerminalIO) Line() {
+	if !io.hidden {
+		io.Flush()
+		io.vspaceN(0)
+	}
+}
+
+func (io *TerminalIO) Par() {
+	if !io.hidden {
+		io.Flush()
+		io.vspaceN(1)
+	}
+}
+
+func (io *TerminalIO) SetBody(id int) {}
+
+func (io *TerminalIO) parseEm(id int, key string, defvalue int) int {
+	if id >= 0 && id < len(io.styles) {
+		if str, ok := io.styles[id][key]; ok {
+			str = strings.TrimSpace(str)
+			if strings.HasSuffix(str, "em") {
+				str = strings.TrimSuffix(str, "em")
+				str = strings.TrimSpace(str)
+				if v, err := strconv.Atoi(str); err == nil {
+					return v
+				}
+			}
+		}
+	}
+	return defvalue
+}
+
+func (io *TerminalIO) EnterDiv(id int) {
+	if !io.hidden {
+		io.Flush()
+		io.vspaceN(io.parseEm(id, "margin-top", 0))
+	}
+}
+
+func (io *TerminalIO) LeaveDiv(id int) {
+	if !io.hidden {
+		io.Flush()
+		io.vspaceN(io.parseEm(id, "margin-bottom", 0))
+	}
+}
+
+func (io *TerminalIO) EnterSpan(id int) {}
+func (io *TerminalIO) LeaveSpan()      {}
+
+func (io *TerminalIO) EnterStatus(area, id int) {
+	io.Line()
+	io.hidden = true
+}
+
+func (io *TerminalIO) LeaveStatus() {
+	io.hidden = false
+}
+
+func (io *TerminalIO) HaveLinks() bool       { return false }
+func (io *TerminalIO) EnterLink(str string)   {}
+func (io *TerminalIO) LeaveLink()             {}
+func (io *TerminalIO) EnterLinkRes(res Resource) {}
+func (io *TerminalIO) LeaveLinkRes()          {}
+func (io *TerminalIO) EnterSelfLink()         {}
+func (io *TerminalIO) LeaveSelfLink()         {}
+
+func (io *TerminalIO) LeaveAll() {
+	io.Line()
+	io.hidden = false
+}
+
+func (io *TerminalIO) EmbedRes(res Resource) {
+	io.Print("[")
+	io.Print(res.Alt)
+	io.Print("]")
+}
+
+func (io *TerminalIO) CanEmbedRes(res Resource) bool { return false }
+
+func (io *TerminalIO) ProgressBar(p, total int) {
+	if !io.hidden {
+		full := 0
+		if io.width <= 0 {
+			full = 80 - 3
+		} else {
+			full = io.width - 3
+		}
+		first := int(float64(full) * (float64(p) / float64(total)))
+		second := full - first
+		io.EnterDiv(-1)
+		io.Print("[")
+		for i := 0; i < first; i++ {
+			io.Print("=")
+		}
+		for i := 0; i < second; i++ {
+			io.Print(" ")
+		}
+		io.Print("]")
+		io.LeaveDiv(-1)
+	}
+}
+
+func (io *TerminalIO) Trace(str string) {
+	if !io.hidden {
+		io.EnterDiv(-1)
+		fmt.Print(str)
+		io.xpos = utf8.RuneCountInString(str)
+		io.newlines = 0
+		io.LeaveDiv(-1)
+	}
+}
+
+func (io *TerminalIO) MeasureDims(which int) int {
+	if which == 0 && io.width > 0 {
+		return io.width
+	}
+	return 0
+}
+
+func (io *TerminalIO) ScriptOn() bool      { return false }
+func (io *TerminalIO) ScriptOff()          {}
+func (io *TerminalIO) ScriptActive() bool  { return false }
+func (io *TerminalIO) HaveStyles() bool    { return false }
+func (io *TerminalIO) HaveColor() bool     { return false }
+func (io *TerminalIO) HaveAlign() bool     { return false }
+func (io *TerminalIO) SetStyle(s int)      {}
+func (io *TerminalIO) ResetStyle(s int)    {}
+func (io *TerminalIO) Unstyle()            {}
+func (io *TerminalIO) Clear()              { io.Par() }
+func (io *TerminalIO) ClearAll()           { io.Par() }
+func (io *TerminalIO) ClearLinks()         {}
+func (io *TerminalIO) ClearOld()           {}
+func (io *TerminalIO) ClearDiv()           {}
+func (io *TerminalIO) ClearStatus()        {}
+
+func (io *TerminalIO) Save(filedata []byte) bool {
+	err := os.WriteFile("saved-game.aasave", filedata, 0644)
+	return err == nil
+}
+
+func (io *TerminalIO) Restore() {}
+
+func addTag(tagLines bool, status int) {
+	if !tagLines {
+		return
+	}
+	fmt.Print("\n")
+	switch status {
+	case StatusGetInput:
+		fmt.Print("> ")
+	case StatusGetKey:
+		fmt.Print(") ")
+	default:
+		fmt.Print("  ")
+	}
+}
+
+func usage() {
+	fmt.Println("Usage: aamrun [OPTIONS] file.aastory")
+	fmt.Println("    -s N            Set random seed.")
+	fmt.Println("    -w N            Set screen width (default 80).")
+	fmt.Println("    -h, --help      Show this message.")
+	fmt.Println("    -v, -V          Show version and exit.")
+	fmt.Println("    -T, --tag-lines Prepend output with \"  \", input with \"> \" or \") \".")
+	fmt.Println("    -D, --dfrotz    Emulate dfrotz quirks.")
+}
+
+func main() {
+	args := os.Args[1:]
+	seed := 0
+	width := 80
+	quirks := false
+	tagLines := false
+	filename := ""
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "-s":
+			if i+1 < len(args) {
+				i++
+				seed, _ = strconv.Atoi(args[i])
+			}
+		case "-w":
+			if i+1 < len(args) {
+				i++
+				width, _ = strconv.Atoi(args[i])
+			}
+		case "-h", "--help":
+			usage()
+			os.Exit(0)
+		case "-v", "-V":
+			fmt.Printf("Å-machine Go frontend version %s\n", VERSION)
+			os.Exit(0)
+		case "-T", "--tag-lines":
+			tagLines = true
+		case "-D", "--dfrotz":
+			quirks = true
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				fmt.Fprintf(os.Stderr, "Unknown option: %s\n", args[i])
+				usage()
+				os.Exit(1)
+			}
+			filename = args[i]
+		}
+	}
+
+	if filename == "" {
+		fmt.Fprintln(os.Stderr, "ERROR: Exactly one filename must be specified")
+		usage()
+		os.Exit(1)
+	}
+
+	storyfile, err := os.ReadFile(filename)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: Unable to read file %s: %v\n", filename, err)
+		os.Exit(1)
+	}
+
+	io := NewTerminalIO(width, quirks)
+	engine := NewEngine(storyfile, io, uint32(seed), true, false, false)
+	io.styles = GetStyles(engine)
+
+	status := engine.VMStart()
+	if status == StatusQuit {
+		io.Line()
+		io.Flush()
+		os.Exit(0)
+	}
+	addTag(tagLines, status)
+
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if status == StatusGetKey {
+			fmt.Println(line)
+			for i := 0; i < len(line) && status == StatusGetKey; i++ {
+				if tagLines {
+					fmt.Print("  ")
+				}
+				status = engine.VMProceedWithKey(int(line[i]))
+				addTag(tagLines, status)
+			}
+			if status == StatusGetKey {
+				if tagLines {
+					fmt.Print("  ")
+				}
+				status = engine.VMProceedWithKey(Keys["KEY_RETURN"])
+				addTag(tagLines, status)
+			}
+		} else if status == StatusGetInput {
+			fmt.Println(line)
+			io.xpos = 0
+			io.pendingSpc = 0
+			if io.quirks {
+				io.newlines = 999
+			} else {
+				io.newlines = 1
+			}
+			if tagLines {
+				fmt.Print("  ")
+			}
+			status = engine.VMProceedWithInput(line)
+			addTag(tagLines, status)
+		}
+		if status == StatusQuit {
+			if io.quirks {
+				io.Par()
+			} else {
+				io.Line()
+			}
+			io.Flush()
+			os.Exit(0)
+		}
+	}
+
+	io.Line()
+	io.Flush()
+}

--- a/src/go/parse.go
+++ b/src/go/parse.go
@@ -1,0 +1,113 @@
+package main
+
+// parseWord tokenizes a character list into a dictionary word, number, character, or unknown
+func parseWord(chars []int, e *Engine) int {
+	state := 0
+	var revEnding []int
+	v := 0
+	enddecoder := get16(e.Lang, 4)
+	l := len(chars)
+
+	buildlist := func(list []int) int {
+		v := 0x3f00
+		for i := 0; i < len(list); i++ {
+			ch := list[i]
+			if ch >= 0x30 && ch <= 0x39 {
+				v = e.createPair(ch+0x4000-0x30, v)
+			} else {
+				v = e.createPair(0x3e00|ch, v)
+			}
+		}
+		return v
+	}
+
+	finddict := func() int {
+		start := 0
+		end := get16(e.Dict, 0)
+		for start < end {
+			mid := (start + end) >> 1
+			dictlen := int(e.Dict[2+3*mid])
+			dictoffs := get16(e.Dict, 2+3*mid+1)
+			diff := 0
+			i := 0
+			for i < l && i < dictlen {
+				diff = chars[i] - int(e.Dict[dictoffs+i])
+				if diff != 0 {
+					break
+				}
+				i++
+			}
+			if i == dictlen && i == l {
+				if diff == 0 {
+					return 0x2000 | mid
+				}
+			} else if i == dictlen {
+				diff = 1
+			} else if i == l {
+				diff = -1
+			}
+			if diff < 0 {
+				end = mid
+			} else {
+				start = mid + 1
+			}
+		}
+		return 0
+	}
+
+	// Try dictionary lookup for words longer than 1
+	if l > 1 {
+		v = finddict()
+		if v != 0 {
+			return v
+		}
+	}
+
+	// Try number
+	v = 0
+	i := 0
+	for i < len(chars) {
+		if chars[i] < 0x30 || chars[i] > 0x39 {
+			break
+		}
+		v = v*10 + chars[i] - 0x30
+		if v >= 16384 {
+			break
+		}
+		i++
+	}
+	if i == len(chars) {
+		return 0x4000 | v
+	}
+
+	// Single character
+	if len(chars) == 1 {
+		return 0x3e00 | chars[0]
+	}
+
+	// Try word ending decomposition
+	for {
+		instr := int(e.Lang[enddecoder+state])
+		state++
+		if instr == 0 {
+			for l > 0 {
+				l--
+				revEnding = append(revEnding, chars[l])
+			}
+			return e.createPair(buildlist(revEnding), 0x3f00) | 0xe000
+		} else if instr == 1 {
+			v = finddict()
+			if v != 0 {
+				return e.createPair(v, buildlist(revEnding)) | 0xe000
+			}
+		} else {
+			next := int(e.Lang[enddecoder+state])
+			state++
+			if l > 2 && instr == chars[l-1] {
+				revEnding = append(revEnding, instr)
+				l--
+				state = next
+			}
+		}
+	}
+}

--- a/src/go/run.go
+++ b/src/go/run.go
@@ -1,0 +1,1560 @@
+package main
+
+import "fmt"
+
+// VMRun executes the VM loop. Returns status code (0=quit, 1=get_input, 2=get_key, 3=restore).
+// Uses an inner closure with defer/recover for VM exception handling (panic with error codes).
+// Uses a result variable to communicate return values back from the closure.
+func (e *Engine) VMRun(param int) int {
+	io := e.IO
+
+	if param != 0 {
+		e.store(int(e.Code[e.Inst]), param)
+		e.Inst++
+	}
+
+	result := -1 // -1 = continue, >= 0 = return status
+
+	for result < 0 {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					if x, ok := r.(int); ok && x > 0x4000 && x < 0x8000 {
+						if e.Spc < SPLine {
+							io.Line()
+						}
+						e.VMClearDivs()
+						e.VMReset(x, false)
+					} else {
+						panic(r)
+					}
+				}
+			}()
+
+			for result < 0 {
+				op := int(e.Code[e.Inst])
+				e.Inst++
+
+				switch op {
+				case 0x00: // nop
+				case 0x01: // fail
+					e.fail()
+				case 0x02: // set_cont code
+					e.Cont = e.fcode()
+				case 0x03: // proceed
+					if e.Sim < 0x8000 {
+						e.Cho = e.Sim
+					}
+					e.Inst = e.Cont
+				case 0x04: // jmp code
+					e.Inst = e.fcode()
+				case 0x05: // jmp_multi code
+					e.Sim = 0xffff
+					e.Inst = e.fcode()
+				case 0x85: // jmpl_multi code
+					a1 := e.fcode()
+					e.Cont = e.Inst
+					e.Sim = 0xffff
+					e.Inst = a1
+				case 0x06: // jmp_simple code
+					e.Sim = e.Cho
+					e.Inst = e.fcode()
+				case 0x86: // jmpl_simple code
+					a1 := e.fcode()
+					e.Cont = e.Inst
+					e.Sim = e.Cho
+					e.Inst = a1
+				case 0x07: // jmp_tail code
+					if e.Sim >= 0x8000 {
+						e.Sim = e.Cho
+					}
+					e.Inst = e.fcode()
+				case 0x87: // tail
+					if e.Sim >= 0x8000 {
+						e.Sim = e.Cho
+					}
+				case 0x08, 0x88: // push_env byte/0
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = int(e.Code[e.Inst])
+						e.Inst++
+					}
+					addr := e.Env
+					if e.Cho < e.Env {
+						addr = e.Cho
+					}
+					addr -= 4 + a1
+					if addr < e.Top {
+						panic(HeapFull)
+					}
+					e.HeapData[addr] = uint16(e.Env)
+					e.HeapData[addr+1] = uint16(e.Sim)
+					e.HeapData[addr+2] = uint16(e.Cont >> 16)
+					e.HeapData[addr+3] = uint16(e.Cont & 0xffff)
+					e.Env = addr
+				case 0x09: // pop_env
+					e.Cont = int(e.HeapData[e.Env+2])<<16 | int(e.HeapData[e.Env+3])
+					e.Sim = int(e.HeapData[e.Env+1])
+					e.Env = int(e.HeapData[e.Env])
+				case 0x89: // pop_env_proceed
+					e.Inst = int(e.HeapData[e.Env+2])<<16 | int(e.HeapData[e.Env+3])
+					if int(e.HeapData[e.Env+1]) < 0x8000 {
+						e.Cho = int(e.HeapData[e.Env+1])
+					}
+					e.Env = int(e.HeapData[e.Env])
+				case 0x0a, 0x8a: // push_choice byte/0 next
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = int(e.Code[e.Inst])
+						e.Inst++
+					}
+					e.pushCho(a1, e.fcode())
+				case 0x0b, 0x8b: // pop_choice byte/0
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = int(e.Code[e.Inst])
+						e.Inst++
+					}
+					for i := 0; i < a1; i++ {
+						e.Reg[i] = e.HeapData[e.Cho+9+i]
+					}
+					for e.Trl < int(e.HeapData[e.Cho+8]) {
+						e.HeapData[int(e.AuxData[e.Trl])] = 0
+						e.Trl++
+					}
+					e.Top = int(e.HeapData[e.Cho+7])
+					e.Cont = int(e.HeapData[e.Cho+2])<<16 | int(e.HeapData[e.Cho+3])
+					e.Sim = int(e.HeapData[e.Cho+1])
+					e.Env = int(e.HeapData[e.Cho])
+					e.Cho = int(e.HeapData[e.Cho+6])
+				case 0x0c, 0x8c: // pop_push_choice byte/0 code
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = int(e.Code[e.Inst])
+						e.Inst++
+					}
+					a2 := e.fcode()
+					e.HeapData[e.Cho+4] = uint16(a2 >> 16)
+					e.HeapData[e.Cho+5] = uint16(a2 & 0xffff)
+					for i := 0; i < a1; i++ {
+						e.Reg[i] = e.HeapData[e.Cho+9+i]
+					}
+					for e.Trl < int(e.HeapData[e.Cho+8]) {
+						e.HeapData[int(e.AuxData[e.Trl])] = 0
+						e.Trl++
+					}
+					e.Top = int(e.HeapData[e.Cho+7])
+					e.Cont = int(e.HeapData[e.Cho+2])<<16 | int(e.HeapData[e.Cho+3])
+					e.Sim = int(e.HeapData[e.Cho+1])
+					e.Env = int(e.HeapData[e.Cho])
+				case 0x0d: // cut_choice
+					e.Cho = int(e.HeapData[e.Cho+6])
+				case 0x0e: // get_cho dest
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					e.store(d, e.Cho)
+				case 0x0f: // set_cho value
+					e.Cho = e.fvalue()
+				case 0x10, 0x90: // assign value/vbyte dest
+					a1 := 0
+					if op&0x80 != 0 {
+						a1 = int(e.Code[e.Inst])
+						e.Inst++
+					} else {
+						a1 = e.fvalue()
+					}
+					a2 := int(e.Code[e.Inst])
+					e.Inst++
+					e.store(a2, a1)
+				case 0x11: // make_var dest
+					a1 := int(e.Code[e.Inst])
+					e.Inst++
+					addr := e.Top
+					e.Top++
+					if e.Top > e.Env || e.Top > e.Cho {
+						panic(HeapFull)
+					}
+					e.HeapData[addr] = 0
+					e.store(a1, 0x8000|addr)
+				case 0x12: // make_pair DEST DEST DEST
+					a1 := int(e.Code[e.Inst])
+					e.Inst++
+					a2 := int(e.Code[e.Inst])
+					e.Inst++
+					a3 := int(e.Code[e.Inst])
+					e.Inst++
+					e.makePair(false, a1, a2, a3)
+				case 0x13, 0x93: // make_pair WORD/VBYTE DEST DEST
+					a1 := 0
+					if op&0x80 != 0 {
+						a1 = int(e.Code[e.Inst])
+						e.Inst++
+					} else {
+						a1 = e.fword()
+					}
+					a2 := int(e.Code[e.Inst])
+					e.Inst++
+					a3 := int(e.Code[e.Inst])
+					e.Inst++
+					e.makePair(true, a1, a2, a3)
+				case 0x14: // aux_push_val value
+					e.pushAux(e.fvalue())
+				case 0x94: // aux_push_raw 0
+					if e.Aux >= e.Trl {
+						panic(AuxFull)
+					}
+					e.AuxData[e.Aux] = 0
+					e.Aux++
+				case 0x15: // aux_push_raw word
+					if e.Aux >= e.Trl {
+						panic(AuxFull)
+					}
+					e.AuxData[e.Aux] = uint16(e.fword())
+					e.Aux++
+				case 0x95: // aux_push_raw vbyte
+					if e.Aux >= e.Trl {
+						panic(AuxFull)
+					}
+					e.AuxData[e.Aux] = uint16(e.Code[e.Inst])
+					e.Inst++
+					e.Aux++
+				case 0x16: // aux_pop_val dest
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					e.store(d, e.popAux())
+				case 0x17: // aux_pop_list dest
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					e.store(d, e.popAuxList())
+				case 0x18: // aux_pop_list_chk value
+					a1 := e.deref(e.fvalue())
+					flag := false
+					for {
+						e.Aux--
+						v := int(e.AuxData[e.Aux])
+						if v == 0 {
+							break
+						}
+						if v == a1 {
+							flag = true
+						}
+					}
+					if !flag {
+						e.fail()
+					}
+				case 0x19: // aux_pop_list_match value
+					e.Tmp = e.Top
+					a1 := e.deref(e.fvalue())
+					v := e.popAuxList()
+					for (a1 & 0xe000) == 0xc000 {
+						iter := v
+						match := false
+						for (iter & 0xe000) == 0xc000 && !match {
+							if e.would_unify(iter-0x4000, a1-0x4000) {
+								match = true
+							}
+							iter = e.deref(iter - 0x3fff)
+						}
+						if !match {
+							e.fail()
+							break
+						}
+						a1 = e.deref(a1 - 0x3fff)
+					}
+					e.Top = e.Tmp
+				case 0x1b: // split_list value value dest
+					a1 := e.deref(e.fvalue())
+					a2 := e.deref(e.fvalue())
+					v := 0x3f00
+					if a1 != a2 && (a1&0xe000) == 0xc000 {
+						curr := e.Top
+						v = 0xc000 | curr
+						for {
+							e.Top += 2
+							if e.Top > e.Env || e.Top > e.Cho {
+								panic(HeapFull)
+							}
+							e.HeapData[curr] = e.HeapData[a1&0x1fff]
+							a1 = e.deref(a1 - 0x3fff)
+							if a1 == a2 || (a1&0xe000) != 0xc000 {
+								break
+							}
+							e.HeapData[curr+1] = uint16(0xc000 | e.Top)
+							curr = e.Top
+						}
+						e.HeapData[curr+1] = 0x3f00
+					}
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					e.store(d, v)
+				case 0x1c: // stop
+					e.Cho = e.Stc
+					e.Inst = int(e.HeapData[e.Cho+4])<<16 | int(e.HeapData[e.Cho+5])
+				case 0x1d: // push_stop code
+					if e.Aux+2 > e.Trl {
+						panic(AuxFull)
+					}
+					e.AuxData[e.Aux] = uint16(e.Stc)
+					e.Aux++
+					e.AuxData[e.Aux] = uint16(e.Sta)
+					e.Aux++
+					e.Sta = e.Aux
+					e.pushCho(0, e.fcode())
+					e.Stc = e.Cho
+				case 0x1e: // pop_stop
+					e.Aux = e.Sta
+					e.Aux--
+					e.Sta = int(e.AuxData[e.Aux])
+					e.Aux--
+					e.Stc = int(e.AuxData[e.Aux])
+				case 0x1f: // split_word value dest
+					a1 := e.deref(e.fvalue())
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					if a1 >= 0x2000 && a1 < 0x3e00 {
+						v := e.prependChars(a1, 0x3f00)
+						e.store(d, v)
+					} else if a1 >= 0x3e00 && a1 < 0x3f00 {
+						v := e.createPair(a1, 0x3f00)
+						e.store(d, v)
+					} else if a1 >= 0x4000 && a1 < 0x8000 {
+						i := a1 & 0x3fff
+						v := 0x3f00
+						for {
+							v = e.createPair(0x4000|(i%10), v)
+							i /= 10
+							if i == 0 {
+								break
+							}
+						}
+						e.store(d, v)
+					} else if a1 >= 0xe000 {
+						a2 := int(e.HeapData[(a1&0x1fff)+0])
+						if a2 >= 0x8000 {
+							e.store(d, a2)
+						} else {
+							a3 := int(e.HeapData[(a1&0x1fff)+1])
+							v := e.prependChars(a2, a3)
+							e.store(d, v)
+						}
+					} else {
+						e.fail()
+					}
+				case 0x9f: // join_words value dest
+					a1 := e.deref(e.fvalue())
+					if (a1 & 0xe000) != 0xc000 {
+						e.fail()
+						break
+					}
+					a2 := e.deref(int(e.HeapData[(a1&0x1fff)+0]))
+					if (a2 & 0xff00) == 0x3e00 {
+						a3 := e.deref(int(e.HeapData[(a1&0x1fff)+1]))
+						if a3 == 0x3f00 {
+							d := int(e.Code[e.Inst])
+							e.Inst++
+							e.store(d, a2)
+							break
+						}
+					}
+					tmp := e.wordsToCharlist(a1)
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					if tmp != nil {
+						e.store(d, parseWord(tmp, e))
+					} else {
+						e.fail()
+					}
+				case 0x20, 0xa0: // load_word value/0 index dest
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = e.fvalue()
+					}
+					a2 := e.findex()
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					e.store(d, e.readfield(a2, a1))
+				case 0x21, 0xa1: // load_byte value/0 index dest
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = e.fvalue()
+					}
+					a2 := e.findex()
+					v := e.readfield(a2>>1, a1)
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					if a2&1 != 0 {
+						e.store(d, v&0xff)
+					} else {
+						e.store(d, v>>8)
+					}
+				case 0x22, 0xa2: // load_val value/0 index dest
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = e.fvalue()
+					}
+					a2 := e.findex()
+					v := e.getLTS(e.readfield(a2, a1))
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					if v != 0 {
+						e.store(d, v)
+					} else {
+						e.fail()
+					}
+				case 0x24, 0xa4: // store_word value/0 index value
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = e.fvalue()
+					}
+					a2 := e.findex()
+					e.RamData[e.fieldaddr(a2, a1)] = uint16(e.fvalue())
+				case 0x25, 0xa5: // store_byte value/0 index value
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = e.fvalue()
+					}
+					a2 := e.findex()
+					a3 := e.fvalue()
+					addr := e.fieldaddr(a2>>1, a1)
+					if a2&1 != 0 {
+						e.RamData[addr] = (e.RamData[addr] & 0xff00) | uint16(a3&0xff)
+					} else {
+						e.RamData[addr] = (e.RamData[addr] & 0x00ff) | uint16((a3&0xff)<<8)
+					}
+				case 0x26, 0xa6: // store_val value/0 index value
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = e.deref(e.fvalue())
+					}
+					a2 := e.findex()
+					a3 := e.fvalue()
+					if a1 <= e.Nob || a3 != 0 {
+						e.putLTS(e.fieldaddr(a2, a1), a3)
+					}
+				case 0x28, 0xa8: // set_flag value/0 index
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = e.fvalue()
+					}
+					a2 := e.findex()
+					e.RamData[e.fieldaddr(a2>>4, a1)] |= uint16(0x8000 >> (a2 & 15))
+				case 0x29, 0xa9: // reset_flag value/0 index
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = e.deref(e.fvalue())
+					}
+					a2 := e.findex()
+					if a1 <= e.Nob {
+						e.RamData[e.fieldaddr(a2>>4, a1)] &^= uint16(0x8000 >> (a2 & 15))
+					}
+				case 0x2d, 0xad: // unlink value/0 index index value
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = e.fvalue()
+					}
+					a2 := e.findex()
+					a3 := e.findex()
+					e.unlink(e.fieldaddr(a2, a1), a3, e.deref(e.fvalue()))
+				case 0x2e, 0x2f, 0xae, 0xaf: // set_parent value/vbyte value/vbyte
+					a1 := 0
+					if op&0x80 != 0 {
+						a1 = int(e.Code[e.Inst])
+						e.Inst++
+					} else {
+						a1 = e.deref(e.fvalue())
+					}
+					a2 := 0
+					if op&0x01 != 0 {
+						a2 = int(e.Code[e.Inst])
+						e.Inst++
+					} else {
+						a2 = e.deref(e.fvalue())
+					}
+					if a1 < e.Nob || a2 != 0 {
+						if a1 >= 0x2000 || a2 >= 0x2000 {
+							panic(ExpectObj)
+						}
+						v := int(e.RamData[e.fieldaddr(0, a1)])
+						if v != 0 {
+							e.unlink(e.fieldaddr(1, v), 2, a1)
+						}
+						e.RamData[e.fieldaddr(0, a1)] = uint16(a2)
+						if a2 != 0 {
+							e.RamData[e.fieldaddr(2, a1)] = e.RamData[e.fieldaddr(1, a2)]
+							e.RamData[e.fieldaddr(1, a2)] = uint16(a1)
+						}
+					}
+				case 0x30, 0xb0: // if_raw_eq word/0 value code
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = e.fword()
+					}
+					a2 := e.fvalue()
+					a3 := e.fcode()
+					if a1 == a2 {
+						e.Inst = a3
+					}
+				case 0x31: // if_bound value code
+					a1 := e.deref(e.fvalue())
+					a2 := e.fcode()
+					if (a1 & 0xe000) != 0x8000 {
+						e.Inst = a2
+					}
+				case 0x32: // if_empty value code
+					a1 := e.deref(e.fvalue())
+					a2 := e.fcode()
+					if a1 == 0x3f00 {
+						e.Inst = a2
+					}
+				case 0x33: // if_num value code
+					a1 := e.deref(e.fvalue())
+					a2 := e.fcode()
+					if a1 >= 0x4000 && a1 < 0x8000 {
+						e.Inst = a2
+					}
+				case 0x34: // if_pair value code
+					a1 := e.deref(e.fvalue())
+					a2 := e.fcode()
+					if (a1 & 0xe000) == 0xc000 {
+						e.Inst = a2
+					}
+				case 0x35: // if_obj value code
+					a1 := e.deref(e.fvalue())
+					a2 := e.fcode()
+					if a1 < 0x2000 {
+						e.Inst = a2
+					}
+				case 0x36: // if_word value code
+					a1 := e.deref(e.fvalue())
+					a2 := e.fcode()
+					if a1 >= 0xe000 || (a1 >= 0x2000 && a1 < 0x3f00) {
+						e.Inst = a2
+					}
+				case 0xb6: // if_listword value code
+					a1 := e.deref(e.fvalue())
+					a2 := e.fcode()
+					if a1 >= 0xe000 && (int(e.HeapData[a1&0x1fff])&0xe000) == 0xc000 {
+						e.Inst = a2
+					}
+				case 0x37: // if_unify value value code
+					a1 := e.fvalue()
+					a2 := e.fvalue()
+					a3 := e.fcode()
+					if e.would_unify(a1, a2) {
+						e.Inst = a3
+					}
+				case 0x38: // if_gt value value code
+					a1 := e.deref(e.fvalue())
+					a2 := e.deref(e.fvalue())
+					a3 := e.fcode()
+					if a1 >= 0x4000 && a1 < 0x8000 && a2 >= 0x4000 && a2 < 0x8000 && a1 > a2 {
+						e.Inst = a3
+					}
+				case 0x39, 0xb9: // if_eq word/vbyte value code
+					a1 := 0
+					if op&0x80 != 0 {
+						a1 = int(e.Code[e.Inst])
+						e.Inst++
+					} else {
+						a1 = e.fword()
+					}
+					a2 := e.fvalue()
+					a3 := e.fcode()
+					if a1 == e.deref(a2) {
+						e.Inst = a3
+					}
+				case 0x3a, 0xba: // if_mem_eq value/0 index value code
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = e.fvalue()
+					}
+					a2 := e.findex()
+					a3 := e.fvalue()
+					a4 := e.fcode()
+					if e.readfield(a2, a1) == a3 {
+						e.Inst = a4
+					}
+				case 0x3b, 0xbb: // if_flag value/0 index code
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = e.fvalue()
+					}
+					a2 := e.findex()
+					a3 := e.fcode()
+					if int(e.readfield(a2>>4, a1))&(0x8000>>(a2&15)) != 0 {
+						e.Inst = a3
+					}
+				case 0x3c: // if_cwl code
+					a1 := e.fcode()
+					if e.Cwl != 0 {
+						e.Inst = a1
+					}
+				case 0x3d, 0xbd: // if_mem_eq value/0 index vbyte code
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = e.fvalue()
+					}
+					a2 := e.findex()
+					a3 := int(e.Code[e.Inst])
+					e.Inst++
+					a4 := e.fcode()
+					if e.readfield(a2, a1) == a3 {
+						e.Inst = a4
+					}
+				case 0x40, 0xc0: // ifn_raw_eq word/0 value code
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = e.fword()
+					}
+					a2 := e.fvalue()
+					a3 := e.fcode()
+					if a1 != a2 {
+						e.Inst = a3
+					}
+				case 0x41: // ifn_bound value code
+					a1 := e.deref(e.fvalue())
+					a2 := e.fcode()
+					if (a1 & 0xe000) == 0x8000 {
+						e.Inst = a2
+					}
+				case 0x42: // ifn_empty value code
+					a1 := e.deref(e.fvalue())
+					a2 := e.fcode()
+					if a1 != 0x3f00 {
+						e.Inst = a2
+					}
+				case 0x43: // ifn_num value code
+					a1 := e.deref(e.fvalue())
+					a2 := e.fcode()
+					if a1 < 0x4000 || a1 >= 0x8000 {
+						e.Inst = a2
+					}
+				case 0x44: // ifn_pair value code
+					a1 := e.deref(e.fvalue())
+					a2 := e.fcode()
+					if (a1 & 0xe000) != 0xc000 {
+						e.Inst = a2
+					}
+				case 0x45: // ifn_obj value code
+					a1 := e.deref(e.fvalue())
+					a2 := e.fcode()
+					if a1 >= 0x2000 {
+						e.Inst = a2
+					}
+				case 0x46: // ifn_word value code
+					a1 := e.deref(e.fvalue())
+					a2 := e.fcode()
+					if a1 < 0xe000 && (a1 < 0x2000 || a1 >= 0x3f00) {
+						e.Inst = a2
+					}
+				case 0xc6: // ifn_listword value code
+					a1 := e.deref(e.fvalue())
+					a2 := e.fcode()
+					if a1 < 0xe000 || (int(e.HeapData[a1&0x1fff])&0xe000) != 0xc000 {
+						e.Inst = a2
+					}
+				case 0x47: // ifn_unify value value code
+					a1 := e.fvalue()
+					a2 := e.fvalue()
+					a3 := e.fcode()
+					if !e.would_unify(a1, a2) {
+						e.Inst = a3
+					}
+				case 0x48: // ifn_gt value value code
+					a1 := e.deref(e.fvalue())
+					a2 := e.deref(e.fvalue())
+					a3 := e.fcode()
+					if !(a1 >= 0x4000 && a1 < 0x8000 && a2 >= 0x4000 && a2 < 0x8000 && a1 > a2) {
+						e.Inst = a3
+					}
+				case 0x49, 0xc9: // ifn_eq word/vbyte value code
+					a1 := 0
+					if op&0x80 != 0 {
+						a1 = int(e.Code[e.Inst])
+						e.Inst++
+					} else {
+						a1 = e.fword()
+					}
+					a2 := e.fvalue()
+					a3 := e.fcode()
+					if a1 != e.deref(a2) {
+						e.Inst = a3
+					}
+				case 0x4a, 0xca: // ifn_mem_eq value/0 index value code
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = e.fvalue()
+					}
+					a2 := e.findex()
+					a3 := e.fvalue()
+					a4 := e.fcode()
+					if e.readfield(a2, a1) != a3 {
+						e.Inst = a4
+					}
+				case 0x4b, 0xcb: // ifn_flag value/0 index code
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = e.fvalue()
+					}
+					a2 := e.findex()
+					a3 := e.fcode()
+					if int(e.readfield(a2>>4, a1))&(0x8000>>(a2&15)) == 0 {
+						e.Inst = a3
+					}
+				case 0x4c: // ifn_cwl code
+					a1 := e.fcode()
+					if e.Cwl == 0 {
+						e.Inst = a1
+					}
+				case 0x4d, 0xcd: // ifn_mem_eq value/0 index vbyte code
+					a1 := 0
+					if op&0x80 == 0 {
+						a1 = e.fvalue()
+					}
+					a2 := e.findex()
+					a3 := int(e.Code[e.Inst])
+					e.Inst++
+					a4 := e.fcode()
+					if e.readfield(a2, a1) != a3 {
+						e.Inst = a4
+					}
+				case 0x50: // add_raw value value dest
+					a1 := e.deref(e.fvalue())
+					a2 := e.deref(e.fvalue())
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					e.store(d, (a1+a2)&0xffff)
+				case 0xd0: // inc_raw value dest
+					a1 := e.deref(e.fvalue())
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					e.store(d, (a1+1)&0xffff)
+				case 0x51: // sub_raw value value dest
+					a1 := e.deref(e.fvalue())
+					a2 := e.deref(e.fvalue())
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					e.store(d, (a1-a2)&0xffff)
+				case 0xd1: // dec_raw value dest
+					a1 := e.deref(e.fvalue())
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					e.store(d, (a1-1)&0xffff)
+				case 0x52: // rand_raw byte dest
+					a1 := int(e.Code[e.Inst])
+					e.Inst++
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					e.store(d, int(e.compatRand())%(a1+1))
+				case 0x58: // add_num value value dest
+					a1 := e.deref(e.fvalue())
+					a2 := e.deref(e.fvalue())
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					if a1 >= 0x4000 && a1 < 0x8000 && a2 >= 0x4000 && a2 < 0x8000 {
+						v := (a1 & 0x3fff) + (a2 & 0x3fff)
+						if v < 0x4000 {
+							e.store(d, v|0x4000)
+						} else {
+							e.fail()
+						}
+					} else {
+						e.fail()
+					}
+				case 0xd8: // inc_num value dest
+					a1 := e.deref(e.fvalue())
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					if a1 >= 0x4000 && a1 < 0x7fff {
+						e.store(d, a1+1)
+					} else {
+						e.fail()
+					}
+				case 0x59: // sub_num value value dest
+					a1 := e.deref(e.fvalue())
+					a2 := e.deref(e.fvalue())
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					if a1 >= 0x4000 && a1 < 0x8000 && a2 >= 0x4000 && a2 < 0x8000 {
+						v := (a1 & 0x3fff) - (a2 & 0x3fff)
+						if v >= 0 {
+							e.store(d, v|0x4000)
+						} else {
+							e.fail()
+						}
+					} else {
+						e.fail()
+					}
+				case 0xd9: // dec_num value dest
+					a1 := e.deref(e.fvalue())
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					if a1 > 0x4000 && a1 < 0x8000 {
+						e.store(d, a1-1)
+					} else {
+						e.fail()
+					}
+				case 0x5a: // rand_num value value dest
+					a1 := e.deref(e.fvalue())
+					a2 := e.deref(e.fvalue())
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					if a1 >= 0x4000 && a1 < 0x8000 && a2 >= 0x4000 && a2 < 0x8000 && a2 >= a1 {
+						v := a1 + int(e.compatRand())%(a2-a1+1)
+						e.store(d, v)
+					} else {
+						e.fail()
+					}
+				case 0x5b: // mul_num value value dest
+					a1 := e.deref(e.fvalue())
+					a2 := e.deref(e.fvalue())
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					if a1 >= 0x4000 && a1 < 0x8000 && a2 >= 0x4000 && a2 < 0x8000 {
+						v := ((a1 & 0x3fff) * (a2 & 0x3fff)) & 0x3fff
+						e.store(d, v|0x4000)
+					} else {
+						e.fail()
+					}
+				case 0x5c: // div_num value value dest
+					a1 := e.deref(e.fvalue())
+					a2 := e.deref(e.fvalue())
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					if a1 >= 0x4000 && a1 < 0x8000 && a2 > 0x4000 && a2 < 0x8000 {
+						v := (a1 & 0x3fff) / (a2 & 0x3fff)
+						e.store(d, v|0x4000)
+					} else {
+						e.fail()
+					}
+				case 0x5d: // mod_num value value dest
+					a1 := e.deref(e.fvalue())
+					a2 := e.deref(e.fvalue())
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					if a1 >= 0x4000 && a1 < 0x8000 && a2 > 0x4000 && a2 < 0x8000 {
+						v := (a1 & 0x3fff) % (a2 & 0x3fff)
+						e.store(d, v|0x4000)
+					} else {
+						e.fail()
+					}
+				case 0x60: // print_a_str_a string
+					if e.Spc == SPAuto || e.Spc == SPPending {
+						io.Space()
+					} else if e.Spc == SPNBSP {
+						io.Nbsp()
+					}
+					io.Print(e.DecodeStr(e.fstring()))
+					e.Spc = SPAuto
+				case 0xe0: // print_n_str_a string
+					if e.Spc == SPPending {
+						io.Space()
+					} else if e.Spc == SPNBSP {
+						io.Nbsp()
+					}
+					io.Print(e.DecodeStr(e.fstring()))
+					e.Spc = SPAuto
+				case 0x61: // print_a_str_n string
+					if e.Spc == SPAuto || e.Spc == SPPending {
+						io.Space()
+					} else if e.Spc == SPNBSP {
+						io.Nbsp()
+					}
+					io.Print(e.DecodeStr(e.fstring()))
+					e.Spc = SPNoSpace
+				case 0xe1: // print_n_str_n string
+					if e.Spc == SPPending {
+						io.Space()
+					} else if e.Spc == SPNBSP {
+						io.Nbsp()
+					}
+					io.Print(e.DecodeStr(e.fstring()))
+					e.Spc = SPNoSpace
+				case 0x62: // nospace
+					if e.Cwl == 0 {
+						if e.Spc < SPNoSpace {
+							e.Spc = SPNoSpace
+						}
+					}
+				case 0xe2: // space
+					if e.Cwl == 0 {
+						if e.Spc < SPPending {
+							e.Spc = SPPending
+						}
+					}
+				case 0x63: // line
+					if e.Cwl == 0 {
+						if e.Spc < SPLine {
+							io.Line()
+							e.Spc = SPLine
+						}
+					}
+				case 0xe3: // par
+					if e.Cwl == 0 {
+						if e.Spc < SPPar {
+							if e.NSpan != 0 {
+								io.Line()
+								io.Line()
+							} else {
+								io.Par()
+							}
+							e.Spc = SPPar
+						}
+					}
+				case 0x64: // space_n value
+					a1 := e.deref(e.fvalue())
+					if e.Cwl == 0 && a1 > 0x4000 && a1 < 0x8000 {
+						io.SpaceN(a1 & 0x3fff)
+						e.Spc = SPSpace
+					}
+				case 0x65: // print_val value
+					a1 := e.deref(e.fvalue())
+					if e.Cwl != 0 {
+						e.pushAux(a1)
+					} else {
+						if (a1 & 0xff00) == 0x3e00 {
+							tmp := a1 & 0xff
+							if e.Spc == SPPending || (e.Spc == SPAuto && !containsByte(e.NospBefore, tmp)) {
+								io.Space()
+							}
+							io.Print(e.DecodeChar(tmp))
+							if containsByte(e.NospAfter, tmp) {
+								e.Spc = SPNoSpace
+							} else {
+								e.Spc = SPAuto
+							}
+						} else {
+							if e.Spc == SPAuto || e.Spc == SPPending {
+								io.Space()
+							}
+							io.Print(e.val2str(a1))
+							e.Spc = SPAuto
+						}
+					}
+				case 0x66: // enter_div index
+					a1 := e.findex()
+					if e.Cwl == 0 {
+						if e.NSpan != 0 {
+							panic(IOState)
+						}
+						io.EnterDiv(a1)
+						e.Divs = append(e.Divs, a1)
+						e.Spc = SPPar
+					}
+				case 0xe6: // leave_div
+					if e.Cwl == 0 {
+						last := len(e.Divs) - 1
+						io.LeaveDiv(e.Divs[last])
+						e.Divs = e.Divs[:last]
+						e.Spc = SPLine
+					}
+				case 0x67:
+					if e.Head[0] < 1 { // enter_status 0 index (pre-1.0)
+						a1 := e.findex()
+						if e.Cwl == 0 {
+							if e.InStatus || e.NSpan != 0 {
+								panic(IOState)
+							}
+							io.EnterStatus(0, a1)
+							e.InStatus = true
+							e.Spc = SPPar
+						}
+					} else { // set_body index (1.0+)
+						a1 := e.findex()
+						if e.InStatus || e.NSpan != 0 {
+							panic(IOState)
+						}
+						io.SetBody(a1)
+					}
+				case 0xe7:
+					if e.Head[0] < 1 { // leave_status (pre-1.0)
+						if e.Cwl == 0 {
+							io.LeaveStatus()
+							e.InStatus = false
+							e.Spc = SPPar
+						}
+					}
+				case 0x68: // enter_link_res value
+					a1 := e.deref(e.fvalue())
+					if e.Cwl == 0 {
+						if e.NLink == 0 {
+							if e.Spc == SPAuto || e.Spc == SPPending {
+								io.Space()
+							}
+							io.EnterLinkRes(e.GetRes(a1 & 0x1fff))
+							e.Spc = SPNoSpace
+						}
+						e.NLink++
+						e.NSpan++
+					}
+				case 0xe8: // leave_link_res
+					if e.Cwl == 0 {
+						e.NLink--
+						e.NSpan--
+						if e.NLink == 0 {
+							io.LeaveLinkRes()
+						}
+					}
+				case 0x69: // enter_link value
+					a1 := e.deref(e.fvalue())
+					if e.Cwl == 0 {
+						if e.NLink == 0 {
+							if e.Spc == SPAuto || e.Spc == SPPending {
+								io.Space()
+							}
+							savedUpper := e.Upper
+							e.Upper = false
+							str := ""
+							for (a1 & 0xe000) == 0xc000 {
+								v := e.deref(a1 - 0x4000)
+								if (v >= 0x2000 && v < 0x8000) || v >= 0xe000 {
+									if str != "" {
+										str += " "
+									}
+									str += e.val2str(v)
+								}
+								a1 = e.deref(a1 - 0x3fff)
+							}
+							io.EnterLink(str)
+							e.Upper = savedUpper
+							e.Spc = SPNoSpace
+						}
+						e.NLink++
+						e.NSpan++
+					}
+				case 0xe9: // leave_link
+					if e.Cwl == 0 {
+						e.NLink--
+						e.NSpan--
+						if e.NLink == 0 {
+							io.LeaveLink()
+						}
+					}
+				case 0x6a: // enter_self_link
+					if e.Cwl == 0 {
+						if e.NLink == 0 {
+							if e.Spc == SPAuto || e.Spc == SPPending {
+								io.Space()
+							}
+							io.EnterSelfLink()
+							e.Spc = SPNoSpace
+						}
+						e.NLink++
+						e.NSpan++
+					}
+				case 0xea: // leave_self_link
+					if e.Cwl == 0 {
+						e.NLink--
+						e.NSpan--
+						if e.NLink == 0 {
+							io.LeaveSelfLink()
+						}
+					}
+				case 0x6b: // set_style byte
+					a1 := int(e.Code[e.Inst])
+					e.Inst++
+					if e.Cwl == 0 {
+						if e.Spc == SPAuto || e.Spc == SPPending {
+							io.Space()
+						}
+						io.SetStyle(a1)
+						e.Spc = SPSpace
+					}
+				case 0xeb: // reset_style byte
+					a1 := int(e.Code[e.Inst])
+					e.Inst++
+					if e.Cwl == 0 {
+						io.ResetStyle(a1)
+					}
+				case 0x6c: // embed_res value
+					a1 := e.deref(e.fvalue())
+					if e.Spc == SPAuto || e.Spc == SPPending {
+						io.Space()
+					}
+					io.EmbedRes(e.GetRes(a1 & 0x1fff))
+					e.Spc = SPAuto
+				case 0xec: // can_embed_res value dest
+					a1 := e.deref(e.fvalue())
+					v := 0
+					if io.CanEmbedRes(e.GetRes(a1 & 0x1fff)) {
+						v = 1
+					}
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					e.store(d, v)
+				case 0x6d: // progress value value
+					a1 := e.deref(e.fvalue())
+					a2 := e.deref(e.fvalue())
+					if e.Cwl == 0 {
+						if a1 >= 0x4000 && a1 < 0x8000 && a2 >= 0x4000 && a2 < 0x8000 {
+							io.ProgressBar(a1&0x3fff, a2&0x3fff)
+						}
+					}
+				case 0x6e: // enter_span index
+					a1 := e.findex()
+					if e.Cwl == 0 {
+						if e.Spc == SPAuto || e.Spc == SPPending {
+							io.Space()
+						}
+						io.EnterSpan(a1)
+						e.NSpan++
+						e.Spc = SPNoSpace
+					}
+				case 0xee: // leave_span
+					if e.Cwl == 0 {
+						io.LeaveSpan()
+						e.NSpan--
+						e.Spc = SPAuto
+					}
+				case 0x6f: // enter_status byte index (1.0+)
+					a1 := int(e.Code[e.Inst])
+					e.Inst++
+					a2 := e.findex()
+					if e.Cwl == 0 {
+						if e.InStatus || e.NSpan != 0 {
+							panic(IOState)
+						}
+						io.EnterStatus(a1, a2)
+						e.InStatus = true
+						e.Spc = SPPar
+					}
+				case 0xef: // leave_status (1.0+)
+					if e.Head[0] > 0 {
+						if e.Cwl == 0 {
+							io.LeaveStatus()
+							e.InStatus = false
+							e.Spc = SPPar
+						}
+					}
+				case 0x70: // ext0 byte
+					a1 := int(e.Code[e.Inst])
+					e.Inst++
+					switch a1 {
+					case 0x00: // quit
+						io.Flush()
+						result = 0
+						return
+					case 0x01: // restart
+						e.VMClearDivs()
+						e.VMReset(0, true)
+						e.VMRestoreState(e.InitState)
+						io.Reset()
+					case 0x02: // restore
+						io.Flush()
+						io.Restore()
+						result = 3
+						return
+					case 0x03: // undo
+						if len(e.UndoData) > 0 {
+							e.VMClearDivs()
+							last := len(e.UndoData) - 1
+							e.VMRestoreState(VMRLDecState(e.InitState, &e.UndoData[last]))
+							e.UndoData = e.UndoData[:last]
+						} else if !e.PrunedUndo {
+							e.fail()
+						}
+					case 0x04: // unstyle
+						if e.Cwl == 0 {
+							io.Unstyle()
+						}
+					case 0x05: // print_serial
+						if e.Cwl == 0 {
+							if e.Spc == SPAuto || e.Spc == SPPending {
+								io.Space()
+							}
+							for i := 0; i < 6; i++ {
+								io.Print(string(rune(e.Head[6+i])))
+							}
+							e.Spc = SPAuto
+						}
+					case 0x06, 0x07: // clear, clear_all
+						if e.InStatus || e.NSpan != 0 {
+							panic(IOState)
+						}
+						tmp := e.Divs
+						e.VMClearDivs()
+						if a1 == 0x06 {
+							io.Clear()
+						} else {
+							io.ClearAll()
+						}
+						for _, d := range tmp {
+							io.EnterDiv(d)
+						}
+						e.Divs = tmp
+					case 0x08: // script_on
+						if !io.ScriptOn() {
+							e.fail()
+						}
+					case 0x09: // script_off
+						io.ScriptOff()
+					case 0x0a: // trace_on
+						e.Trace = true
+					case 0x0b: // trace_off
+						e.Trace = false
+					case 0x0c: // inc_cwl
+						e.Cwl++
+					case 0x0d: // dec_cwl
+						e.Cwl--
+					case 0x0e: // uppercase
+						if e.Cwl == 0 {
+							e.Upper = true
+						}
+					case 0x0f: // clear_links
+						io.ClearLinks()
+					case 0x10: // clear_old
+						if e.NSpan != 0 {
+							panic(IOState)
+						}
+						io.ClearOld()
+					case 0x11: // clear_div
+						io.ClearDiv()
+					case 0x12: // clear_status
+						if e.InStatus {
+							panic(IOState)
+						}
+						io.ClearStatus()
+					case 0x13: // nbsp
+						if e.Cwl == 0 {
+							if e.Spc < SPNBSP {
+								e.Spc = SPNBSP
+							}
+						}
+					}
+				case 0x72: // save code
+					a1 := e.fcode()
+					if e.InStatus || e.NSpan != 0 {
+						panic(IOState)
+					}
+					if !io.Save(VMWrapSavefile(e, VMRLEncState(e.InitState, e.VMCaptureState(a1)))) {
+						e.fail()
+					}
+				case 0xf2: // save_undo code
+					a1 := e.fcode()
+					if e.InStatus || e.NSpan != 0 {
+						panic(IOState)
+					}
+					if len(e.UndoData) > 50 {
+						e.UndoData = e.UndoData[1:]
+						e.PrunedUndo = true
+					}
+					e.UndoData = append(e.UndoData, *VMRLEncState(e.InitState, e.VMCaptureState(a1)))
+				case 0x73: // get_input dest
+					if e.Spc == SPAuto || e.Spc == SPPending {
+						io.Space()
+					} else if e.Spc == SPNBSP {
+						io.Nbsp()
+					}
+					io.Flush()
+					result = 1
+					return
+				case 0xf3: // get_key dest
+					if e.Spc == SPAuto || e.Spc == SPPending {
+						io.Space()
+					} else if e.Spc == SPNBSP {
+						io.Nbsp()
+					}
+					io.Flush()
+					result = 2
+					return
+				case 0x74: // vm_info byte dest
+					a1 := int(e.Code[e.Inst])
+					e.Inst++
+					v := 0
+					switch a1 {
+					case 0x00: // peak heap
+						for i := 0; i < len(e.HeapData); i++ {
+							if e.HeapData[i] != 0x3f3f {
+								v++
+							}
+						}
+						v += 0x4000
+					case 0x01: // peak aux
+						for i := 0; i < len(e.AuxData); i++ {
+							if e.AuxData[i] != 0x3f3f {
+								v++
+							}
+						}
+						v += 0x4000
+					case 0x02: // peak lts
+						for i := e.Ltb; i < len(e.RamData); i++ {
+							if e.RamData[i] != 0x3f3f {
+								v++
+							}
+						}
+						v += 0x4000
+					case 0x20: // div width
+						v = 0x4000 | io.MeasureDims(0)
+					case 0x21: // div height
+						v = 0x4000 | io.MeasureDims(1)
+					case 0x40: // interpreter supports undo
+						v = 1
+					case 0x41: // interpreter supports save/restore
+						v = 1
+					case 0x42: // interpreter supports links
+						if io.HaveLinks() {
+							v = 1
+						}
+					case 0x43: // interpreter supports quit
+						if e.HaveQuit {
+							v = 1
+						}
+					case 0x44: // interpreter supports styling
+						if io.HaveStyles() {
+							v = 1
+						}
+					case 0x45: // interpreter supports color
+						if io.HaveColor() {
+							v = 1
+						}
+					case 0x46: // interpreter supports text-align
+						if io.HaveAlign() {
+							v = 1
+						}
+					case 0x50: // currently transcripting
+						if io.ScriptActive() {
+							v = 1
+						}
+					case 0x60: // interpreter supports top status area
+						if e.HaveTop {
+							v = 1
+						}
+					case 0x61: // interpreter supports inline status area
+						if e.HaveInline {
+							v = 1
+						}
+					default:
+						if a1 < 0x40 {
+							v = 0x4000
+						}
+					}
+					d := int(e.Code[e.Inst])
+					e.Inst++
+					e.store(d, v)
+				case 0x78: // set_idx value
+					v := e.deref(e.fvalue())
+					if v >= 0xe000 {
+						v = int(e.HeapData[v&0x1fff])
+					}
+					e.Reg[0x3f] = uint16(v)
+				case 0x79, 0xf9: // check_eq word/vbyte code
+					a1 := 0
+					if op&0x80 != 0 {
+						a1 = int(e.Code[e.Inst])
+						e.Inst++
+					} else {
+						a1 = e.fword()
+					}
+					a2 := e.fcode()
+					if int(e.Reg[0x3f]) == a1 {
+						e.Inst = a2
+					}
+				case 0x7a, 0xfa: // check_gt_eq word/vbyte code code
+					a1 := 0
+					if op&0x80 != 0 {
+						a1 = int(e.Code[e.Inst])
+						e.Inst++
+					} else {
+						a1 = e.fword()
+					}
+					a2 := e.fcode()
+					a3 := e.fcode()
+					if int(e.Reg[0x3f]) > a1 {
+						e.Inst = a2
+					} else if int(e.Reg[0x3f]) == a1 {
+						e.Inst = a3
+					}
+				case 0x7b, 0xfb: // check_gt value/byte code
+					a1 := 0
+					if op&0x80 != 0 {
+						a1 = int(e.Code[e.Inst])
+						e.Inst++
+					} else {
+						a1 = e.fvalue()
+					}
+					a2 := e.fcode()
+					if int(e.Reg[0x3f]) > a1 {
+						e.Inst = a2
+					}
+				case 0x7c: // check_wordmap index code
+					a1 := e.findex()
+					a2 := e.fcode()
+					if e.wordMap(a1, int(e.Reg[0x3f])) {
+						e.Inst = a2
+					}
+				case 0x7d, 0xfd: // check_eq word/vbyte word/vbyte code
+					a1 := 0
+					if op&0x80 != 0 {
+						a1 = int(e.Code[e.Inst])
+						e.Inst++
+					} else {
+						a1 = e.fword()
+					}
+					a2 := 0
+					if op&0x80 != 0 {
+						a2 = int(e.Code[e.Inst])
+						e.Inst++
+					} else {
+						a2 = e.fword()
+					}
+					a3 := e.fcode()
+					if int(e.Reg[0x3f]) == a1 || int(e.Reg[0x3f]) == a2 {
+						e.Inst = a3
+					}
+				case 0x7f: // tracepoint string string string word
+					a1 := e.fstring()
+					a2s := e.fstring()
+					a3 := e.fstring()
+					a4 := e.fword()
+					if e.Trace {
+						str := e.DecodeStr(a1) + "("
+						a2str := e.DecodeStr(a2s)
+						j := 0
+						for i := 0; i < len(a2str); i++ {
+							if a2str[i] == '$' {
+								str += e.val2str(int(e.Reg[j]))
+								j++
+							} else {
+								str += string(a2str[i])
+							}
+						}
+						str += ") " + e.DecodeStr(a3) + ":" + fmt.Sprintf("%d", a4)
+						io.Trace(str)
+					}
+				default:
+					panic(fmt.Sprintf("Unimplemented op 0x%02x at 0x%06x", op, e.Inst-1))
+				}
+			}
+		}()
+	}
+
+	return result
+}
+
+// VMStart begins execution from the start of the code section
+func (e *Engine) VMStart() int {
+	return e.VMRun(0)
+}
+
+// VMProceedWithInput processes a line of user input
+func (e *Engine) VMProceedWithInput(str string) int {
+	var chars []int
+	for _, r := range str {
+		c := int(r)
+		if c >= 0x41 && c <= 0x5a {
+			chars = append(chars, c^0x20)
+		} else if c < 0x80 {
+			chars = append(chars, c)
+		} else {
+			found := 0x3f
+			for j := int(e.Lang[e.ExtChars]) - 1; j >= 0; j-- {
+				entry := e.ExtChars + 1 + j*5
+				if int(e.Lang[entry+2]) == (c>>16)&0xff &&
+					int(e.Lang[entry+3]) == (c>>8)&0xff &&
+					int(e.Lang[entry+4]) == c&0xff {
+					found = int(e.Lang[entry])
+					break
+				}
+			}
+			chars = append(chars, found)
+		}
+	}
+
+	var words [][]int
+	start := 0
+	for i := 0; i < len(chars); i++ {
+		if chars[i] == 32 {
+			if i != start {
+				words = append(words, chars[start:i])
+			}
+			start = i + 1
+		} else {
+			if containsByte(e.StopChars, chars[i]) {
+				if i != start {
+					words = append(words, chars[start:i])
+				}
+				words = append(words, chars[i:i+1])
+				start = i + 1
+			}
+		}
+	}
+	if len(chars) != start {
+		words = append(words, chars[start:])
+	}
+
+	v := 0x3f00
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				if x, ok := r.(int); ok && x == HeapFull {
+					if e.Spc < SPLine {
+						e.IO.Line()
+					}
+					e.VMClearDivs()
+					e.VMReset(x, false)
+					v = 0
+				} else {
+					panic(r)
+				}
+			}
+		}()
+		for i := len(words) - 1; i >= 0; i-- {
+			v = e.createPair(parseWord(words[i], e), v)
+		}
+	}()
+
+	e.Spc = SPLine
+	return e.VMRun(v)
+}
+
+// VMProceedWithKey processes a keypress
+func (e *Engine) VMProceedWithKey(code int) int {
+	v := 0
+	if code >= 0x20 && code < 0x7f {
+		if code >= 0x41 && code <= 0x5a {
+			code ^= 0x20
+		}
+		v = code
+	}
+	if v == 0 {
+		for _, k := range Keys {
+			if code == k {
+				v = code
+				break
+			}
+		}
+	}
+	if v == 0 {
+		for i := 0; i < int(e.Lang[e.ExtChars]); i++ {
+			entry := 1 + i*5
+			if code == (int(e.Lang[entry+2])<<16 |
+				int(e.Lang[entry+3])<<8 |
+				int(e.Lang[entry+4])) {
+				v = 0x80 | int(e.Lang[1+i*5])
+				break
+			}
+		}
+	}
+	if v == 0 {
+		return StatusGetKey
+	}
+	e.Spc = SPSpace
+	if v >= 0x30 && v <= 0x39 {
+		v += 0x4000 - 0x30
+	} else {
+		v |= 0x3e00
+	}
+	return e.VMRun(v)
+}
+
+// VMRestore restores from save data
+func (e *Engine) VMRestore(filedata []byte) int {
+	v := VMUnwrapSavefile(e, filedata)
+	if v != nil {
+		e.VMClearDivs()
+		e.VMReset(0, true)
+		e.VMRestoreState(VMRLDecState(e.InitState, v))
+	}
+	e.Spc = SPLine
+	return e.VMRun(0)
+}

--- a/src/go/vm.go
+++ b/src/go/vm.go
@@ -1,0 +1,756 @@
+package main
+
+import "fmt"
+
+// Operand decoders - these must be byte-exact matches with the JS engine
+
+// fvalue reads a value operand from the code stream
+func (e *Engine) fvalue() int {
+	v := int(e.Code[e.Inst])
+	e.Inst++
+	if v >= 0xc0 {
+		return int(e.HeapData[e.Env+4+(v&0x3f)])
+	} else if v >= 0x80 {
+		return int(e.Reg[v&0x3f])
+	} else {
+		r := (v << 8) | int(e.Code[e.Inst])
+		e.Inst++
+		return r
+	}
+}
+
+// findex reads an index operand from the code stream
+func (e *Engine) findex() int {
+	v := int(e.Code[e.Inst])
+	e.Inst++
+	if v >= 0xc0 {
+		r := ((v & 0x3f) << 8) | int(e.Code[e.Inst])
+		e.Inst++
+		return r
+	} else {
+		return v
+	}
+}
+
+// fcode reads a code address operand from the code stream
+// CRITICAL: bit 13 sign extension for 2-byte form
+func (e *Engine) fcode() int {
+	v := int(e.Code[e.Inst])
+	e.Inst++
+	if v == 0 {
+		return 0
+	} else if v < 0x40 {
+		return e.Inst + v
+	} else if v < 0x80 {
+		v = ((v & 0x3f) << 8) | int(e.Code[e.Inst])
+		e.Inst++
+		if v&0x2000 != 0 {
+			return e.Inst + v - 0x4000
+		} else {
+			return e.Inst + v
+		}
+	} else {
+		v = ((v & 0x7f) << 16) | (int(e.Code[e.Inst]) << 8)
+		e.Inst++
+		v |= int(e.Code[e.Inst])
+		e.Inst++
+		return v
+	}
+}
+
+// fstring reads a string address operand from the code stream
+func (e *Engine) fstring() int {
+	v := int(e.Code[e.Inst])
+	e.Inst++
+	if v >= 0xc0 {
+		v = ((v & 0x3f) << 16) | (int(e.Code[e.Inst]) << 8)
+		e.Inst++
+		v |= int(e.Code[e.Inst])
+		e.Inst++
+		return v << e.StrShift
+	} else if v >= 0x80 {
+		v = ((v & 0x3f) << 8) | int(e.Code[e.Inst])
+		e.Inst++
+		return v << e.StrShift
+	} else {
+		return v << 1
+	}
+}
+
+// fword reads a 16-bit word operand from the code stream
+func (e *Engine) fword() int {
+	v := int(e.Code[e.Inst])
+	e.Inst++
+	r := (v << 8) | int(e.Code[e.Inst])
+	e.Inst++
+	return r
+}
+
+// --- Core VM operations ---
+
+// deref follows unbound variable chains through the heap
+func (e *Engine) deref(v int) int {
+	for (v & 0xe000) == 0x8000 {
+		t := int(e.HeapData[v&0x1fff])
+		if t == 0 {
+			return v
+		}
+		v = t
+	}
+	return v
+}
+
+// fail sets inst to the choice point's next pointer
+func (e *Engine) fail() {
+	e.Inst = int(e.HeapData[e.Cho+4])<<16 | int(e.HeapData[e.Cho+5])
+}
+
+// unify attempts to make a and b equal, using trail for backtracking
+func (e *Engine) unify(a, b int) bool {
+	for {
+		a = e.deref(a)
+		b = e.deref(b)
+		if (a&0xe000) == 0x8000 && (b&0xe000) == 0x8000 {
+			if e.Trl <= e.Aux {
+				panic(AuxFull)
+			}
+			if a < b {
+				e.Trl--
+				e.AuxData[e.Trl] = uint16(b & 0x1fff)
+				e.HeapData[b&0x1fff] = uint16(a)
+			} else if a > b {
+				e.Trl--
+				e.AuxData[e.Trl] = uint16(a & 0x1fff)
+				e.HeapData[a&0x1fff] = uint16(b)
+			}
+			return true
+		} else if (a & 0xe000) == 0x8000 {
+			if e.Trl <= e.Aux {
+				panic(AuxFull)
+			}
+			e.Trl--
+			e.AuxData[e.Trl] = uint16(a & 0x1fff)
+			e.HeapData[a&0x1fff] = uint16(b)
+			return true
+		} else if (b & 0xe000) == 0x8000 {
+			if e.Trl <= e.Aux {
+				panic(AuxFull)
+			}
+			e.Trl--
+			e.AuxData[e.Trl] = uint16(b & 0x1fff)
+			e.HeapData[b&0x1fff] = uint16(a)
+			return true
+		} else if a >= 0xe000 && b >= 0xe000 {
+			a = int(e.HeapData[a&0x1fff])
+			b = int(e.HeapData[b&0x1fff])
+		} else if a >= 0xe000 {
+			a = int(e.HeapData[a&0x1fff])
+		} else if b >= 0xe000 {
+			b = int(e.HeapData[b&0x1fff])
+		} else if a == b {
+			return true
+		} else if a >= 0xc000 && b >= 0xc000 {
+			if !e.unify(a-0x4000, b-0x4000) {
+				return false
+			}
+			a = a - 0x3fff
+			b = b - 0x3fff
+		} else {
+			return false
+		}
+	}
+}
+
+// would_unify checks if a and b could unify without actually binding
+func (e *Engine) would_unify(a, b int) bool {
+	for {
+		a = e.deref(a)
+		b = e.deref(b)
+		if (a&0xe000) == 0x8000 || (b&0xe000) == 0x8000 {
+			return true
+		} else if a >= 0xe000 && b >= 0xe000 {
+			a = int(e.HeapData[a&0x1fff])
+			b = int(e.HeapData[b&0x1fff])
+		} else if a >= 0xe000 {
+			a = int(e.HeapData[a&0x1fff])
+		} else if b >= 0xe000 {
+			b = int(e.HeapData[b&0x1fff])
+		} else if a == b {
+			return true
+		} else if a >= 0xc000 && b >= 0xc000 {
+			if !e.would_unify(a-0x4000, b-0x4000) {
+				return false
+			}
+			a = a - 0x3fff
+			b = b - 0x3fff
+		} else {
+			return false
+		}
+	}
+}
+
+// destvalue reads a destination value (for make_pair)
+func (e *Engine) destvalue(dest int) int {
+	if dest&0x40 != 0 {
+		return int(e.HeapData[e.Env+4+(dest&0x3f)])
+	}
+	return int(e.Reg[dest&0x3f])
+}
+
+// store writes a value to a destination, using unify for bound destinations
+func (e *Engine) store(dest, src int) {
+	if dest >= 0xc0 {
+		if !e.unify(int(e.HeapData[e.Env+4+(dest&0x3f)]), src) {
+			e.fail()
+		}
+	} else if dest >= 0x80 {
+		if !e.unify(int(e.Reg[dest&0x3f]), src) {
+			e.fail()
+		}
+	} else if dest >= 0x40 {
+		e.HeapData[e.Env+4+(dest&0x3f)] = uint16(src)
+	} else {
+		e.Reg[dest] = uint16(src)
+	}
+}
+
+// push_cho creates a choice point
+func (e *Engine) pushCho(narg, next int) {
+	addr := e.Env
+	if e.Cho < e.Env {
+		addr = e.Cho
+	}
+	addr -= 9 + narg
+	if addr < e.Top {
+		panic(HeapFull)
+	}
+	e.HeapData[addr] = uint16(e.Env)
+	e.HeapData[addr+1] = uint16(e.Sim)
+	e.HeapData[addr+2] = uint16(e.Cont >> 16)
+	e.HeapData[addr+3] = uint16(e.Cont & 0xffff)
+	e.HeapData[addr+4] = uint16(next >> 16)
+	e.HeapData[addr+5] = uint16(next & 0xffff)
+	e.HeapData[addr+6] = uint16(e.Cho)
+	e.HeapData[addr+7] = uint16(e.Top)
+	e.HeapData[addr+8] = uint16(e.Trl)
+	for i := 0; i < narg; i++ {
+		e.HeapData[addr+9+i] = e.Reg[i]
+	}
+	e.Cho = addr
+}
+
+// push_aux pushes a value onto the auxiliary stack
+func (e *Engine) pushAux(v int) {
+	v = e.deref(v)
+	if v >= 0xe000 {
+		e.pushAux(int(e.HeapData[(v&0x1fff)+1]))
+		e.pushAux(int(e.HeapData[(v&0x1fff)+0]))
+		v = 0x8100
+	} else if v >= 0xc000 {
+		count := 0
+		for {
+			e.pushAux(v - 0x4000)
+			count++
+			v = e.deref(v - 0x3fff)
+			if v == 0x3f00 {
+				v = 0xc000 | count
+				break
+			} else if (v & 0xe000) != 0xc000 {
+				e.pushAux(v)
+				v = 0xe000 | count
+				break
+			}
+		}
+	} else if v >= 0x8000 {
+		v = 0x8000
+	}
+	if e.Aux >= e.Trl {
+		panic(AuxFull)
+	}
+	e.AuxData[e.Aux] = uint16(v)
+	e.Aux++
+}
+
+// pop_aux pops a value from the auxiliary stack
+func (e *Engine) popAux() int {
+	e.Aux--
+	v := int(e.AuxData[e.Aux])
+
+	if v == 0x8000 {
+		addr := e.Top
+		e.Top++
+		if e.Top > e.Env || e.Top > e.Cho {
+			panic(HeapFull)
+		}
+		e.HeapData[addr] = 0
+		v = 0x8000 | addr
+	} else if v == 0x8100 {
+		addr := e.Top
+		e.Top += 2
+		if e.Top > e.Env || e.Top > e.Cho {
+			panic(HeapFull)
+		}
+		e.HeapData[addr] = uint16(e.popAux())
+		e.HeapData[addr+1] = uint16(e.popAux())
+		v = 0xe000 | addr
+	} else if v >= 0xc000 {
+		count := v & 0x1fff
+		if v&0x2000 != 0 {
+			v = e.popAux()
+		} else {
+			v = 0x3f00
+		}
+		for count > 0 {
+			count--
+			addr := e.Top
+			e.Top += 2
+			if e.Top > e.Env || e.Top > e.Cho {
+				panic(HeapFull)
+			}
+			e.HeapData[addr] = uint16(e.popAux())
+			e.HeapData[addr+1] = uint16(v)
+			v = 0xc000 | addr
+		}
+	}
+	return v
+}
+
+// pop_aux_list pops a list from the auxiliary stack
+func (e *Engine) popAuxList() int {
+	list := 0x3f00
+	for {
+		v := e.popAux()
+		if v == 0 {
+			break
+		}
+		addr := e.Top
+		e.Top += 2
+		if e.Top > e.Env || e.Top > e.Cho {
+			panic(HeapFull)
+		}
+		e.HeapData[addr] = uint16(v)
+		e.HeapData[addr+1] = uint16(list)
+		list = 0xc000 | addr
+	}
+	return list
+}
+
+// fieldaddr returns the RAM address of a field for an object
+func (e *Engine) fieldaddr(field, obj int) int {
+	obj = e.deref(obj)
+	if obj > e.Nob {
+		panic(ExpectObj)
+	}
+	return int(e.RamData[obj]) + field
+}
+
+// readfield reads a field from an object
+func (e *Engine) readfield(field, obj int) int {
+	obj = e.deref(obj)
+	if obj > e.Nob {
+		return 0
+	}
+	return int(e.RamData[int(e.RamData[obj])+field])
+}
+
+// unlink removes an object from a linked list
+func (e *Engine) unlink(rootAddr, next, key int) {
+	if key == 0 || key >= 0x2000 {
+		return
+	}
+	tail := int(e.RamData[e.fieldaddr(next, key)])
+	addr := rootAddr
+	for e.RamData[addr] != 0 {
+		if int(e.RamData[addr]) == key {
+			e.RamData[addr] = uint16(tail)
+			return
+		}
+		addr = e.fieldaddr(next, int(e.RamData[addr]))
+	}
+}
+
+// --- LTS (Long-Term Storage) operations ---
+
+func (e *Engine) popLTS() int {
+	e.Tmp--
+	v := int(e.RamData[e.Tmp])
+
+	if v == 0x8100 {
+		addr := e.Top
+		e.Top += 2
+		if e.Top > e.Env || e.Top > e.Cho {
+			panic(HeapFull)
+		}
+		e.HeapData[addr] = uint16(e.popLTS())
+		e.HeapData[addr+1] = uint16(e.popLTS())
+		v = 0xe000 | addr
+	} else if v >= 0xc000 {
+		count := v & 0x1fff
+		if v&0x2000 != 0 {
+			v = e.popLTS()
+		} else {
+			v = 0x3f00
+		}
+		for count > 0 {
+			count--
+			addr := e.Top
+			e.Top += 2
+			if e.Top > e.Env || e.Top > e.Cho {
+				panic(HeapFull)
+			}
+			e.HeapData[addr] = uint16(e.popLTS())
+			e.HeapData[addr+1] = uint16(v)
+			v = 0xc000 | addr
+		}
+	}
+	return v
+}
+
+func (e *Engine) pushLTS(v int) {
+	v = e.deref(v)
+	if v >= 0xe000 {
+		e.pushLTS(int(e.HeapData[(v&0x1fff)+1]))
+		e.pushLTS(int(e.HeapData[(v&0x1fff)+0]))
+		v = 0x8100
+	} else if v >= 0xc000 {
+		count := 0
+		for {
+			e.pushLTS(v - 0x4000)
+			count++
+			v = e.deref(v - 0x3fff)
+			if v == 0x3f00 {
+				v = 0xc000 | count
+				break
+			} else if (v & 0xe000) != 0xc000 {
+				e.pushLTS(v)
+				v = 0xe000 | count
+				break
+			}
+		}
+	} else if v >= 0x8000 {
+		panic(ExpectBound)
+	}
+	if e.Tmp > len(e.RamData) {
+		panic(LTSFull)
+	}
+	e.RamData[e.Tmp] = uint16(v)
+	e.Tmp++
+}
+
+func (e *Engine) clearLTS(addr int) {
+	v := int(e.RamData[addr])
+	if v&0x8000 != 0 {
+		e.RamData[addr] = 0
+		v &= 0x7fff
+		size := int(e.RamData[v])
+		for i := v; i < e.Ltt-size; i++ {
+			e.RamData[i] = e.RamData[i+size]
+		}
+		e.Ltt -= size
+		for v < e.Ltt {
+			e.RamData[int(e.RamData[v+1])] -= uint16(size)
+			v += int(e.RamData[v])
+		}
+	}
+}
+
+func (e *Engine) getLTS(v int) int {
+	if v&0x8000 != 0 {
+		e.Tmp = v & 0x7fff
+		e.Tmp += int(e.RamData[e.Tmp])
+		return e.popLTS()
+	}
+	return v
+}
+
+func (e *Engine) putLTS(addr, v int) {
+	e.clearLTS(addr)
+	v = e.deref(v)
+	if v < 0x8000 {
+		e.RamData[addr] = uint16(v)
+	} else {
+		e.Tmp = e.Ltt + 2
+		if e.Tmp > len(e.RamData) {
+			panic(LTSFull)
+		}
+		e.pushLTS(v)
+		e.RamData[addr] = uint16(0x8000 | e.Ltt)
+		e.RamData[e.Ltt+0] = uint16(e.Tmp - e.Ltt)
+		e.RamData[e.Ltt+1] = uint16(addr)
+		e.Ltt = e.Tmp
+	}
+}
+
+// --- Pair operations ---
+
+func (e *Engine) createPair(head, tail int) int {
+	addr := e.Top
+	e.Top += 2
+	if e.Top > e.Env || e.Top > e.Cho {
+		panic(HeapFull)
+	}
+	e.HeapData[addr] = uint16(head)
+	e.HeapData[addr+1] = uint16(tail)
+	return addr | 0xc000
+}
+
+func (e *Engine) makePairSub(literal bool, arg, addr int) {
+	if literal {
+		e.HeapData[addr] = uint16(arg)
+	} else if arg&0x80 != 0 {
+		e.HeapData[addr] = uint16(e.destvalue(arg))
+	} else {
+		e.HeapData[addr] = 0
+		e.store(arg, 0x8000|addr)
+	}
+}
+
+func (e *Engine) makePair(a1val bool, a1, a2, a3 int) {
+	if a3&0x80 != 0 {
+		a3 = e.deref(e.destvalue(a3))
+		if (a3 & 0xe000) == 0xc000 {
+			if a1val {
+				if !e.unify(a1, a3-0x4000) {
+					e.fail()
+				}
+			} else {
+				e.store(a1, a3-0x4000)
+			}
+			e.store(a2, a3-0x3fff)
+		} else if (a3 & 0xe000) == 0x8000 {
+			addr := e.Top
+			e.Top += 2
+			if e.Top > e.Env || e.Top > e.Cho {
+				panic(HeapFull)
+			}
+			e.makePairSub(a1val, a1, addr)
+			e.makePairSub(false, a2, addr+1)
+			e.unify(a3, 0xc000|addr)
+		} else {
+			e.fail()
+		}
+	} else {
+		addr := e.Top
+		e.Top += 2
+		if e.Top > e.Env || e.Top > e.Cho {
+			panic(HeapFull)
+		}
+		e.makePairSub(a1val, a1, addr)
+		e.makePairSub(false, a2, addr+1)
+		e.store(a3, 0xc000|addr)
+	}
+}
+
+// --- Value-to-string conversion ---
+
+func (e *Engine) val2str(v int) string {
+	v = e.deref(v)
+	if v >= 0xe000 {
+		str := ""
+		for i := 0; i < 2; i++ {
+			x := int(e.HeapData[(v&0x1fff)+i])
+			if x >= 0x3f00 {
+				for x >= 0xc000 {
+					str += e.val2str(int(e.HeapData[x&0x1fff]))
+					x = int(e.HeapData[(x&0x1fff)+1])
+				}
+			} else {
+				str += e.val2str(x)
+			}
+		}
+		return str
+	} else if v >= 0xc000 {
+		needsp := false
+		e.Upper = false
+		str := "["
+		for (v & 0xe000) == 0xc000 {
+			if needsp {
+				str += " "
+			}
+			str += e.val2str(v - 0x4000)
+			needsp = true
+			v = e.deref(v - 0x3fff)
+		}
+		if v == 0x3f00 {
+			str += "]"
+		} else {
+			str += " | " + e.val2str(v) + "]"
+		}
+		return str
+	} else if v >= 0x8000 {
+		e.Upper = false
+		return "$"
+	} else if v >= 0x4000 {
+		e.Upper = false
+		return fmt.Sprintf("%d", v&0x3fff)
+	} else if v >= 0x3f00 {
+		e.Upper = false
+		return "[]"
+	} else if v >= 0x3e00 {
+		return e.DecodeChar(v & 0xff)
+	} else if v >= 0x2000 {
+		entry := 2 + (v&0x1fff)*3
+		l := int(e.Dict[entry])
+		addr := get16(e.Dict, entry+1)
+		str := ""
+		for i := 0; i < l; i++ {
+			str += e.DecodeChar(int(e.Dict[addr+i]))
+		}
+		return str
+	} else if v != 0 {
+		e.Upper = false
+		str := "#"
+		if e.Tags != nil {
+			addr := get16(e.Tags, v*2)
+			for {
+				ch := int(e.Tags[addr])
+				addr++
+				if ch == 0 {
+					break
+				}
+				str += e.DecodeChar(ch)
+			}
+		}
+		return str
+	}
+	return ""
+}
+
+// --- Random number generator ---
+
+func (e *Engine) compatRand() uint32 {
+	high := (e.RandomState >> 16) & 0xffff
+	low := e.RandomState & 0xffff
+	newhigh := ((0x15a * low) + (0x4e35 * high)) & 0xffff
+	e.RandomState = ((newhigh << 16) + (0x4e35 * low) + 1) & 0xffffffff
+	return (e.RandomState >> 16) & 0x7fff
+}
+
+// --- Word map lookup ---
+
+func (e *Engine) wordMap(mapnum, v int) bool {
+	mapOff := get16(e.Maps, 2+mapnum*2)
+	start := 0
+	end := get16(e.Maps, mapOff)
+	for start < end {
+		mid := (start + end) >> 1
+		midval := get16(e.Maps, mapOff+2+mid*4)
+		if midval == v {
+			ptr := get16(e.Maps, mapOff+4+mid*4)
+			if ptr == 0 {
+				return false
+			} else if ptr&0xe000 != 0 {
+				if e.Aux >= e.Trl {
+					panic(AuxFull)
+				}
+				e.AuxData[e.Aux] = uint16(ptr & 0x1fff)
+				e.Aux++
+				return true
+			} else {
+				for {
+					o := int(e.Maps[ptr])
+					ptr++
+					if o == 0 {
+						break
+					}
+					if o >= 0xe0 {
+						o = ((o & 0x1f) << 8) | int(e.Maps[ptr])
+						ptr++
+					}
+					if e.Aux >= e.Trl {
+						panic(AuxFull)
+					}
+					e.AuxData[e.Aux] = uint16(o)
+					e.Aux++
+				}
+				return true
+			}
+		} else if midval > v {
+			end = mid
+		} else {
+			start = mid + 1
+		}
+	}
+	return true
+}
+
+// --- PrependChars and WordsToCharlist ---
+
+func (e *Engine) prependChars(v, list int) int {
+	entry := 2 + (v&0x1fff)*3
+	l := int(e.Dict[entry])
+	addr := get16(e.Dict, entry+1)
+	for i := l - 1; i >= 0; i-- {
+		ch := int(e.Dict[addr+i])
+		if ch >= '0' && ch <= '9' {
+			ch += 0x4000 - '0'
+		} else {
+			ch |= 0x3e00
+		}
+		list = e.createPair(ch, list)
+	}
+	return list
+}
+
+func containsByte(slice []byte, val int) bool {
+	for _, b := range slice {
+		if int(b) == val {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *Engine) wordsToCharlist(list int) []int {
+	var buf []int
+	for {
+		v := e.deref(int(e.HeapData[(list&0x1fff)+0]))
+		if v >= 0xe000 {
+			part1 := int(e.HeapData[(v&0x1fff)+0])
+			if part1 >= 0x8000 {
+				sub := e.wordsToCharlist(part1)
+				if sub == nil {
+					return nil
+				}
+				buf = append(buf, sub...)
+			} else {
+				sub := e.wordsToCharlist(v)
+				if sub == nil {
+					return nil
+				}
+				buf = append(buf, sub...)
+			}
+		} else if v >= 0x4000 && v < 0x8000 {
+			str := fmt.Sprintf("%d", v&0x3fff)
+			for _, c := range str {
+				buf = append(buf, int(c))
+			}
+		} else if v >= 0x3e00 && v < 0x3f00 {
+			ch := v & 0xff
+			if ch <= 0x20 {
+				return nil
+			}
+			if containsByte(e.StopChars, ch) {
+				return nil
+			}
+			buf = append(buf, ch)
+		} else if v >= 0x2000 && v < 0x3e00 {
+			entry := 2 + (v&0x1fff)*3
+			l := int(e.Dict[entry])
+			addr := get16(e.Dict, entry+1)
+			for i := 0; i < l; i++ {
+				buf = append(buf, int(e.Dict[addr+i]))
+			}
+		} else {
+			return nil
+		}
+		list = e.deref(int(e.HeapData[(list&0x1fff)+1]))
+		if (list & 0xe000) != 0xc000 {
+			break
+		}
+	}
+	if list != 0x3f00 {
+		return nil
+	}
+	return buf
+}

--- a/src/go/vm_test.go
+++ b/src/go/vm_test.go
@@ -1,0 +1,328 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestFCodeSignExtension(t *testing.T) {
+	data := loadStory(t, "../../test/gosling/gosling.aastory")
+	io := NewMockIO()
+	e := NewEngine(data, io, 1234, true, false, false)
+
+	// fcode reads bytes from e.Code starting at e.Inst, advances e.Inst,
+	// and returns an absolute address. Let's verify the raw decode logic.
+
+	// Test 1: Zero returns 0, inst unchanged (only 1 byte consumed)
+	e.Code = []byte{0x00, 0xff, 0xff}
+	e.Inst = 0
+	result := e.fcode()
+	if result != 0 {
+		t.Errorf("fcode(0x00): got %d, want 0", result)
+	}
+	if e.Inst != 1 {
+		t.Errorf("fcode(0x00) inst: got %d, want 1", e.Inst)
+	}
+
+	// Test 2: Small positive offset (v < 0x40): result = inst + v
+	// inst starts at 0, v = 5, after reading 1 byte inst = 1, result = 1 + 5 = 6
+	e.Code = []byte{0x05, 0xff, 0xff}
+	e.Inst = 0
+	result = e.fcode()
+	if result != 6 {
+		t.Errorf("fcode(0x05): got %d, want 6", result)
+	}
+
+	// Test 3: 2-byte form, positive offset (bit 13 = 0)
+	// 0x40 0x01 => v = (0x00 << 8) | 0x01 = 1, inst = 2, result = 2 + 1 = 3
+	e.Code = []byte{0x40, 0x01, 0xff}
+	e.Inst = 0
+	result = e.fcode()
+	if result != 3 {
+		t.Errorf("fcode(0x40 0x01): got %d, want 3", result)
+	}
+
+	// Test 4: 2-byte form, sign-extended negative offset (bit 13 = 1)
+	// 0x60 0x00 => (0x20 << 8) | 0x00 = 0x2000, bit 13 set
+	// result = 2 + 0x2000 - 0x4000 = -8190
+	e.Code = []byte{0x60, 0x00, 0xff}
+	e.Inst = 0
+	result = e.fcode()
+	expected := 2 + 0x2000 - 0x4000
+	if result != expected {
+		t.Errorf("fcode(0x60 0x00): got %d, want %d", result, expected)
+	}
+
+	// Test 5: 2-byte form, max negative
+	// 0x7f 0xff => (0x3f << 8) | 0xff = 0x3fff, bit 13 set
+	// result = 2 + 0x3fff - 0x4000 = 1
+	e.Code = []byte{0x7f, 0xff, 0xff}
+	e.Inst = 0
+	result = e.fcode()
+	expected = 2 + 0x3fff - 0x4000
+	if result != expected {
+		t.Errorf("fcode(0x7f 0xff): got %d, want %d", result, expected)
+	}
+
+	// Test 6: 2-byte form, bit 13 just below
+	// 0x5f 0xff => (0x1f << 8) | 0xff = 0x1fff, bit 13 = 0
+	// result = 2 + 0x1fff = 8193
+	e.Code = []byte{0x5f, 0xff, 0xff}
+	e.Inst = 0
+	result = e.fcode()
+	expected = 2 + 0x1fff
+	if result != expected {
+		t.Errorf("fcode(0x5f 0xff): got %d, want %d", result, expected)
+	}
+
+	// Test 7: 3-byte form
+	// 0x80 0x00 0x01 => v = (0x00 << 16) | (0x00 << 8) | 0x01 = 1
+	e.Code = []byte{0x80, 0x00, 0x01}
+	e.Inst = 0
+	result = e.fcode()
+	if result != 1 {
+		t.Errorf("fcode(0x80 0x00 0x01): got %d, want 1", result)
+	}
+	if e.Inst != 3 {
+		t.Errorf("fcode 3-byte inst: got %d, want 3", e.Inst)
+	}
+}
+
+func TestFValue(t *testing.T) {
+	data := loadStory(t, "../../test/gosling/gosling.aastory")
+	io := NewMockIO()
+	e := NewEngine(data, io, 1234, true, false, false)
+
+	// Test register reference (v >= 0x80, v < 0xc0)
+	e.Code = []byte{0x85} // Register 5
+	e.Reg[5] = 0x1234
+	e.Inst = 0
+	result := e.fvalue()
+	if result != 0x1234 {
+		t.Errorf("fvalue reg 5: got 0x%x, want 0x1234", result)
+	}
+
+	// Test immediate 2-byte value (v < 0x80)
+	e.Code = []byte{0x42, 0x56} // (0x42 << 8) | 0x56 = 0x4256
+	e.Inst = 0
+	result = e.fvalue()
+	if result != 0x4256 {
+		t.Errorf("fvalue immediate: got 0x%x, want 0x4256", result)
+	}
+
+	// Test heap reference (v >= 0xc0)
+	// Create a fresh engine with larger heap for this test
+	e2 := &Engine{}
+	e2.HeapData = make([]uint16, 2000)
+	e2.Reg = [64]uint16{}
+	e2.Env = 1500 // point env somewhere with room
+	e2.Code = []byte{0xc3} // Heap env+4+3 = env+7
+	e2.Inst = 0
+	e2.HeapData[1500+4+3] = 0x5678
+	result = e2.fvalue()
+	if result != 0x5678 {
+		t.Errorf("fvalue heap: got 0x%x, want 0x5678", result)
+	}
+}
+
+func TestFWord(t *testing.T) {
+	data := loadStory(t, "../../test/gosling/gosling.aastory")
+	io := NewMockIO()
+	e := NewEngine(data, io, 1234, true, false, false)
+
+	e.Code = []byte{0xab, 0xcd}
+	e.Inst = 0
+	result := e.fword()
+	if result != 0xabcd {
+		t.Errorf("fword: got 0x%x, want 0xabcd", result)
+	}
+}
+
+func TestFIndex(t *testing.T) {
+	data := loadStory(t, "../../test/gosling/gosling.aastory")
+	io := NewMockIO()
+	e := NewEngine(data, io, 1234, true, false, false)
+
+	// Small index (v < 0xc0)
+	e.Code = []byte{0x42}
+	e.Inst = 0
+	result := e.findex()
+	if result != 0x42 {
+		t.Errorf("findex small: got 0x%x, want 0x42", result)
+	}
+
+	// Large index (v >= 0xc0): (0x00 << 8) | 0xab = 0xab
+	e.Code = []byte{0xc0, 0xab}
+	e.Inst = 0
+	result = e.findex()
+	if result != 0xab {
+		t.Errorf("findex large: got 0x%x, want 0xab", result)
+	}
+}
+
+func TestDeref(t *testing.T) {
+	data := loadStory(t, "../../test/gosling/gosling.aastory")
+	io := NewMockIO()
+	e := NewEngine(data, io, 1234, true, false, false)
+
+	// Unbound variable (heap[addr] = 0) returns itself
+	addr := e.Top
+	e.Top += 2
+	e.HeapData[addr] = 0
+	v := 0x8000 | addr
+	result := e.deref(v)
+	if result != v {
+		t.Errorf("deref unbound: got 0x%x, want 0x%x", result, v)
+	}
+
+	// Bound variable follows chain to value
+	addr2 := e.Top
+	e.Top += 2
+	e.HeapData[addr2] = 0x1234
+	v2 := 0x8000 | addr2
+	result = e.deref(v2)
+	if result != 0x1234 {
+		t.Errorf("deref bound: got 0x%x, want 0x1234", result)
+	}
+
+	// Non-variable returns itself
+	result = e.deref(0x4005)
+	if result != 0x4005 {
+		t.Errorf("deref non-var: got 0x%x, want 0x4005", result)
+	}
+}
+
+func TestUnify(t *testing.T) {
+	data := loadStory(t, "../../test/gosling/gosling.aastory")
+	io := NewMockIO()
+	e := NewEngine(data, io, 1234, true, false, false)
+
+	// Equal constants
+	if !e.unify(0x4005, 0x4005) {
+		t.Error("unify equal constants should succeed")
+	}
+
+	// Different constants
+	if e.unify(0x4005, 0x4006) {
+		t.Error("unify different constants should fail")
+	}
+
+	// Unbound variable with constant
+	addr := e.Top
+	e.Top += 2
+	e.HeapData[addr] = 0
+	v := 0x8000 | addr
+	if !e.unify(v, 0x4005) {
+		t.Error("unify unbound with constant should succeed")
+	}
+	if e.HeapData[addr] != 0x4005 {
+		t.Errorf("after unify, heap[addr] = 0x%x, want 0x4005", e.HeapData[addr])
+	}
+
+	// Two unbound variables
+	addr1 := e.Top
+	e.Top++
+	e.HeapData[addr1] = 0
+	v1 := 0x8000 | addr1
+	addr2 := e.Top
+	e.Top++
+	e.HeapData[addr2] = 0
+	v2 := 0x8000 | addr2
+	if !e.unify(v1, v2) {
+		t.Error("unify two unbound should succeed")
+	}
+	// Lower-addressed var points to higher-addressed
+	if addr1 < addr2 {
+		if e.HeapData[addr2] != uint16(v1) {
+			t.Errorf("heap[%d] = 0x%x, want 0x%x", addr2, e.HeapData[addr2], v1)
+		}
+	} else {
+		if e.HeapData[addr1] != uint16(v2) {
+			t.Errorf("heap[%d] = 0x%x, want 0x%x", addr1, e.HeapData[addr1], v2)
+		}
+	}
+}
+
+func TestCompatRand(t *testing.T) {
+	data := loadStory(t, "../../test/gosling/gosling.aastory")
+	io := NewMockIO()
+	e := NewEngine(data, io, 1234, true, false, false)
+
+	// Deterministic sequence
+	e.RandomState = 1234
+	r1 := e.compatRand()
+	r2 := e.compatRand()
+	r3 := e.compatRand()
+
+	t.Logf("CompatRand: %d, %d, %d", r1, r2, r3)
+
+	if r1 > 0x7fff || r2 > 0x7fff || r3 > 0x7fff {
+		t.Error("CompatRand out of range")
+	}
+
+	// Determinism
+	e.RandomState = 1234
+	r1b := e.compatRand()
+	r2b := e.compatRand()
+	r3b := e.compatRand()
+	if r1 != r1b || r2 != r2b || r3 != r3b {
+		t.Error("CompatRand not deterministic")
+	}
+}
+
+func TestCreatePair(t *testing.T) {
+	data := loadStory(t, "../../test/gosling/gosling.aastory")
+	io := NewMockIO()
+	e := NewEngine(data, io, 1234, true, false, false)
+
+	addr := e.createPair(0x4005, 0x3f00)
+	if addr&0xe000 != 0xc000 {
+		t.Errorf("createPair tag: got 0x%x, want 0xc000 tag", addr)
+	}
+	if e.HeapData[addr&0x1fff] != 0x4005 {
+		t.Errorf("createPair head: got 0x%x, want 0x4005", e.HeapData[addr&0x1fff])
+	}
+	if e.HeapData[(addr&0x1fff)+1] != 0x3f00 {
+		t.Errorf("createPair tail: got 0x%x, want 0x3f00", e.HeapData[(addr&0x1fff)+1])
+	}
+}
+
+func TestStore(t *testing.T) {
+	data := loadStory(t, "../../test/gosling/gosling.aastory")
+	io := NewMockIO()
+	e := NewEngine(data, io, 1234, true, false, false)
+
+	// Store to register (dest < 0x40)
+	e.store(5, 0x1234)
+	if e.Reg[5] != 0x1234 {
+		t.Errorf("store reg: got 0x%x, want 0x1234", e.Reg[5])
+	}
+
+	// Store to unbound variable (dest >= 0x80) via unify
+	vaddr := e.Top
+	e.Top++
+	e.HeapData[vaddr] = 0
+	e.Reg[10] = uint16(0x8000 | vaddr)
+	e.store(0x8a, 0x5678)
+	derefResult := e.deref(int(e.Reg[10]))
+	if derefResult != 0x5678 {
+		t.Errorf("store unify reg: got 0x%x, want 0x5678", derefResult)
+	}
+}
+
+func TestFieldAddr(t *testing.T) {
+	data := loadStory(t, "../../test/gosling/gosling.aastory")
+	io := NewMockIO()
+	e := NewEngine(data, io, 1234, true, false, false)
+
+	// Object 1 should have its RAM address set during init
+	if e.Nob < 1 {
+		t.Skip("No objects in this story")
+	}
+
+	addr := e.fieldaddr(0, 1) // parent field of object 1
+	t.Logf("fieldaddr(0, 1) = %d (RAM base = %d)", addr, e.RamData[1])
+
+	if addr < 0 || addr >= len(e.RamData) {
+		t.Errorf("fieldaddr out of range: %d", addr)
+	}
+}

--- a/src/lua/engine.lua
+++ b/src/lua/engine.lua
@@ -1,0 +1,2968 @@
+-- Å-machine virtual machine engine, ported from src/js/engine.js to LuaJIT.
+--
+-- Original JavaScript engine: Copyright 2019-2022 Linus Åkesson.
+-- See license.txt for the BSD 2-clause terms that also cover this port.
+--
+-- The port follows the JavaScript source closely. Arrays are 0-based Lua
+-- tables carrying an explicit `length` field, matching the original index
+-- arithmetic and opcode encodings so no offsets need adjusting.
+
+local bit = require("bit")
+local band, bor, bxor, bnot = bit.band, bit.bor, bit.bxor, bit.bnot
+local lshift, rshift, arshift = bit.lshift, bit.rshift, bit.arshift
+
+-- Error codes
+local HEAPFULL = 0x4001
+local AUXFULL = 0x4002
+local EXPECTOBJ = 0x4003
+local EXPECTBOUND = 0x4004
+local LTSFULL = 0x4006
+local IOSTATE = 0x4007
+
+-- Opcode names
+local opcodes = {
+	[0x00]='nop', [0x01]='fail', [0x02]='cont-set', [0x03]='proceed', [0x04]='jmp',
+	[0x05]='jmp-multi', [0x85]='jmpl-multi', [0x06]='jmpl-simple', [0x86]='jmpl-simple',
+	[0x07]='jmp-tail', [0x87]='tail', [0x08]='env-push', [0x88]='env-push/0',
+	[0x09]='env-pop', [0x89]='env-pop-proceed', [0x0a]='choice-push', [0x8a]='choice-push/0',
+	[0x0b]='choice-pop', [0x8b]='choice-pop/0', [0x0c]='choice-pop-push', [0x8c]='choice-pop-push/0',
+	[0x0d]='choice-cut', [0x0e]='cho-get', [0x0f]='cho-set', [0x10]='assign', [0x90]='assign/vbyte',
+	[0x11]='make-var', [0x12]='make-pair/dest', [0x13]='make-pair/word', [0x93]='make-pair/vbyte',
+	[0x14]='aux-val-push', [0x94]='aux-raw-push/0', [0x15]='aux-raw-push/word', [0x95]='aux-raw-push/vbyte',
+	[0x16]='aux-val-pop', [0x17]='aux-list-pop', [0x18]='aux-list-chk-pop', [0x19]='aux-list-match-pop',
+	[0x1b]='list-split', [0x1c]='stop', [0x1d]='stop-push', [0x1e]='stop-pop', [0x1f]='word-split',
+	[0x9f]='words-join', [0x20]='load-word', [0xa0]='load-word/0', [0x21]='load-byte', [0xa1]='load-byte/0',
+	[0x22]='load-val', [0xa2]='load-val/0', [0x24]='store-word', [0xa4]='store-word/0',
+	[0x25]='store-byte', [0xa5]='store-byte/0', [0x26]='store-val', [0xa6]='store-val/0',
+	[0x28]='flag-set', [0xa8]='flag-set/0', [0x29]='flag-reset', [0xa9]='flag-reset/0',
+	[0x2d]='unlink', [0xad]='unlink/0', [0x2e]='parent-set', [0xae]='parent-set/vbyte',
+	[0x2f]='parent-set/vbyte2', [0xaf]='parent-set/vbyte-both', [0x30]='raw-eq?/word', [0xb0]='raw-eq?/0',
+	[0x31]='bound?', [0x32]='empty?', [0x33]='num?', [0x34]='pair?', [0x35]='obj?', [0x36]='word?',
+	[0xb6]='uword?', [0x37]='unify?', [0x38]='gt?', [0x39]='eq?/word', [0xb9]='eq?/vbyte',
+	[0x3a]='mem-eq?', [0xba]='mem-eq?/0', [0x3b]='flag?', [0xbb]='flag?/0', [0x3c]='cwl?',
+	[0x3d]='mem-eq?', [0xbd]='mem-eq?', [0x40]='not-raw-eq?/word', [0xc0]='not-raw-eq?/0',
+	[0x41]='not-bound?', [0x42]='not-empty?', [0x43]='not-num?', [0x44]='not-pair?', [0x45]='not-obj?',
+	[0x46]='not-uword?', [0x47]='not-unify?', [0x48]='not-gt?', [0x49]='not-eq?/word', [0xc9]='not-eq?/vbyte',
+	[0x4a]='not-mem-eq?', [0xca]='not-mem-eq?/0', [0x4b]='not-flag?', [0xcb]='not-flag?/0', [0x4c]='not-cwl?',
+	[0x4d]='not-mem-eq?', [0xcd]='not-mem-eq?/0', [0x50]='raw-add', [0xd0]='raw-inc', [0x51]='raw-sub',
+	[0xd1]='raw-dec', [0x52]='raw-rand', [0x58]='num-add', [0xd8]='num-inc', [0x59]='num-sub',
+	[0xd9]='num-dec', [0x5a]='num-rand', [0x5b]='num-mul', [0x5c]='num-div', [0x5d]='num-mod',
+	[0x60]='print-a-str-a', [0xe0]='print-n-str-a', [0x61]='print-a-str-n', [0xe1]='print-n-str-n',
+	[0x62]='no-space', [0xe2]='space', [0x63]='line', [0xe3]='par', [0x64]='space-n', [0x65]='print-val',
+	[0x66]='enter-div', [0xe6]='leave-div', [0x67]='set-body/old-enter-status', [0xe7]='old-leave-status',
+	[0x68]='enter-link-res', [0xe8]='leave-link-res', [0x69]='enter-link', [0xe9]='leave-link',
+	[0x6a]='enter-self-link', [0xea]='leave-self-link', [0x6b]='set-style', [0xeb]='reset-style',
+	[0x6c]='embed-res', [0xec]='res-embeddable?', [0x6d]='progress', [0x6e]='enter-span', [0xee]='leave-span',
+	[0x6f]='enter-status', [0xef]='leave-status', [0x70]='ext-0', [0x72]='save', [0xf2]='save-undo',
+	[0x73]='get-input', [0xf3]='get-key', [0x74]='vm-info', [0x78]='idx-set', [0x79]='check-eq?',
+	[0xf9]='check-eq?/vbyte', [0x7a]='check-gt-eq?', [0xfa]='check-gt-eq?/vbyte', [0x7b]='check-gt?',
+	[0xfb]='check-gt?/byte', [0x7c]='check-wordmap?', [0x7d]='check-compare?', [0xfd]='check-compare?/vbyte',
+	[0x7f]='tracepoint'
+}
+
+-- vm_proceed_with_key parameters
+local keys = {
+	KEY_BACKSPACE = 8,
+	KEY_RETURN = 13,
+	KEY_UP = 16,
+	KEY_DOWN = 17,
+	KEY_LEFT = 18,
+	KEY_RIGHT = 19
+}
+
+local status = {
+	quit = 0,
+	get_input = 1,
+	get_key = 2,
+	restore = 3
+}
+
+-- Array and byte helpers
+local function newbytes(n)
+	local a = {length = n}
+	for i = 0, n - 1 do a[i] = 0 end
+	return a
+end
+
+local function slice_bytes(a, from, to)
+	local r = {length = to - from}
+	for i = 0, (to - from) - 1 do r[i] = a[from + i] end
+	return r
+end
+
+local function bytes_set(dst, src, offset)
+	for i = 0, src.length - 1 do dst[offset + i] = src[i] end
+	return dst
+end
+
+local function bytes_includes(a, x)
+	for i = 0, a.length - 1 do
+		if a[i] == x then return true end
+	end
+	return false
+end
+
+local function arr_push(a, v)
+	a[a.length] = v
+	a.length = a.length + 1
+end
+
+local function arr_pop(a)
+	a.length = a.length - 1
+	local v = a[a.length]
+	a[a.length] = nil
+	return v
+end
+
+local function concat_arr(a, b)
+	if type(b) == "table" then
+		for i = 0, b.length - 1 do
+			a[a.length] = b[i]
+			a.length = a.length + 1
+		end
+	else
+		a[a.length] = b
+		a.length = a.length + 1
+	end
+	return a
+end
+
+local function getfour(a, o)
+	return string.char(a[o], a[o + 1], a[o + 2], a[o + 3])
+end
+
+local function get32(a, o)
+	return bor(lshift(a[o], 24), lshift(a[o + 1], 16), lshift(a[o + 2], 8), a[o + 3])
+end
+
+local function get16(a, o)
+	return bor(lshift(a[o], 8), a[o + 1])
+end
+
+local function putfour(a, o, str)
+	for i = 0, 3 do a[o + i] = string.byte(str, i + 1) end
+end
+
+local function put32(a, o, value)
+	a[o] = band(rshift(value, 24), 0xff)
+	a[o + 1] = band(rshift(value, 16), 0xff)
+	a[o + 2] = band(rshift(value, 8), 0xff)
+	a[o + 3] = band(value, 0xff)
+	return o + 4
+end
+
+local function put16(a, o, value)
+	a[o] = band(rshift(value, 8), 0xff)
+	a[o + 1] = band(value, 0xff)
+	return o + 2
+end
+
+local function findchunk(filedata, name)
+	local size = get32(filedata, 4) + 8
+	local pos = 12
+	while pos < size do
+		local chname = getfour(filedata, pos)
+		local chsize = get32(filedata, pos + 4)
+		if chname == name then
+			return slice_bytes(filedata, pos + 8, pos + 8 + chsize)
+		end
+		pos = pos + 8 + band(chsize + 1, bnot(1))
+	end
+	return nil
+end
+
+-- UTF-8 helpers
+local function fromCharCode(code)
+	code = band(code, 0xffff)
+	if code < 0x80 then
+		return string.char(code)
+	elseif code < 0x800 then
+		return string.char(0xc0 + rshift(code, 6), 0x80 + band(code, 0x3f))
+	else
+		return string.char(0xe0 + rshift(code, 12), 0x80 + band(rshift(code, 6), 0x3f), 0x80 + band(code, 0x3f))
+	end
+end
+
+local function utf8_codepoints(s)
+	local cps = {length = 0}
+	local i = 1
+	local len = #s
+	while i <= len do
+		local c = string.byte(s, i)
+		local cp, adv
+		if c < 0x80 then
+			cp = c; adv = 1
+		elseif c < 0xe0 then
+			cp = bor(lshift(band(c, 0x1f), 6), band(string.byte(s, i + 1) or 0, 0x3f)); adv = 2
+		elseif c < 0xf0 then
+			cp = bor(lshift(band(c, 0x0f), 12), lshift(band(string.byte(s, i + 1) or 0, 0x3f), 6), band(string.byte(s, i + 2) or 0, 0x3f)); adv = 3
+		else
+			cp = bor(lshift(band(c, 0x07), 18), lshift(band(string.byte(s, i + 1) or 0, 0x3f), 12), lshift(band(string.byte(s, i + 2) or 0, 0x3f), 6), band(string.byte(s, i + 3) or 0, 0x3f)); adv = 4
+		end
+		cps[cps.length] = cp
+		cps.length = cps.length + 1
+		i = i + adv
+	end
+	return cps
+end
+
+-- Character and string decoding
+local function decodechar(e, aach)
+	if e.upper then
+		if aach >= 0x61 and aach <= 0x7a then
+			aach = bxor(aach, 0x20)
+		elseif aach >= 0x80 then
+			aach = e.lang[e.extchars + 1 + band(aach, 0x7f) * 5 + 1]
+		end
+		e.upper = false
+	end
+	if aach < 0x80 then
+		return fromCharCode(aach)
+	else
+		aach = band(aach, 0x7f)
+		if aach >= e.lang[e.extchars] then
+			e.upper = false
+			return "??"
+		else
+			local entry = e.extchars + 1 + aach * 5
+			local uchar = bor(lshift(e.lang[entry + 2], 16), lshift(e.lang[entry + 3], 8), e.lang[entry + 4])
+			return fromCharCode(uchar)
+		end
+	end
+end
+
+local function decodestr(e, addr)
+	local decoder = get16(e.lang, 0)
+	local state, code, bits, nbit = 0, 0, 0, 0
+	local out = {}
+	while true do
+		if nbit == 0 then bits = e.writ[addr]; addr = addr + 1; nbit = 8 end
+		code = e.lang[decoder + lshift(state, 1) + (band(bits, 0x80) ~= 0 and 1 or 0)]
+		bits = lshift(bits, 1)
+		nbit = nbit - 1
+		if code >= 0x81 then
+			state = band(code, 0x7f)
+		elseif code == 0x80 then
+			break
+		elseif code == 0x5f then
+			code = 0
+			for _ = 1, e.esc_bits do
+				if nbit == 0 then bits = e.writ[addr]; addr = addr + 1; nbit = 8 end
+				code = lshift(code, 1)
+				if band(bits, 0x80) ~= 0 then code = bor(code, 1) end
+				bits = lshift(bits, 1)
+				nbit = nbit - 1
+			end
+			if e.head[0] == 0 and e.head[1] < 4 then
+				out[#out + 1] = decodechar(e, 0x80 + code)
+			elseif code < e.esc_boundary then
+				out[#out + 1] = decodechar(e, 0xa0 + code)
+			else
+				out[#out + 1] = " "
+				local entry = 2 + (code - e.esc_boundary) * 3
+				local len = e.dict[entry]
+				local charaddr = bor(lshift(e.dict[entry + 1], 8), e.dict[entry + 2])
+				for i = 0, len - 1 do
+					out[#out + 1] = decodechar(e, e.dict[charaddr + i])
+				end
+			end
+			state = 0
+		else
+			out[#out + 1] = decodechar(e, code + 0x20)
+			state = 0
+		end
+	end
+	return table.concat(out)
+end
+
+-- VM state lifecycle
+local function vm_reinit(e)
+	e.nob = get16(e.init, 0)
+	e.ltb = get16(e.init, 2)
+	e.ltt = get16(e.init, 4)
+	for i = 0, e.heapdata.length - 1 do e.heapdata[i] = 0x3f3f end
+	for i = 0, e.auxdata.length - 1 do e.auxdata[i] = 0x3f3f end
+	for i = rshift(e.init.length - 6, 1), e.ramdata.length - 1 do e.ramdata[i] = 0x3f3f end
+	local i = 6
+	while i < e.init.length do
+		e.ramdata[rshift(i - 6, 1)] = get16(e.init, i)
+		i = i + 2
+	end
+end
+
+local function vm_reset(e, arg0, clear_undo)
+	e.reg[0] = arg0
+	for i = 1, 63 do e.reg[i] = 0 end
+	e.inst = 1
+	e.cont = 0
+	e.top = 0
+	e.env = e.heapdata.length
+	e.cho = e.heapdata.length
+	e.sim = 0xffff
+	e.aux = 0
+	e.trl = e.auxdata.length
+	e.sta = 0
+	e.stc = 0
+	e.cwl = 0
+	e.spc = e.SP_LINE
+	e.divs = {length = 0}
+	e.upper = false
+	e.in_status = false
+	if clear_undo then
+		e.undodata = {}
+		e.pruned_undo = false
+	end
+	if e.randomseed and e.randomseed ~= 0 then
+		e.randomstate = e.randomseed
+	else
+		e.randomstate = (os.time() * 1000) % 4294967296
+	end
+end
+
+local function vm_capture_state(e, new_inst)
+	local nword = 3 + e.ramdata.length + e.auxdata.length + e.heapdata.length
+	local data = newbytes(nword * 2)
+	local regs = newbytes(128 + 26 + 2 + e.divs.length * 2)
+	local j = 0
+
+	j = put16(data, j, e.nob)
+	j = put16(data, j, e.ltb)
+	j = put16(data, j, e.ltt)
+	for i = 0, e.ramdata.length - 1 do
+		j = put16(data, j, (i < e.ltt) and e.ramdata[i] or 0x3f3f)
+	end
+	for i = 0, e.auxdata.length - 1 do
+		j = put16(data, j, (i < e.aux or i >= e.trl) and e.auxdata[i] or 0x3f3f)
+	end
+	for i = 0, e.heapdata.length - 1 do
+		j = put16(data, j, (i < e.top or i >= e.env or i >= e.cho) and e.heapdata[i] or 0x3f3f)
+	end
+
+	j = 0
+	for i = 0, 63 do j = put16(regs, j, e.reg[i]) end
+	j = put32(regs, j, new_inst)
+	j = put32(regs, j, e.cont)
+	j = put16(regs, j, e.top)
+	j = put16(regs, j, e.env)
+	j = put16(regs, j, e.cho)
+	j = put16(regs, j, e.sim)
+	j = put16(regs, j, e.aux)
+	j = put16(regs, j, e.trl)
+	j = put16(regs, j, e.sta)
+	j = put16(regs, j, e.stc)
+	regs[j] = band(e.cwl, 0xff); j = j + 1
+	regs[j] = band(e.spc, 0xff); j = j + 1
+	j = put16(regs, j, e.divs.length)
+	for i = 0, e.divs.length - 1 do j = put16(regs, j, e.divs[i]) end
+
+	return {data = data, regs = regs}
+end
+
+local function vm_clear_divs(e)
+	e.io.leave_all()
+	e.in_status = false
+	e.n_span = 0
+	e.n_link = 0
+	e.divs = {length = 0}
+end
+
+local function vm_restore_state(e, state)
+	local data, regs = state.data, state.regs
+	local j = 0
+
+	e.nob = get16(data, j); j = j + 2
+	e.ltb = get16(data, j); j = j + 2
+	e.ltt = get16(data, j); j = j + 2
+	for i = 0, e.ramdata.length - 1 do e.ramdata[i] = get16(data, j); j = j + 2 end
+	for i = 0, e.auxdata.length - 1 do e.auxdata[i] = get16(data, j); j = j + 2 end
+	for i = 0, e.heapdata.length - 1 do e.heapdata[i] = get16(data, j); j = j + 2 end
+
+	j = 0
+	for i = 0, 63 do e.reg[i] = get16(regs, j); j = j + 2 end
+	e.inst = get32(regs, j); j = j + 4
+	e.cont = get32(regs, j); j = j + 4
+	e.top = get16(regs, j); j = j + 2
+	e.env = get16(regs, j); j = j + 2
+	e.cho = get16(regs, j); j = j + 2
+	e.sim = get16(regs, j); j = j + 2
+	e.aux = get16(regs, j); j = j + 2
+	e.trl = get16(regs, j); j = j + 2
+	e.sta = get16(regs, j); j = j + 2
+	e.stc = get16(regs, j); j = j + 2
+	e.cwl = regs[j]; j = j + 1
+	e.spc = regs[j]; j = j + 1
+	local ndiv = get16(regs, j); j = j + 2
+	e.divs = {length = 0}
+	for i = 0, ndiv - 1 do
+		e.divs[i] = get16(regs, j); j = j + 2
+		e.divs.length = i + 1
+		e.io.enter_div(e.divs[i])
+	end
+end
+
+local function xat(ref, st, idx)
+	local a = ref[idx]; if a == nil then a = 0 end
+	local b = st[idx]; if b == nil then b = 0 end
+	return bxor(a, b)
+end
+
+local function vm_rlenc_state(reference, state)
+	local bytes, nz = 0, 0
+
+	for i = 0, reference.data.length - 1 do
+		if bxor(reference.data[i], state.data[i]) ~= 0 then
+			bytes = bytes + 1; nz = 0
+		else
+			if nz ~= 0 and nz < 0x100 then
+				nz = nz + 1
+			else
+				bytes = bytes + 2; nz = 1
+			end
+		end
+	end
+
+	local encoded = newbytes(bytes)
+	local j = 0
+	local i = 0
+	while i < reference.data.length do
+		local diff = bxor(reference.data[i], state.data[i])
+		if diff ~= 0 then
+			encoded[j] = diff; j = j + 1
+		else
+			encoded[j] = 0; j = j + 1
+			nz = 1
+			while nz < 0x100 and xat(reference.data, state.data, i + nz) == 0 do
+				nz = nz + 1
+			end
+			encoded[j] = nz - 1; j = j + 1
+			i = i + nz - 1
+		end
+		i = i + 1
+	end
+
+	return {rledata = encoded, regs = state.regs}
+end
+
+local function vm_rldec_state(reference, encoded)
+	local array = newbytes(reference.data.length)
+	local j = 0
+	local i = 0
+	while i < encoded.rledata.length do
+		local diff = encoded.rledata[i]
+		if diff ~= 0 then
+			array[j] = bxor(reference.data[j] or 0, diff); j = j + 1
+		else
+			i = i + 1
+			local nz = encoded.rledata[i] + 1
+			while nz > 0 do
+				nz = nz - 1
+				array[j] = reference.data[j] or 0; j = j + 1
+			end
+		end
+		i = i + 1
+	end
+
+	return {data = array, regs = encoded.regs}
+end
+
+local function vm_wrap_savefile(e, encoded)
+	local function makechunk(tag, array)
+		local size = band(array.length + 1, bnot(1))
+		local result = newbytes(8 + size)
+		putfour(result, 0, tag)
+		put32(result, 4, array.length)
+		bytes_set(result, array, 8)
+		return result
+	end
+
+	local head = makechunk("HEAD", e.head)
+	local data = makechunk("DATA", encoded.rledata)
+	local regs = makechunk("REGS", encoded.regs)
+	local size = 4 + head.length + data.length + regs.length
+	local result = newbytes(8 + size)
+
+	putfour(result, 0, "FORM")
+	put32(result, 4, size)
+	putfour(result, 8, "AASV")
+	bytes_set(result, head, 12)
+	bytes_set(result, data, 12 + head.length)
+	bytes_set(result, regs, 12 + head.length + data.length)
+
+	return result
+end
+
+local function vm_unwrap_savefile(e, filedata)
+	if getfour(filedata, 0) ~= "FORM" or getfour(filedata, 8) ~= "AASV" then
+		e.io.print("Not an aasave file!")
+		e.io.line()
+		return nil
+	end
+	local head = findchunk(filedata, "HEAD")
+	local data = findchunk(filedata, "DATA")
+	local regs = findchunk(filedata, "REGS")
+	if not head or not data or not regs then
+		e.io.print("Incomplete aasave file!")
+		e.io.line()
+		return nil
+	end
+	local i = 0
+	while i < head.length and i < e.head.length do
+		if head[i] ~= e.head[i] then break end
+		i = i + 1
+	end
+	if i ~= head.length or i ~= e.head.length then
+		e.io.print("This savefile is from another story (or another version of the present story).")
+		e.io.line()
+		return nil
+	end
+	return {rledata = data, regs = regs}
+end
+
+-- Resources
+local function combine_arrays(oldarr, newval)
+	if oldarr == true then
+		return newval
+	elseif type(oldarr) == "table" then
+		oldarr[oldarr.length] = newval
+		oldarr.length = oldarr.length + 1
+		return oldarr
+	else
+		return {length = 2, [0] = oldarr, [1] = newval}
+	end
+end
+
+local function split_opts(opts)
+	local t = {}
+	for token in (opts .. ","):gmatch("([^,]*),") do
+		local trimmed = token:gsub("^%s+", ""):gsub("%s+$", "")
+		if trimmed ~= "" then t[#t + 1] = trimmed end
+	end
+	return t
+end
+
+local function get_res(e, id)
+	local obj = {url = "", alt = "", options = {}}
+	local opts = ""
+	if e.urls then
+		local n = get16(e.urls, 0)
+		if id < n then
+			local offs = get16(e.urls, 2 + id * 2)
+			obj.alt = decodestr(e, lshift(bor(lshift(e.urls[offs], 16), lshift(e.urls[offs + 1], 8), e.urls[offs + 2]), e.strshift))
+			local i = 3
+			while e.urls[offs + i] ~= 0 do
+				obj.url = obj.url .. string.char(e.urls[offs + i])
+				i = i + 1
+			end
+			i = i + 1
+			while e.urls[offs + i] ~= 0 do
+				opts = opts .. string.char(e.urls[offs + i])
+				i = i + 1
+			end
+		end
+	end
+	for _, opt in ipairs(split_opts(opts)) do
+		local k, v = opt:match("^(.-)%s*:%s*(.*)$")
+		if k then
+			if obj.options[k] ~= nil then
+				v = combine_arrays(obj.options[k], v)
+			end
+			obj.options[k] = v
+		else
+			if obj.options[opt] == nil then
+				obj.options[opt] = true
+			end
+		end
+	end
+	return obj
+end
+
+local function get_resources(e)
+	local ress = {length = 0}
+	if not e.urls then return ress end
+	local n = get16(e.urls, 0)
+	for i = 0, n - 1 do
+		ress[ress.length] = get_res(e, i)
+		ress.length = ress.length + 1
+	end
+	return ress
+end
+
+-- Styles and metadata
+local function get_styles(e)
+	local styles = {length = 0}
+	local n = get16(e.look, 0)
+	for i = 0, n - 1 do
+		local offs = get16(e.look, 2 + i * 2)
+		local map = {}
+		while e.look[offs] ~= 0 do
+			local chars = {}
+			while true do
+				local c = e.look[offs]; offs = offs + 1
+				if c == 0 then break end
+				chars[#chars + 1] = string.char(c)
+			end
+			local str = table.concat(chars)
+			local ci = str:find(":", 1, true)
+			if ci and ci > 1 then
+				local key = str:sub(1, ci - 1)
+				local p = ci + 1
+				while str:sub(p, p) == " " do p = p + 1 end
+				map[key] = str:sub(p)
+			end
+		end
+		styles[styles.length] = map
+		styles.length = styles.length + 1
+	end
+	return styles
+end
+
+local function get_metadata(e)
+	local result = {title = "Untitled story", release = get16(e.head, 4)}
+	local keynames = {"title", "author", "noun", "blurb", "date", "compiler"}
+	if e.meta then
+		local offs = 1
+		for _ = 0, e.meta[0] - 1 do
+			local key = e.meta[offs]; offs = offs + 1
+			local val = {}
+			while true do
+				local ch = e.meta[offs]; offs = offs + 1
+				if ch == 0 then break end
+				val[#val + 1] = decodechar(e, ch)
+			end
+			if key >= 1 and key <= #keynames then
+				result[keynames[key]] = table.concat(val)
+			end
+		end
+	end
+	return result
+end
+
+-- VM core helpers
+local function create_pair(e, head, tail)
+	local addr = e.top
+	e.top = e.top + 2
+	if e.top > e.env or e.top > e.cho then error(HEAPFULL, 0) end
+	e.heapdata[addr + 0] = head
+	e.heapdata[addr + 1] = tail
+	return bor(addr, 0xc000)
+end
+
+local function deref(e, v)
+	while band(v, 0xe000) == 0x8000 do
+		local t = e.heapdata[band(v, 0x1fff)]
+		if t == 0 then return v end
+		v = t
+	end
+	return v
+end
+
+local function fail(e)
+	e.inst = bor(lshift(e.heapdata[e.cho + 4], 16), e.heapdata[e.cho + 5])
+end
+
+local function unify(e, a, b)
+	while true do
+		a = deref(e, a)
+		b = deref(e, b)
+		if band(a, 0xe000) == 0x8000 and band(b, 0xe000) == 0x8000 then
+			if e.trl <= e.aux then error(AUXFULL, 0) end
+			if a < b then
+				e.trl = e.trl - 1
+				e.auxdata[e.trl] = band(b, 0x1fff)
+				e.heapdata[band(b, 0x1fff)] = a
+			elseif a > b then
+				e.trl = e.trl - 1
+				e.auxdata[e.trl] = band(a, 0x1fff)
+				e.heapdata[band(a, 0x1fff)] = b
+			end
+			return true
+		elseif band(a, 0xe000) == 0x8000 then
+			if e.trl <= e.aux then error(AUXFULL, 0) end
+			e.trl = e.trl - 1
+			e.auxdata[e.trl] = band(a, 0x1fff)
+			e.heapdata[band(a, 0x1fff)] = b
+			return true
+		elseif band(b, 0xe000) == 0x8000 then
+			if e.trl <= e.aux then error(AUXFULL, 0) end
+			e.trl = e.trl - 1
+			e.auxdata[e.trl] = band(b, 0x1fff)
+			e.heapdata[band(b, 0x1fff)] = a
+			return true
+		elseif a >= 0xe000 and b >= 0xe000 then
+			a = e.heapdata[band(a, 0x1fff)]
+			b = e.heapdata[band(b, 0x1fff)]
+		elseif a >= 0xe000 then
+			a = e.heapdata[band(a, 0x1fff)]
+		elseif b >= 0xe000 then
+			b = e.heapdata[band(b, 0x1fff)]
+		elseif a == b then
+			return true
+		elseif a >= 0xc000 and b >= 0xc000 then
+			if not unify(e, a - 0x4000, b - 0x4000) then return false end
+			a = a - 0x3fff
+			b = b - 0x3fff
+		else
+			return false
+		end
+	end
+end
+
+local function would_unify(e, a, b)
+	while true do
+		a = deref(e, a)
+		b = deref(e, b)
+		if band(a, 0xe000) == 0x8000 or band(b, 0xe000) == 0x8000 then
+			return true
+		elseif a >= 0xe000 and b >= 0xe000 then
+			a = e.heapdata[band(a, 0x1fff)]
+			b = e.heapdata[band(b, 0x1fff)]
+		elseif a >= 0xe000 then
+			a = e.heapdata[band(a, 0x1fff)]
+		elseif b >= 0xe000 then
+			b = e.heapdata[band(b, 0x1fff)]
+		elseif a == b then
+			return true
+		elseif a >= 0xc000 and b >= 0xc000 then
+			if not would_unify(e, a - 0x4000, b - 0x4000) then return false end
+			a = a - 0x3fff
+			b = b - 0x3fff
+		else
+			return false
+		end
+	end
+end
+
+local function destvalue(e, dest)
+	if band(dest, 0x40) ~= 0 then
+		return e.heapdata[e.env + 4 + band(dest, 0x3f)]
+	else
+		return e.reg[band(dest, 0x3f)]
+	end
+end
+
+local function store(e, dest, src)
+	if dest >= 0xc0 then
+		if not unify(e, e.heapdata[e.env + 4 + band(dest, 0x3f)], src) then fail(e) end
+	elseif dest >= 0x80 then
+		if not unify(e, e.reg[band(dest, 0x3f)], src) then fail(e) end
+	elseif dest >= 0x40 then
+		e.heapdata[e.env + 4 + band(dest, 0x3f)] = band(src, 0xffff)
+	else
+		e.reg[dest] = band(src, 0xffff)
+	end
+end
+
+local function push_cho(e, narg, nextv)
+	local addr = (e.env < e.cho and e.env or e.cho) - 9 - narg
+	if addr < e.top then error(HEAPFULL, 0) end
+	e.heapdata[addr + 0] = e.env
+	e.heapdata[addr + 1] = e.sim
+	e.heapdata[addr + 2] = rshift(e.cont, 16)
+	e.heapdata[addr + 3] = band(e.cont, 0xffff)
+	e.heapdata[addr + 4] = rshift(nextv, 16)
+	e.heapdata[addr + 5] = band(nextv, 0xffff)
+	e.heapdata[addr + 6] = e.cho
+	e.heapdata[addr + 7] = e.top
+	e.heapdata[addr + 8] = e.trl
+	for i = 0, narg - 1 do
+		e.heapdata[addr + 9 + i] = e.reg[i]
+	end
+	e.cho = addr
+end
+
+local function push_aux(e, v)
+	v = deref(e, v)
+	if v >= 0xe000 then
+		push_aux(e, e.heapdata[band(v, 0x1fff) + 1])
+		push_aux(e, e.heapdata[band(v, 0x1fff) + 0])
+		v = 0x8100
+	elseif v >= 0xc000 then
+		local count = 0
+		while true do
+			push_aux(e, v - 0x4000)
+			count = count + 1
+			v = deref(e, v - 0x3fff)
+			if v == 0x3f00 then
+				v = bor(0xc000, count); break
+			elseif band(v, 0xe000) ~= 0xc000 then
+				push_aux(e, v)
+				v = bor(0xe000, count); break
+			end
+		end
+	elseif v >= 0x8000 then
+		v = 0x8000
+	end
+	if e.aux >= e.trl then error(AUXFULL, 0) end
+	e.auxdata[e.aux] = v
+	e.aux = e.aux + 1
+end
+
+local function pop_aux(e)
+	e.aux = e.aux - 1
+	local v = e.auxdata[e.aux]
+	local addr, count
+	if v == 0x8000 then
+		addr = e.top; e.top = e.top + 1
+		if e.top > e.env or e.top > e.cho then error(HEAPFULL, 0) end
+		e.heapdata[addr] = 0
+		v = bor(0x8000, addr)
+	elseif v == 0x8100 then
+		addr = e.top; e.top = e.top + 2
+		if e.top > e.env or e.top > e.cho then error(HEAPFULL, 0) end
+		e.heapdata[addr + 0] = pop_aux(e)
+		e.heapdata[addr + 1] = pop_aux(e)
+		v = bor(0xe000, addr)
+	elseif v >= 0xc000 then
+		count = band(v, 0x1fff)
+		if band(v, 0x2000) ~= 0 then v = pop_aux(e) else v = 0x3f00 end
+		while count > 0 do
+			count = count - 1
+			addr = e.top; e.top = e.top + 2
+			if e.top > e.env or e.top > e.cho then error(HEAPFULL, 0) end
+			e.heapdata[addr + 0] = pop_aux(e)
+			e.heapdata[addr + 1] = v
+			v = bor(0xc000, addr)
+		end
+	end
+	return v
+end
+
+local function pop_aux_list(e)
+	local list = 0x3f00
+	while true do
+		local v = pop_aux(e)
+		if v == 0 then break end
+		local addr = e.top; e.top = e.top + 2
+		if e.top > e.env or e.top > e.cho then error(HEAPFULL, 0) end
+		e.heapdata[addr + 0] = v
+		e.heapdata[addr + 1] = list
+		list = bor(0xc000, addr)
+	end
+	return list
+end
+
+local function fieldaddr(e, field, obj)
+	obj = deref(e, obj)
+	if obj > e.nob then
+		error(EXPECTOBJ, 0)
+	else
+		return e.ramdata[obj] + field
+	end
+end
+
+local function readfield(e, field, obj)
+	obj = deref(e, obj)
+	if obj > e.nob then
+		return 0
+	else
+		return e.ramdata[e.ramdata[obj] + field]
+	end
+end
+
+local function unlink(e, root_addr, nextv, key)
+	if key == 0 or key >= 0x2000 then return end
+	local tail = e.ramdata[fieldaddr(e, nextv, key)]
+	local addr = root_addr
+	while e.ramdata[addr] ~= 0 do
+		if e.ramdata[addr] == key then
+			e.ramdata[addr] = tail
+			return
+		end
+		addr = fieldaddr(e, nextv, e.ramdata[addr])
+	end
+end
+
+local function pop_lts(e)
+	e.tmp = e.tmp - 1
+	local v = e.ramdata[e.tmp]
+	local addr, count
+	if v == 0x8100 then
+		addr = e.top; e.top = e.top + 2
+		if e.top > e.env or e.top > e.cho then error(HEAPFULL, 0) end
+		e.heapdata[addr + 0] = pop_lts(e)
+		e.heapdata[addr + 1] = pop_lts(e)
+		v = bor(0xe000, addr)
+	elseif v >= 0xc000 then
+		count = band(v, 0x1fff)
+		if band(v, 0x2000) ~= 0 then v = pop_lts(e) else v = 0x3f00 end
+		while count > 0 do
+			count = count - 1
+			addr = e.top; e.top = e.top + 2
+			if e.top > e.env or e.top > e.cho then error(HEAPFULL, 0) end
+			e.heapdata[addr + 0] = pop_lts(e)
+			e.heapdata[addr + 1] = v
+			v = bor(0xc000, addr)
+		end
+	end
+	return v
+end
+
+local function push_lts(e, v)
+	v = deref(e, v)
+	if v >= 0xe000 then
+		push_lts(e, e.heapdata[band(v, 0x1fff) + 1])
+		push_lts(e, e.heapdata[band(v, 0x1fff) + 0])
+		v = 0x8100
+	elseif v >= 0xc000 then
+		local count = 0
+		while true do
+			push_lts(e, v - 0x4000)
+			count = count + 1
+			v = deref(e, v - 0x3fff)
+			if v == 0x3f00 then
+				v = bor(0xc000, count); break
+			elseif band(v, 0xe000) ~= 0xc000 then
+				push_lts(e, v)
+				v = bor(0xe000, count); break
+			end
+		end
+	elseif v >= 0x8000 then
+		error(EXPECTBOUND, 0)
+	end
+	if e.tmp > e.ramdata.length then error(LTSFULL, 0) end
+	e.ramdata[e.tmp] = v
+	e.tmp = e.tmp + 1
+end
+
+local function clear_lts(e, addr)
+	local v = e.ramdata[addr]
+	if band(v, 0x8000) ~= 0 then
+		e.ramdata[addr] = 0
+		v = band(v, 0x7fff)
+		local size = e.ramdata[v]
+		for i = v, e.ltt - size - 1 do
+			e.ramdata[i] = e.ramdata[i + size]
+		end
+		e.ltt = e.ltt - size
+		while v < e.ltt do
+			e.ramdata[e.ramdata[v + 1]] = e.ramdata[e.ramdata[v + 1]] - size
+			v = v + e.ramdata[v]
+		end
+	end
+end
+
+local function get_lts(e, v)
+	if band(v, 0x8000) ~= 0 then
+		e.tmp = band(v, 0x7fff)
+		e.tmp = e.tmp + e.ramdata[e.tmp]
+		return pop_lts(e)
+	else
+		return v
+	end
+end
+
+local function put_lts(e, addr, v)
+	clear_lts(e, addr)
+	v = deref(e, v)
+	if v < 0x8000 then
+		e.ramdata[addr] = v
+	else
+		e.tmp = e.ltt + 2
+		if e.tmp > e.ramdata.length then error(LTSFULL, 0) end
+		push_lts(e, v)
+		e.ramdata[addr] = bor(0x8000, e.ltt)
+		e.ramdata[e.ltt + 0] = e.tmp - e.ltt
+		e.ramdata[e.ltt + 1] = addr
+		e.ltt = e.tmp
+	end
+end
+
+local function val2str(e, v)
+	v = deref(e, v)
+	local str
+	if v >= 0xe000 then
+		str = ""
+		for i = 0, 1 do
+			local x = e.heapdata[band(v, 0x1fff) + i]
+			if x >= 0x3f00 then
+				while x >= 0xc000 do
+					str = str .. val2str(e, e.heapdata[band(x, 0x1fff)])
+					x = e.heapdata[band(x, 0x1fff) + 1]
+				end
+			else
+				str = str .. val2str(e, x)
+			end
+		end
+	elseif v >= 0xc000 then
+		local needsp = false
+		e.upper = false
+		str = "["
+		while band(v, 0xe000) == 0xc000 do
+			if needsp then str = str .. " " end
+			str = str .. val2str(e, v - 0x4000)
+			needsp = true
+			v = deref(e, v - 0x3fff)
+		end
+		if v == 0x3f00 then
+			str = str .. "]"
+		else
+			str = str .. " | " .. val2str(e, v) .. "]"
+		end
+	elseif v >= 0x8000 then
+		e.upper = false
+		str = "$"
+	elseif v >= 0x4000 then
+		e.upper = false
+		str = tostring(band(v, 0x3fff))
+	elseif v >= 0x3f00 then
+		e.upper = false
+		str = "[]"
+	elseif v >= 0x3e00 then
+		str = decodechar(e, band(v, 0xff))
+	elseif v >= 0x2000 then
+		local entry = 2 + band(v, 0x1fff) * 3
+		local len = e.dict[entry]
+		local addr = bor(lshift(e.dict[entry + 1], 8), e.dict[entry + 2])
+		str = ""
+		for i = 0, len - 1 do
+			str = str .. decodechar(e, e.dict[addr + i])
+		end
+	elseif v ~= 0 then
+		e.upper = false
+		str = "#"
+		if e.tags then
+			local addr = get16(e.tags, v * 2)
+			while true do
+				local c = e.tags[addr]; addr = addr + 1
+				if c == 0 then break end
+				str = str .. decodechar(e, c)
+			end
+		end
+	else
+		str = ""
+	end
+	return str
+end
+
+local function wordmap(e, mapnum, v)
+	local map = get16(e.maps, 2 + mapnum * 2)
+	local start = 0
+	local endd = get16(e.maps, map)
+	while start < endd do
+		local mid = rshift(start + endd, 1)
+		local midval = get16(e.maps, map + 2 + mid * 4)
+		if midval == v then
+			local ptr = get16(e.maps, map + 4 + mid * 4)
+			if ptr == 0 then
+				return false
+			elseif band(ptr, 0xe000) ~= 0 then
+				if e.aux >= e.trl then error(AUXFULL, 0) end
+				e.auxdata[e.aux] = band(ptr, 0x1fff)
+				e.aux = e.aux + 1
+				return true
+			else
+				while true do
+					local o = e.maps[ptr]; ptr = ptr + 1
+					if o == 0 then break end
+					if e.aux >= e.trl then error(AUXFULL, 0) end
+					if o >= 0xe0 then
+						o = bor(lshift(band(o, 0x1f), 8), e.maps[ptr]); ptr = ptr + 1
+					end
+					e.auxdata[e.aux] = o
+					e.aux = e.aux + 1
+				end
+				return true
+			end
+		elseif midval > v then
+			endd = mid
+		else
+			start = mid + 1
+		end
+	end
+	return true
+end
+
+local function compat_rand(e)
+	local rs = e.randomstate
+	local high = math.floor(rs / 65536) % 65536
+	local low = rs % 65536
+	local newhigh = (0x15a * low + 0x4e35 * high) % 65536
+	rs = (newhigh * 65536 + 0x4e35 * low + 1) % 4294967296
+	e.randomstate = rs
+	return math.floor(rs / 65536) % 32768
+end
+
+local function makepairsub(e, literal, arg, addr)
+	if literal then
+		e.heapdata[addr] = arg
+	elseif band(arg, 0x80) ~= 0 then
+		e.heapdata[addr] = destvalue(e, arg)
+	else
+		e.heapdata[addr] = 0
+		store(e, arg, bor(0x8000, addr))
+	end
+end
+
+local function makepair(e, a1val, a1, a2, a3)
+	local addr
+	if band(a3, 0x80) ~= 0 then
+		a3 = deref(e, destvalue(e, a3))
+		if band(a3, 0xe000) == 0xc000 then
+			if a1val then
+				if not unify(e, a1, a3 - 0x4000) then fail(e) end
+			else
+				store(e, a1, a3 - 0x4000)
+			end
+			store(e, a2, a3 - 0x3fff)
+		elseif band(a3, 0xe000) == 0x8000 then
+			addr = e.top; e.top = e.top + 2
+			if e.top > e.env or e.top > e.cho then error(HEAPFULL, 0) end
+			makepairsub(e, a1val, a1, addr)
+			makepairsub(e, false, a2, addr + 1)
+			unify(e, a3, bor(0xc000, addr))
+		else
+			fail(e)
+		end
+	else
+		addr = e.top; e.top = e.top + 2
+		if e.top > e.env or e.top > e.cho then error(HEAPFULL, 0) end
+		makepairsub(e, a1val, a1, addr)
+		makepairsub(e, false, a2, addr + 1)
+		store(e, a3, bor(0xc000, addr))
+	end
+end
+
+local function prepend_chars(e, v, list)
+	local entry = 2 + band(v, 0x1fff) * 3
+	local len = e.dict[entry]
+	local addr = bor(lshift(e.dict[entry + 1], 8), e.dict[entry + 2])
+	for i = len - 1, 0, -1 do
+		local ch = e.dict[addr + i]
+		if ch >= 0x30 and ch <= 0x39 then
+			ch = ch + 0x4000 - 0x30
+		else
+			ch = bor(ch, 0x3e00)
+		end
+		list = create_pair(e, ch, list)
+	end
+	return list
+end
+
+local function words_to_charlist(e, list)
+	local buf = {length = 0}
+	repeat
+		local v = deref(e, e.heapdata[band(list, 0x1fff) + 0])
+		if v >= 0xe000 then
+			local part1 = e.heapdata[band(v, 0x1fff) + 0]
+			if part1 >= 0x8000 then
+				buf = concat_arr(buf, words_to_charlist(e, part1))
+			else
+				buf = concat_arr(buf, words_to_charlist(e, v))
+			end
+		elseif v >= 0x4000 and v < 0x8000 then
+			local s = tostring(band(v, 0x3fff))
+			for i = 1, #s do arr_push(buf, string.byte(s, i)) end
+		elseif v >= 0x3e00 and v < 0x3f00 then
+			local ch = band(v, 0xff)
+			if ch <= 0x20 then return 0 end
+			if bytes_includes(e.stopchars, ch) then return 0 end
+			arr_push(buf, ch)
+		elseif v >= 0x2000 and v < 0x3e00 then
+			local entry = 2 + band(v, 0x1fff) * 3
+			local len = e.dict[entry]
+			local addr = bor(lshift(e.dict[entry + 1], 8), e.dict[entry + 2])
+			for i = 0, len - 1 do arr_push(buf, e.dict[addr + i]) end
+		else
+			return 0
+		end
+		list = deref(e, e.heapdata[band(list, 0x1fff) + 1])
+	until band(list, 0xe000) ~= 0xc000
+	if list ~= 0x3f00 then return 0 end
+	return buf
+end
+
+-- Bytecode value fetchers
+local function fvalue(e)
+	local v = e.code[e.inst]; e.inst = e.inst + 1
+	if v >= 0xc0 then
+		return e.heapdata[e.env + 4 + band(v, 0x3f)]
+	elseif v >= 0x80 then
+		return e.reg[band(v, 0x3f)]
+	else
+		local lo = e.code[e.inst]; e.inst = e.inst + 1
+		return bor(lshift(v, 8), lo)
+	end
+end
+
+local function findex(e)
+	local v = e.code[e.inst]; e.inst = e.inst + 1
+	if v >= 0xc0 then
+		local lo = e.code[e.inst]; e.inst = e.inst + 1
+		return bor(lshift(band(v, 0x3f), 8), lo)
+	else
+		return v
+	end
+end
+
+local function fcode(e)
+	local v = e.code[e.inst]; e.inst = e.inst + 1
+	if v == 0 then
+		return 0
+	elseif v < 0x40 then
+		return e.inst + v
+	elseif v < 0x80 then
+		v = bor(lshift(band(v, 0x3f), 8), e.code[e.inst]); e.inst = e.inst + 1
+		if band(v, 0x2000) ~= 0 then
+			return e.inst + v - 0x4000
+		else
+			return e.inst + v
+		end
+	else
+		v = bor(lshift(band(v, 0x7f), 16), lshift(e.code[e.inst], 8)); e.inst = e.inst + 1
+		local r = bor(v, e.code[e.inst]); e.inst = e.inst + 1
+		return r
+	end
+end
+
+local function fstring(e)
+	local v = e.code[e.inst]; e.inst = e.inst + 1
+	if v >= 0xc0 then
+		v = bor(lshift(band(v, 0x3f), 16), lshift(e.code[e.inst], 8)); e.inst = e.inst + 1
+		v = bor(v, e.code[e.inst]); e.inst = e.inst + 1
+		return lshift(v, e.strshift)
+	elseif v >= 0x80 then
+		v = bor(lshift(band(v, 0x3f), 8), e.code[e.inst]); e.inst = e.inst + 1
+		return lshift(v, e.strshift)
+	else
+		return lshift(v, 1)
+	end
+end
+
+local function fword(e)
+	local v = e.code[e.inst]; e.inst = e.inst + 1
+	local lo = e.code[e.inst]; e.inst = e.inst + 1
+	return bor(lshift(v, 8), lo)
+end
+
+local function nextbyte(e)
+	local b = e.code[e.inst]; e.inst = e.inst + 1
+	return b
+end
+
+-- Word parsing
+local function parse_word(e, chars)
+	local len = chars.length
+	local enddecoder = get16(e.lang, 4)
+	local rev_ending = {length = 0}
+
+	local function buildlist(list)
+		local v = 0x3f00
+		for i = 0, list.length - 1 do
+			local ch = list[i]
+			if ch >= 0x30 and ch <= 0x39 then
+				v = create_pair(e, ch + 0x4000 - 0x30, v)
+			else
+				v = create_pair(e, bor(0x3e00, ch), v)
+			end
+		end
+		return v
+	end
+
+	local function finddict()
+		local start = 0
+		local endd = get16(e.dict, 0)
+		local diff = 0
+		while start < endd do
+			local mid = rshift(start + endd, 1)
+			local dictlen = e.dict[2 + 3 * mid]
+			local dictoffs = get16(e.dict, 2 + 3 * mid + 1)
+			local i = 0
+			diff = 0
+			while i < len and i < dictlen do
+				diff = chars[i] - e.dict[dictoffs + i]
+				if diff ~= 0 then break end
+				i = i + 1
+			end
+			if i == dictlen and i == len then
+				if diff == 0 then return bor(0x2000, mid) end
+			elseif i == dictlen then
+				diff = 1
+			elseif i == len then
+				diff = -1
+			end
+			if diff < 0 then endd = mid else start = mid + 1 end
+		end
+		return 0
+	end
+
+	local v
+	if len > 1 then
+		v = finddict()
+		if v ~= 0 then return v end
+	end
+
+	v = 0
+	do
+		local i = 0
+		while i < chars.length do
+			if chars[i] < 0x30 or chars[i] > 0x39 then break end
+			v = v * 10 + chars[i] - 0x30
+			if v >= 16384 then break end
+			i = i + 1
+		end
+		if i == chars.length then
+			return bor(0x4000, v)
+		end
+	end
+
+	if len == 1 then
+		return bor(0x3e00, chars[0])
+	end
+
+	local state = 0
+	while true do
+		local instr = e.lang[enddecoder + state]; state = state + 1
+		if instr == 0 then
+			while len > 0 do len = len - 1; arr_push(rev_ending, chars[len]) end
+			return bor(create_pair(e, buildlist(rev_ending), 0x3f00), 0xe000)
+		elseif instr == 1 then
+			v = finddict()
+			if v ~= 0 then
+				return bor(create_pair(e, v, buildlist(rev_ending)), 0xe000)
+			end
+		else
+			local nxt = e.lang[enddecoder + state]; state = state + 1
+			if len > 2 and instr == chars[len - 1] then
+				arr_push(rev_ending, instr)
+				len = len - 1
+				state = nxt
+			end
+		end
+	end
+end
+
+-- Opcode handlers
+local ophandlers = {}
+
+ophandlers[0x00] = function(e, op) end
+
+ophandlers[0x01] = function(e, op)
+	fail(e)
+end
+
+ophandlers[0x02] = function(e, op)
+	e.cont = fcode(e)
+end
+
+ophandlers[0x03] = function(e, op)
+	if e.sim < 0x8000 then e.cho = e.sim end
+	e.inst = e.cont
+end
+
+ophandlers[0x04] = function(e, op)
+	e.inst = fcode(e)
+end
+
+ophandlers[0x05] = function(e, op)
+	e.sim = 0xffff
+	e.inst = fcode(e)
+end
+
+ophandlers[0x85] = function(e, op)
+	local a1 = fcode(e)
+	e.cont = e.inst
+	e.sim = 0xffff
+	e.inst = a1
+end
+
+ophandlers[0x06] = function(e, op)
+	e.sim = e.cho
+	e.inst = fcode(e)
+end
+
+ophandlers[0x86] = function(e, op)
+	local a1 = fcode(e)
+	e.cont = e.inst
+	e.sim = e.cho
+	e.inst = a1
+end
+
+ophandlers[0x07] = function(e, op)
+	if e.sim >= 0x8000 then e.sim = e.cho end
+	e.inst = fcode(e)
+end
+
+ophandlers[0x87] = function(e, op)
+	if e.sim >= 0x8000 then e.sim = e.cho end
+end
+
+ophandlers[0x08] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and 0 or nextbyte(e)
+	local addr = (e.env < e.cho and e.env or e.cho) - 4 - a1
+	if addr < e.top then error(HEAPFULL, 0) end
+	e.heapdata[addr + 0] = e.env
+	e.heapdata[addr + 1] = e.sim
+	e.heapdata[addr + 2] = rshift(e.cont, 16)
+	e.heapdata[addr + 3] = band(e.cont, 0xffff)
+	e.env = addr
+end
+ophandlers[0x88] = ophandlers[0x08]
+
+ophandlers[0x09] = function(e, op)
+	e.cont = bor(lshift(e.heapdata[e.env + 2], 16), e.heapdata[e.env + 3])
+	e.sim = e.heapdata[e.env + 1]
+	e.env = e.heapdata[e.env + 0]
+end
+
+ophandlers[0x89] = function(e, op)
+	e.inst = bor(lshift(e.heapdata[e.env + 2], 16), e.heapdata[e.env + 3])
+	if e.heapdata[e.env + 1] < 0x8000 then e.cho = e.heapdata[e.env + 1] end
+	e.env = e.heapdata[e.env + 0]
+end
+
+ophandlers[0x0a] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and 0 or nextbyte(e)
+	push_cho(e, a1, fcode(e))
+end
+ophandlers[0x8a] = ophandlers[0x0a]
+
+ophandlers[0x0b] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and 0 or nextbyte(e)
+	for i = 0, a1 - 1 do
+		e.reg[i] = e.heapdata[e.cho + 9 + i]
+	end
+	while e.trl < e.heapdata[e.cho + 8] do
+		e.heapdata[e.auxdata[e.trl]] = 0
+		e.trl = e.trl + 1
+	end
+	e.top = e.heapdata[e.cho + 7]
+	e.cont = bor(lshift(e.heapdata[e.cho + 2], 16), e.heapdata[e.cho + 3])
+	e.sim = e.heapdata[e.cho + 1]
+	e.env = e.heapdata[e.cho + 0]
+	e.cho = e.heapdata[e.cho + 6]
+end
+ophandlers[0x8b] = ophandlers[0x0b]
+
+ophandlers[0x0c] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and 0 or nextbyte(e)
+	local a2 = fcode(e)
+	e.heapdata[e.cho + 4] = rshift(a2, 16)
+	e.heapdata[e.cho + 5] = band(a2, 0xffff)
+	for i = 0, a1 - 1 do
+		e.reg[i] = e.heapdata[e.cho + 9 + i]
+	end
+	while e.trl < e.heapdata[e.cho + 8] do
+		e.heapdata[e.auxdata[e.trl]] = 0
+		e.trl = e.trl + 1
+	end
+	e.top = e.heapdata[e.cho + 7]
+	e.cont = bor(lshift(e.heapdata[e.cho + 2], 16), e.heapdata[e.cho + 3])
+	e.sim = e.heapdata[e.cho + 1]
+	e.env = e.heapdata[e.cho + 0]
+end
+ophandlers[0x8c] = ophandlers[0x0c]
+
+ophandlers[0x0d] = function(e, op)
+	e.cho = e.heapdata[e.cho + 6]
+end
+
+ophandlers[0x0e] = function(e, op)
+	store(e, nextbyte(e), e.cho)
+end
+
+ophandlers[0x0f] = function(e, op)
+	e.cho = fvalue(e)
+end
+
+ophandlers[0x10] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and nextbyte(e) or fvalue(e)
+	local a2 = nextbyte(e)
+	store(e, a2, a1)
+end
+ophandlers[0x90] = ophandlers[0x10]
+
+ophandlers[0x11] = function(e, op)
+	local addr = e.top; e.top = e.top + 1
+	if e.top > e.env or e.top > e.cho then error(HEAPFULL, 0) end
+	e.heapdata[addr] = 0
+	store(e, nextbyte(e), bor(0x8000, addr))
+end
+
+ophandlers[0x12] = function(e, op)
+	local a1 = nextbyte(e)
+	local a2 = nextbyte(e)
+	local a3 = nextbyte(e)
+	makepair(e, false, a1, a2, a3)
+end
+
+ophandlers[0x13] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and nextbyte(e) or fword(e)
+	local a2 = nextbyte(e)
+	local a3 = nextbyte(e)
+	makepair(e, true, a1, a2, a3)
+end
+ophandlers[0x93] = ophandlers[0x13]
+
+ophandlers[0x14] = function(e, op)
+	push_aux(e, fvalue(e))
+end
+
+ophandlers[0x94] = function(e, op)
+	if e.aux >= e.trl then error(AUXFULL, 0) end
+	e.auxdata[e.aux] = 0; e.aux = e.aux + 1
+end
+
+ophandlers[0x15] = function(e, op)
+	if e.aux >= e.trl then error(AUXFULL, 0) end
+	e.auxdata[e.aux] = fword(e); e.aux = e.aux + 1
+end
+
+ophandlers[0x95] = function(e, op)
+	if e.aux >= e.trl then error(AUXFULL, 0) end
+	e.auxdata[e.aux] = nextbyte(e); e.aux = e.aux + 1
+end
+
+ophandlers[0x16] = function(e, op)
+	store(e, nextbyte(e), pop_aux(e))
+end
+
+ophandlers[0x17] = function(e, op)
+	store(e, nextbyte(e), pop_aux_list(e))
+end
+
+ophandlers[0x18] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local flag = false
+	while true do
+		e.aux = e.aux - 1
+		local v = e.auxdata[e.aux]
+		if v == 0 then break end
+		if v == a1 then flag = true end
+	end
+	if not flag then fail(e) end
+end
+
+ophandlers[0x19] = function(e, op)
+	local saved = e.top
+	local a1 = deref(e, fvalue(e))
+	local v = pop_aux_list(e)
+	while band(a1, 0xe000) == 0xc000 do
+		local iter = v
+		local match = false
+		while band(iter, 0xe000) == 0xc000 and not match do
+			if would_unify(e, iter - 0x4000, a1 - 0x4000) then
+				match = true
+			end
+			iter = deref(e, iter - 0x3fff)
+		end
+		if not match then
+			fail(e)
+			break
+		end
+		a1 = deref(e, a1 - 0x3fff)
+	end
+	e.top = saved
+end
+
+ophandlers[0x1b] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = deref(e, fvalue(e))
+	local v = 0x3f00
+	if a1 ~= a2 and band(a1, 0xe000) == 0xc000 then
+		local curr = e.top
+		v = bor(0xc000, curr)
+		while true do
+			e.top = e.top + 2
+			if e.top > e.env or e.top > e.cho then error(HEAPFULL, 0) end
+			e.heapdata[curr + 0] = e.heapdata[band(a1, 0x1fff)]
+			a1 = deref(e, a1 - 0x3fff)
+			if a1 == a2 or band(a1, 0xe000) ~= 0xc000 then
+				break
+			end
+			e.heapdata[curr + 1] = bor(0xc000, e.top)
+			curr = e.top
+		end
+		e.heapdata[curr + 1] = 0x3f00
+	end
+	store(e, nextbyte(e), v)
+end
+
+ophandlers[0x1c] = function(e, op)
+	e.cho = e.stc
+	e.inst = bor(lshift(e.heapdata[e.cho + 4], 16), e.heapdata[e.cho + 5])
+end
+
+ophandlers[0x1d] = function(e, op)
+	if e.aux + 2 > e.trl then error(AUXFULL, 0) end
+	e.auxdata[e.aux] = e.stc; e.aux = e.aux + 1
+	e.auxdata[e.aux] = e.sta; e.aux = e.aux + 1
+	e.sta = e.aux
+	push_cho(e, 0, fcode(e))
+	e.stc = e.cho
+end
+
+ophandlers[0x1e] = function(e, op)
+	e.aux = e.sta
+	e.aux = e.aux - 1; e.sta = e.auxdata[e.aux]
+	e.aux = e.aux - 1; e.stc = e.auxdata[e.aux]
+end
+
+ophandlers[0x1f] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local v
+	if a1 >= 0x2000 and a1 < 0x3e00 then
+		v = prepend_chars(e, a1, 0x3f00)
+	elseif a1 >= 0x3e00 and a1 < 0x3f00 then
+		v = create_pair(e, a1, 0x3f00)
+	elseif a1 >= 0x4000 and a1 < 0x8000 then
+		local i = band(a1, 0x3fff)
+		v = 0x3f00
+		repeat
+			v = create_pair(e, bor(0x4000, i % 10), v)
+			i = math.floor(i / 10)
+		until i == 0
+	elseif a1 >= 0xe000 then
+		local a2 = e.heapdata[band(a1, 0x1fff) + 0]
+		if a2 >= 0x8000 then
+			v = a2
+		else
+			local a3 = e.heapdata[band(a1, 0x1fff) + 1]
+			v = prepend_chars(e, a2, a3)
+		end
+	else
+		fail(e)
+		return
+	end
+	store(e, nextbyte(e), v)
+end
+
+ophandlers[0x9f] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	if band(a1, 0xe000) ~= 0xc000 then
+		fail(e)
+		return
+	end
+	local a2 = deref(e, e.heapdata[band(a1, 0x1fff) + 0])
+	if band(a2, 0xff00) == 0x3e00 then
+		local a3 = deref(e, e.heapdata[band(a1, 0x1fff) + 1])
+		if a3 == 0x3f00 then
+			store(e, nextbyte(e), a2)
+			return
+		end
+	end
+	local buf = words_to_charlist(e, a1)
+	if buf ~= 0 then
+		store(e, nextbyte(e), parse_word(e, buf))
+	else
+		fail(e)
+	end
+end
+
+ophandlers[0x20] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and 0 or fvalue(e)
+	local a2 = findex(e)
+	store(e, nextbyte(e), readfield(e, a2, a1))
+end
+ophandlers[0xa0] = ophandlers[0x20]
+
+ophandlers[0x21] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and 0 or fvalue(e)
+	local a2 = findex(e)
+	local v = readfield(e, rshift(a2, 1), a1)
+	store(e, nextbyte(e), (band(a2, 1) ~= 0) and band(v, 0xff) or rshift(v, 8))
+end
+ophandlers[0xa1] = ophandlers[0x21]
+
+ophandlers[0x22] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and 0 or fvalue(e)
+	local a2 = findex(e)
+	local v = get_lts(e, readfield(e, a2, a1))
+	if v ~= 0 then
+		store(e, nextbyte(e), v)
+	else
+		fail(e)
+	end
+end
+ophandlers[0xa2] = ophandlers[0x22]
+
+ophandlers[0x24] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and 0 or fvalue(e)
+	local a2 = findex(e)
+	e.ramdata[fieldaddr(e, a2, a1)] = fvalue(e)
+end
+ophandlers[0xa4] = ophandlers[0x24]
+
+ophandlers[0x25] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and 0 or fvalue(e)
+	local a2 = findex(e)
+	local a3 = fvalue(e)
+	local addr = fieldaddr(e, rshift(a2, 1), a1)
+	if band(a2, 1) ~= 0 then
+		e.ramdata[addr] = bor(band(e.ramdata[addr], 0xff00), band(a3, 0xff))
+	else
+		e.ramdata[addr] = bor(band(e.ramdata[addr], 0x00ff), lshift(band(a3, 0xff), 8))
+	end
+end
+ophandlers[0xa5] = ophandlers[0x25]
+
+ophandlers[0x26] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and 0 or deref(e, fvalue(e))
+	local a2 = findex(e)
+	local a3 = fvalue(e)
+	if a1 <= e.nob or a3 ~= 0 then
+		put_lts(e, fieldaddr(e, a2, a1), a3)
+	end
+end
+ophandlers[0xa6] = ophandlers[0x26]
+
+ophandlers[0x28] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and 0 or fvalue(e)
+	local a2 = findex(e)
+	local addr = fieldaddr(e, rshift(a2, 4), a1)
+	e.ramdata[addr] = bor(e.ramdata[addr], rshift(0x8000, band(a2, 15)))
+end
+ophandlers[0xa8] = ophandlers[0x28]
+
+ophandlers[0x29] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and 0 or deref(e, fvalue(e))
+	local a2 = findex(e)
+	if a1 <= e.nob then
+		local addr = fieldaddr(e, rshift(a2, 4), a1)
+		e.ramdata[addr] = band(e.ramdata[addr], bnot(rshift(0x8000, band(a2, 15))))
+	end
+end
+ophandlers[0xa9] = ophandlers[0x29]
+
+ophandlers[0x2d] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and 0 or fvalue(e)
+	local a2 = findex(e)
+	local a3 = findex(e)
+	unlink(e, fieldaddr(e, a2, a1), a3, deref(e, fvalue(e)))
+end
+ophandlers[0xad] = ophandlers[0x2d]
+
+ophandlers[0x2e] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and nextbyte(e) or deref(e, fvalue(e))
+	local a2 = (band(op, 0x01) ~= 0) and nextbyte(e) or deref(e, fvalue(e))
+	if a1 < e.nob or a2 ~= 0 then
+		if a1 >= 0x2000 or a2 >= 0x2000 then error(EXPECTOBJ, 0) end
+		local v = e.ramdata[fieldaddr(e, 0, a1)]
+		if v ~= 0 then
+			unlink(e, fieldaddr(e, 1, v), 2, a1)
+		end
+		e.ramdata[fieldaddr(e, 0, a1)] = a2
+		if a2 ~= 0 then
+			e.ramdata[fieldaddr(e, 2, a1)] = e.ramdata[fieldaddr(e, 1, a2)]
+			e.ramdata[fieldaddr(e, 1, a2)] = a1
+		end
+	end
+end
+ophandlers[0x2f] = ophandlers[0x2e]
+ophandlers[0xae] = ophandlers[0x2e]
+ophandlers[0xaf] = ophandlers[0x2e]
+
+ophandlers[0x30] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and 0 or fword(e)
+	local a2 = fvalue(e)
+	local a3 = fcode(e)
+	if a1 == a2 then e.inst = a3 end
+end
+ophandlers[0xb0] = ophandlers[0x30]
+
+ophandlers[0x31] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = fcode(e)
+	if band(a1, 0xe000) ~= 0x8000 then e.inst = a2 end
+end
+
+ophandlers[0x32] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = fcode(e)
+	if a1 == 0x3f00 then e.inst = a2 end
+end
+
+ophandlers[0x33] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = fcode(e)
+	if a1 >= 0x4000 and a1 < 0x8000 then e.inst = a2 end
+end
+
+ophandlers[0x34] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = fcode(e)
+	if band(a1, 0xe000) == 0xc000 then e.inst = a2 end
+end
+
+ophandlers[0x35] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = fcode(e)
+	if a1 < 0x2000 then e.inst = a2 end
+end
+
+ophandlers[0x36] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = fcode(e)
+	if a1 >= 0xe000 or (a1 >= 0x2000 and a1 < 0x3f00) then e.inst = a2 end
+end
+
+ophandlers[0xb6] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = fcode(e)
+	if a1 >= 0xe000 and band(e.heapdata[band(a1, 0x1fff)], 0xe000) == 0xc000 then e.inst = a2 end
+end
+
+ophandlers[0x37] = function(e, op)
+	local a1 = fvalue(e)
+	local a2 = fvalue(e)
+	local a3 = fcode(e)
+	if would_unify(e, a1, a2) then e.inst = a3 end
+end
+
+ophandlers[0x38] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = deref(e, fvalue(e))
+	local a3 = fcode(e)
+	if a1 >= 0x4000 and a1 < 0x8000 and a2 >= 0x4000 and a2 < 0x8000 and a1 > a2 then e.inst = a3 end
+end
+
+ophandlers[0x39] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and nextbyte(e) or fword(e)
+	local a2 = fvalue(e)
+	local a3 = fcode(e)
+	if a1 == deref(e, a2) then e.inst = a3 end
+end
+ophandlers[0xb9] = ophandlers[0x39]
+
+ophandlers[0x3a] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and 0 or fvalue(e)
+	local a2 = findex(e)
+	local a3 = (band(op, 1) ~= 0) and nextbyte(e) or fvalue(e)
+	local a4 = fcode(e)
+	if readfield(e, a2, a1) == a3 then e.inst = a4 end
+end
+ophandlers[0xba] = ophandlers[0x3a]
+ophandlers[0x3d] = ophandlers[0x3a]
+ophandlers[0xbd] = ophandlers[0x3a]
+
+ophandlers[0x3b] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and 0 or fvalue(e)
+	local a2 = findex(e)
+	local a3 = fcode(e)
+	if band(readfield(e, rshift(a2, 4), a1), rshift(0x8000, band(a2, 15))) ~= 0 then e.inst = a3 end
+end
+ophandlers[0xbb] = ophandlers[0x3b]
+
+ophandlers[0x3c] = function(e, op)
+	local a1 = fcode(e)
+	if e.cwl ~= 0 then e.inst = a1 end
+end
+
+ophandlers[0x40] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and 0 or fword(e)
+	local a2 = fvalue(e)
+	local a3 = fcode(e)
+	if a1 ~= a2 then e.inst = a3 end
+end
+ophandlers[0xc0] = ophandlers[0x40]
+
+ophandlers[0x41] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = fcode(e)
+	if band(a1, 0xe000) == 0x8000 then e.inst = a2 end
+end
+
+ophandlers[0x42] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = fcode(e)
+	if a1 ~= 0x3f00 then e.inst = a2 end
+end
+
+ophandlers[0x43] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = fcode(e)
+	if a1 < 0x4000 or a1 >= 0x8000 then e.inst = a2 end
+end
+
+ophandlers[0x44] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = fcode(e)
+	if band(a1, 0xe000) ~= 0xc000 then e.inst = a2 end
+end
+
+ophandlers[0x45] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = fcode(e)
+	if a1 >= 0x2000 then e.inst = a2 end
+end
+
+ophandlers[0x46] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = fcode(e)
+	if a1 < 0xe000 and (a1 < 0x2000 or a1 >= 0x3f00) then e.inst = a2 end
+end
+
+ophandlers[0xc6] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = fcode(e)
+	if a1 < 0xe000 or band(e.heapdata[band(a1, 0x1fff)], 0xe000) ~= 0xc000 then e.inst = a2 end
+end
+
+ophandlers[0x47] = function(e, op)
+	local a1 = fvalue(e)
+	local a2 = fvalue(e)
+	local a3 = fcode(e)
+	if not would_unify(e, a1, a2) then e.inst = a3 end
+end
+
+ophandlers[0x48] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = deref(e, fvalue(e))
+	local a3 = fcode(e)
+	if not (a1 >= 0x4000 and a1 < 0x8000 and a2 >= 0x4000 and a2 < 0x8000 and a1 > a2) then e.inst = a3 end
+end
+
+ophandlers[0x49] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and nextbyte(e) or fword(e)
+	local a2 = fvalue(e)
+	local a3 = fcode(e)
+	if a1 ~= deref(e, a2) then e.inst = a3 end
+end
+ophandlers[0xc9] = ophandlers[0x49]
+
+ophandlers[0x4a] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and 0 or fvalue(e)
+	local a2 = findex(e)
+	local a3 = (band(op, 1) ~= 0) and nextbyte(e) or fvalue(e)
+	local a4 = fcode(e)
+	if readfield(e, a2, a1) ~= a3 then e.inst = a4 end
+end
+ophandlers[0xca] = ophandlers[0x4a]
+ophandlers[0x4d] = ophandlers[0x4a]
+ophandlers[0xcd] = ophandlers[0x4a]
+
+ophandlers[0x4b] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and 0 or fvalue(e)
+	local a2 = findex(e)
+	local a3 = fcode(e)
+	if band(readfield(e, rshift(a2, 4), a1), rshift(0x8000, band(a2, 15))) == 0 then e.inst = a3 end
+end
+ophandlers[0xcb] = ophandlers[0x4b]
+
+ophandlers[0x4c] = function(e, op)
+	local a1 = fcode(e)
+	if e.cwl == 0 then e.inst = a1 end
+end
+
+ophandlers[0x50] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = deref(e, fvalue(e))
+	store(e, nextbyte(e), band(a1 + a2, 0xffff))
+end
+
+ophandlers[0xd0] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	store(e, nextbyte(e), band(a1 + 1, 0xffff))
+end
+
+ophandlers[0x51] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = deref(e, fvalue(e))
+	store(e, nextbyte(e), band(a1 - a2, 0xffff))
+end
+
+ophandlers[0xd1] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	store(e, nextbyte(e), band(a1 - 1, 0xffff))
+end
+
+ophandlers[0x52] = function(e, op)
+	local a1 = nextbyte(e)
+	store(e, nextbyte(e), compat_rand(e) % (a1 + 1))
+end
+
+ophandlers[0x58] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = deref(e, fvalue(e))
+	if a1 >= 0x4000 and a1 < 0x8000 and a2 >= 0x4000 and a2 < 0x8000 then
+		local v = band(a1, 0x3fff) + band(a2, 0x3fff)
+		if v < 0x4000 then
+			store(e, nextbyte(e), bor(v, 0x4000))
+		else fail(e) end
+	else fail(e) end
+end
+
+ophandlers[0xd8] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	if a1 >= 0x4000 and a1 < 0x7fff then
+		store(e, nextbyte(e), a1 + 1)
+	else fail(e) end
+end
+
+ophandlers[0x59] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = deref(e, fvalue(e))
+	if a1 >= 0x4000 and a1 < 0x8000 and a2 >= 0x4000 and a2 < 0x8000 then
+		local v = band(a1, 0x3fff) - band(a2, 0x3fff)
+		if v >= 0 then
+			store(e, nextbyte(e), bor(v, 0x4000))
+		else fail(e) end
+	else fail(e) end
+end
+
+ophandlers[0xd9] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	if a1 > 0x4000 and a1 < 0x8000 then
+		store(e, nextbyte(e), a1 - 1)
+	else fail(e) end
+end
+
+ophandlers[0x5a] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = deref(e, fvalue(e))
+	if a1 >= 0x4000 and a1 < 0x8000 and a2 >= 0x4000 and a2 < 0x8000 and a2 >= a1 then
+		local v = a1 + (compat_rand(e) % (a2 - a1 + 1))
+		store(e, nextbyte(e), v)
+	else fail(e) end
+end
+
+ophandlers[0x5b] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = deref(e, fvalue(e))
+	if a1 >= 0x4000 and a1 < 0x8000 and a2 >= 0x4000 and a2 < 0x8000 then
+		local v = band(band(a1, 0x3fff) * band(a2, 0x3fff), 0x3fff)
+		store(e, nextbyte(e), bor(v, 0x4000))
+	else fail(e) end
+end
+
+ophandlers[0x5c] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = deref(e, fvalue(e))
+	if a1 >= 0x4000 and a1 < 0x8000 and a2 > 0x4000 and a2 < 0x8000 then
+		local v = math.floor(band(a1, 0x3fff) / band(a2, 0x3fff))
+		store(e, nextbyte(e), bor(v, 0x4000))
+	else fail(e) end
+end
+
+ophandlers[0x5d] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = deref(e, fvalue(e))
+	if a1 >= 0x4000 and a1 < 0x8000 and a2 > 0x4000 and a2 < 0x8000 then
+		local v = band(a1, 0x3fff) % band(a2, 0x3fff)
+		store(e, nextbyte(e), bor(v, 0x4000))
+	else fail(e) end
+end
+
+ophandlers[0x60] = function(e, op)
+	if e.spc == e.SP_AUTO or e.spc == e.SP_PENDING then e.io.space()
+	elseif e.spc == e.SP_NBSP then e.io.nbsp() end
+	e.io.print(decodestr(e, fstring(e)))
+	e.spc = e.SP_AUTO
+end
+
+ophandlers[0xe0] = function(e, op)
+	if e.spc == e.SP_PENDING then e.io.space()
+	elseif e.spc == e.SP_NBSP then e.io.nbsp() end
+	e.io.print(decodestr(e, fstring(e)))
+	e.spc = e.SP_AUTO
+end
+
+ophandlers[0x61] = function(e, op)
+	if e.spc == e.SP_AUTO or e.spc == e.SP_PENDING then e.io.space()
+	elseif e.spc == e.SP_NBSP then e.io.nbsp() end
+	e.io.print(decodestr(e, fstring(e)))
+	e.spc = e.SP_NOSPACE
+end
+
+ophandlers[0xe1] = function(e, op)
+	if e.spc == e.SP_PENDING then e.io.space()
+	elseif e.spc == e.SP_NBSP then e.io.nbsp() end
+	e.io.print(decodestr(e, fstring(e)))
+	e.spc = e.SP_NOSPACE
+end
+
+ophandlers[0x62] = function(e, op)
+	if e.cwl == 0 then
+		if e.spc < e.SP_NOSPACE then e.spc = e.SP_NOSPACE end
+	end
+end
+
+ophandlers[0xe2] = function(e, op)
+	if e.cwl == 0 then
+		if e.spc < e.SP_PENDING then e.spc = e.SP_PENDING end
+	end
+end
+
+ophandlers[0x63] = function(e, op)
+	if e.cwl == 0 then
+		if e.spc < e.SP_LINE then
+			e.io.line()
+			e.spc = e.SP_LINE
+		end
+	end
+end
+
+ophandlers[0xe3] = function(e, op)
+	if e.cwl == 0 then
+		if e.spc < e.SP_PAR then
+			if e.n_span ~= 0 then
+				e.io.line()
+				e.io.line()
+			else
+				e.io.par()
+			end
+			e.spc = e.SP_PAR
+		end
+	end
+end
+
+ophandlers[0x64] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	if e.cwl == 0 and a1 > 0x4000 and a1 < 0x8000 then
+		e.io.space_n(band(a1, 0x3fff))
+		e.spc = e.SP_SPACE
+	end
+end
+
+ophandlers[0x65] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	if e.cwl ~= 0 then
+		push_aux(e, a1)
+	else
+		if band(a1, 0xff00) == 0x3e00 then
+			local tmp = band(a1, 0xff)
+			if e.spc == e.SP_PENDING or (e.spc == e.SP_AUTO and not bytes_includes(e.nospcbefore, tmp)) then
+				e.io.space()
+			end
+			e.io.print(decodechar(e, tmp))
+			if bytes_includes(e.nospcafter, tmp) then
+				e.spc = e.SP_NOSPACE
+			else
+				e.spc = e.SP_AUTO
+			end
+		else
+			if e.spc == e.SP_AUTO or e.spc == e.SP_PENDING then e.io.space() end
+			e.io.print(val2str(e, a1))
+			e.spc = e.SP_AUTO
+		end
+	end
+end
+
+ophandlers[0x66] = function(e, op)
+	local a1 = findex(e)
+	if e.cwl == 0 then
+		if e.n_span ~= 0 then error(IOSTATE, 0) end
+		e.io.enter_div(a1)
+		arr_push(e.divs, a1)
+		e.spc = e.SP_PAR
+	end
+end
+
+ophandlers[0xe6] = function(e, op)
+	if e.cwl == 0 then
+		e.io.leave_div(arr_pop(e.divs))
+		e.spc = e.SP_LINE
+	end
+end
+
+ophandlers[0x67] = function(e, op)
+	if e.head[0] < 1 then
+		local a1 = findex(e)
+		if e.cwl == 0 then
+			if e.in_status or e.n_span ~= 0 then error(IOSTATE, 0) end
+			e.io.enter_status(0, a1)
+			e.in_status = 1
+			e.spc = e.SP_PAR
+		end
+	else
+		local a1 = findex(e)
+		if e.in_status or e.n_span ~= 0 then error(IOSTATE, 0) end
+		e.io.set_body(a1)
+	end
+end
+
+ophandlers[0xe7] = function(e, op)
+	if e.head[0] < 1 then
+		if e.cwl == 0 then
+			e.io.leave_status()
+			e.in_status = false
+			e.spc = e.SP_PAR
+		end
+	else
+		io.stderr:write("Opcode $E7 is not defined in version 1.x\n")
+	end
+end
+
+ophandlers[0x68] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	if e.cwl == 0 then
+		if e.n_link == 0 then
+			if e.spc == e.SP_AUTO or e.spc == e.SP_PENDING then e.io.space() end
+			e.io.enter_link_res(get_res(e, band(a1, 0x1fff)))
+			e.spc = e.SP_NOSPACE
+		end
+		e.n_link = e.n_link + 1
+		e.n_span = e.n_span + 1
+	end
+end
+
+ophandlers[0xe8] = function(e, op)
+	if e.cwl == 0 then
+		e.n_link = e.n_link - 1
+		e.n_span = e.n_span - 1
+		if e.n_link == 0 then e.io.leave_link_res() end
+	end
+end
+
+ophandlers[0x69] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	if e.cwl == 0 then
+		if e.n_link == 0 then
+			if e.spc == e.SP_AUTO or e.spc == e.SP_PENDING then e.io.space() end
+			local saved_upper = e.upper
+			e.upper = false
+			local str = ""
+			while band(a1, 0xe000) == 0xc000 do
+				local v = deref(e, a1 - 0x4000)
+				if (v >= 0x2000 and v < 0x8000) or v >= 0xe000 then
+					if str ~= "" then str = str .. " " end
+					str = str .. val2str(e, v)
+				end
+				a1 = deref(e, a1 - 0x3fff)
+			end
+			e.io.enter_link(str)
+			e.upper = saved_upper
+			e.spc = e.SP_NOSPACE
+		end
+		e.n_link = e.n_link + 1
+		e.n_span = e.n_span + 1
+	end
+end
+
+ophandlers[0xe9] = function(e, op)
+	if e.cwl == 0 then
+		e.n_link = e.n_link - 1
+		e.n_span = e.n_span - 1
+		if e.n_link == 0 then e.io.leave_link() end
+	end
+end
+
+ophandlers[0x6a] = function(e, op)
+	if e.cwl == 0 then
+		if e.n_link == 0 then
+			if e.spc == e.SP_AUTO or e.spc == e.SP_PENDING then e.io.space() end
+			e.io.enter_self_link()
+			e.spc = e.SP_NOSPACE
+		end
+		e.n_link = e.n_link + 1
+		e.n_span = e.n_span + 1
+	end
+end
+
+ophandlers[0xea] = function(e, op)
+	if e.cwl == 0 then
+		e.n_link = e.n_link - 1
+		e.n_span = e.n_span - 1
+		if e.n_link == 0 then e.io.leave_self_link() end
+	end
+end
+
+ophandlers[0x6b] = function(e, op)
+	local a1 = nextbyte(e)
+	if e.cwl == 0 then
+		if e.spc == e.SP_AUTO or e.spc == e.SP_PENDING then e.io.space() end
+		e.io.setstyle(a1)
+		e.spc = e.SP_SPACE
+	end
+end
+
+ophandlers[0xeb] = function(e, op)
+	local a1 = nextbyte(e)
+	if e.cwl == 0 then
+		e.io.resetstyle(a1)
+	end
+end
+
+ophandlers[0x6c] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	if e.spc == e.SP_AUTO or e.spc == e.SP_PENDING then e.io.space() end
+	e.io.embed_res(get_res(e, band(a1, 0x1fff)))
+	e.spc = e.SP_AUTO
+end
+
+ophandlers[0xec] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	store(e, nextbyte(e), e.io.can_embed_res(get_res(e, band(a1, 0x1fff))) and 1 or 0)
+end
+
+ophandlers[0x6d] = function(e, op)
+	local a1 = deref(e, fvalue(e))
+	local a2 = deref(e, fvalue(e))
+	if e.cwl == 0 then
+		if a1 >= 0x4000 and a1 < 0x8000 and a2 >= 0x4000 and a2 < 0x8000 then
+			e.io.progressbar(band(a1, 0x3fff), band(a2, 0x3fff))
+		end
+	end
+end
+
+ophandlers[0x6e] = function(e, op)
+	local a1 = findex(e)
+	if e.cwl == 0 then
+		if e.spc == e.SP_AUTO or e.spc == e.SP_PENDING then e.io.space() end
+		e.io.enter_span(a1)
+		e.n_span = e.n_span + 1
+		e.spc = e.SP_NOSPACE
+	end
+end
+
+ophandlers[0xee] = function(e, op)
+	if e.cwl == 0 then
+		e.io.leave_span()
+		e.n_span = e.n_span - 1
+		e.spc = e.SP_AUTO
+	end
+end
+
+ophandlers[0x6f] = function(e, op)
+	local a1 = nextbyte(e)
+	local a2 = findex(e)
+	if e.cwl == 0 then
+		if e.in_status or e.n_span ~= 0 then error(IOSTATE, 0) end
+		e.io.enter_status(a1, a2)
+		e.in_status = a1 + 1
+		e.spc = e.SP_PAR
+	end
+end
+
+ophandlers[0xef] = function(e, op)
+	if e.head[0] > 0 then
+		if e.cwl == 0 then
+			e.io.leave_status()
+			e.in_status = false
+			e.spc = e.SP_PAR
+		end
+	else
+		io.stderr:write("Opcode $EF is not defined in version 0.x\n")
+	end
+end
+
+ophandlers[0x70] = function(e, op)
+	local a1 = nextbyte(e)
+	if a1 == 0x00 then -- quit
+		e.io.flush()
+		return status.quit
+	elseif a1 == 0x01 then -- restart
+		vm_clear_divs(e)
+		vm_reset(e, 0, true)
+		vm_restore_state(e, e.initstate)
+		e.io.reset()
+	elseif a1 == 0x02 then -- restore
+		e.io.flush()
+		e.io.restore()
+		return status.restore
+	elseif a1 == 0x03 then -- undo
+		if #e.undodata > 0 then
+			vm_clear_divs(e)
+			vm_restore_state(e, vm_rldec_state(e.initstate, table.remove(e.undodata)))
+		elseif not e.pruned_undo then
+			fail(e)
+		end
+	elseif a1 == 0x04 then -- unstyle
+		if e.cwl == 0 then e.io.unstyle() end
+	elseif a1 == 0x05 then -- print_serial
+		if e.cwl == 0 then
+			if e.spc == e.SP_AUTO or e.spc == e.SP_PENDING then e.io.space() end
+			for i = 0, 5 do
+				e.io.print(string.char(e.head[6 + i]))
+			end
+			e.spc = e.SP_AUTO
+		end
+	elseif a1 == 0x06 or a1 == 0x07 then -- clear / clear_all
+		if e.in_status or e.n_span ~= 0 then error(IOSTATE, 0) end
+		local tmp = e.divs
+		vm_clear_divs(e)
+		if a1 == 0x06 then
+			e.io.clear()
+		else
+			e.io.clear_all()
+		end
+		for i = 0, tmp.length - 1 do
+			e.io.enter_div(tmp[i])
+		end
+		e.divs = tmp
+	elseif a1 == 0x08 then -- script_on
+		if not e.io.script_on() then fail(e) end
+	elseif a1 == 0x09 then -- script_off
+		e.io.script_off()
+	elseif a1 == 0x0a then -- trace_on
+		e.trace = true
+	elseif a1 == 0x0b then -- trace_off
+		e.trace = false
+	elseif a1 == 0x0c then -- inc_cwl
+		e.cwl = e.cwl + 1
+	elseif a1 == 0x0d then -- dec_cwl
+		e.cwl = e.cwl - 1
+	elseif a1 == 0x0e then -- uppercase
+		if e.cwl == 0 then e.upper = true end
+	elseif a1 == 0x0f then -- clear_links
+		e.io.clear_links()
+	elseif a1 == 0x10 then -- clear_old
+		if e.n_span ~= 0 then error(IOSTATE, 0) end
+		e.io.clear_old()
+	elseif a1 == 0x11 then -- clear_div
+		e.io.clear_div()
+	elseif a1 == 0x12 then -- clear_status
+		if e.in_status then error(IOSTATE, 0) end
+		e.io.clear_status()
+	elseif a1 == 0x13 then -- nbsp
+		if e.cwl == 0 then
+			if e.spc < e.SP_NBSP then e.spc = e.SP_NBSP end
+		end
+	else
+		error("Unimplemented ext0 " .. string.format("%x", a1) .. " at " .. string.format("%x", e.inst - 2), 0)
+	end
+end
+
+ophandlers[0x72] = function(e, op)
+	local a1 = fcode(e)
+	if e.in_status or e.n_span ~= 0 then error(IOSTATE, 0) end
+	if not e.io.save(vm_wrap_savefile(e, vm_rlenc_state(e.initstate, vm_capture_state(e, a1)))) then
+		fail(e)
+	end
+end
+
+ophandlers[0xf2] = function(e, op)
+	local a1 = fcode(e)
+	if e.in_status or e.n_span ~= 0 then error(IOSTATE, 0) end
+	if #e.undodata > 50 then
+		table.remove(e.undodata, 1)
+		e.pruned_undo = true
+	end
+	e.undodata[#e.undodata + 1] = vm_rlenc_state(e.initstate, vm_capture_state(e, a1))
+end
+
+ophandlers[0x73] = function(e, op)
+	if e.spc == e.SP_AUTO or e.spc == e.SP_PENDING then e.io.space()
+	elseif e.spc == e.SP_NBSP then e.io.nbsp() end
+	e.io.flush()
+	return status.get_input
+end
+
+ophandlers[0xf3] = function(e, op)
+	if e.spc == e.SP_AUTO or e.spc == e.SP_PENDING then e.io.space()
+	elseif e.spc == e.SP_NBSP then e.io.nbsp() end
+	e.io.flush()
+	return status.get_key
+end
+
+ophandlers[0x74] = function(e, op)
+	local a1 = nextbyte(e)
+	local v = 0
+	if a1 == 0x00 then
+		v = 0x4000
+		for i = 0, e.heapdata.length - 1 do
+			if e.heapdata[i] ~= 0x3f3f then v = v + 1 end
+		end
+	elseif a1 == 0x01 then
+		v = 0x4000
+		for i = 0, e.auxdata.length - 1 do
+			if e.auxdata[i] ~= 0x3f3f then v = v + 1 end
+		end
+	elseif a1 == 0x02 then
+		v = 0x4000
+		for i = e.ltb, e.ramdata.length - 1 do
+			if e.ramdata[i] ~= 0x3f3f then v = v + 1 end
+		end
+	elseif a1 == 0x20 then
+		v = bor(0x4000, e.io.measure_dims(0))
+	elseif a1 == 0x21 then
+		v = bor(0x4000, e.io.measure_dims(1))
+	elseif a1 == 0x40 then
+		v = 1
+	elseif a1 == 0x41 then
+		v = 1
+	elseif a1 == 0x42 then
+		v = e.io.have_links() and 1 or 0
+	elseif a1 == 0x43 then
+		v = e.havequit and 1 or 0
+	elseif a1 == 0x44 then
+		v = e.io.have_styles() and 1 or 0
+	elseif a1 == 0x45 then
+		v = e.io.have_color() and 1 or 0
+	elseif a1 == 0x46 then
+		v = e.io.have_align() and 1 or 0
+	elseif a1 == 0x50 then
+		v = e.io.script_active() and 1 or 0
+	elseif a1 == 0x60 then
+		v = e.havetop and 1 or 0
+	elseif a1 == 0x61 then
+		v = e.haveinline and 1 or 0
+	else
+		if a1 > 0x7f then
+			error("Unimplemented vminfo " .. string.format("%x", a1) .. " at " .. string.format("%x", e.inst - 2), 0)
+		end
+		if a1 < 0x40 then
+			v = 0x4000
+		end
+		io.stderr:write("Unrecognized vminfo " .. string.format("%x", a1) .. "; returning default " .. string.format("%x", v) .. "\n")
+	end
+	store(e, nextbyte(e), v)
+end
+
+ophandlers[0x78] = function(e, op)
+	local v = deref(e, fvalue(e))
+	if v >= 0xe000 then v = e.heapdata[band(v, 0x1fff)] end
+	e.reg[0x3f] = v
+end
+
+ophandlers[0x79] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and nextbyte(e) or fword(e)
+	local a2 = fcode(e)
+	if e.reg[0x3f] == a1 then e.inst = a2 end
+end
+ophandlers[0xf9] = ophandlers[0x79]
+
+ophandlers[0x7a] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and nextbyte(e) or fword(e)
+	local a2 = fcode(e)
+	local a3 = fcode(e)
+	if e.reg[0x3f] > a1 then
+		e.inst = a2
+	elseif e.reg[0x3f] == a1 then
+		e.inst = a3
+	end
+end
+ophandlers[0xfa] = ophandlers[0x7a]
+
+ophandlers[0x7b] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and nextbyte(e) or fvalue(e)
+	local a2 = fcode(e)
+	if e.reg[0x3f] > a1 then e.inst = a2 end
+end
+ophandlers[0xfb] = ophandlers[0x7b]
+
+ophandlers[0x7c] = function(e, op)
+	local a1 = findex(e)
+	local a2 = fcode(e)
+	if wordmap(e, a1, e.reg[0x3f]) then e.inst = a2 end
+end
+
+ophandlers[0x7d] = function(e, op)
+	local a1 = (band(op, 0x80) ~= 0) and nextbyte(e) or fword(e)
+	local a2 = (band(op, 0x80) ~= 0) and nextbyte(e) or fword(e)
+	local a3 = fcode(e)
+	if e.reg[0x3f] == a1 or e.reg[0x3f] == a2 then e.inst = a3 end
+end
+ophandlers[0xfd] = ophandlers[0x7d]
+
+ophandlers[0x7f] = function(e, op)
+	local a1 = fstring(e)
+	local a2 = fstring(e)
+	local a3 = fstring(e)
+	local a4 = fword(e)
+	if e.trace then
+		local str = decodestr(e, a1) .. "("
+		local arg = decodestr(e, a2)
+		local j = 0
+		for i = 1, #arg do
+			local ch = arg:sub(i, i)
+			if ch == "$" then
+				str = str .. val2str(e, e.reg[j]); j = j + 1
+			else
+				str = str .. ch
+			end
+		end
+		str = str .. ") " .. decodestr(e, a3) .. ":" .. a4
+		e.io.trace(str)
+	end
+end
+
+-- VM run loop
+local function dispatch(e)
+	while true do
+		local op = e.code[e.inst]; e.inst = e.inst + 1
+		local h = ophandlers[op]
+		if not h then
+			error("Unimplemented op " .. string.format("%x", op) .. " at " .. string.format("%x", e.inst - 1), 0)
+		end
+		local r = h(e, op)
+		if r ~= nil then return r end
+	end
+end
+
+local function vm_run(e, param)
+	if param and param ~= 0 then
+		store(e, nextbyte(e), param)
+	end
+	while true do
+		local ok, res = pcall(dispatch, e)
+		if ok then
+			return res
+		elseif type(res) == "number" and res > 0x4000 and res < 0x8000 then
+			if e.spc < e.SP_LINE then e.io.line() end
+			vm_clear_divs(e)
+			vm_reset(e, res, false)
+		else
+			error(res, 0)
+		end
+	end
+end
+
+-- Story preparation and input
+local function prepare_story(file_array, io_obj, seed, quit, toparea, inlinearea)
+	local function findfiles()
+		local size = get32(file_array, 4) + 8
+		local pos = 12
+		local list = {}
+		while pos < size do
+			local chname = getfour(file_array, pos)
+			local chsize = get32(file_array, pos + 4)
+			if chname == "FILE" then
+				local fname = {}
+				local i = 0
+				while file_array[pos + 8 + i] ~= 0 do
+					fname[#fname + 1] = string.char(file_array[pos + 8 + i])
+					i = i + 1
+				end
+				list[table.concat(fname)] = slice_bytes(file_array, pos + 8 + i + 1, pos + 8 + chsize)
+			end
+			pos = pos + 8 + band(chsize + 1, bnot(1))
+		end
+		return list
+	end
+
+	local function findch(name, mandatory)
+		local data = findchunk(file_array, name)
+		if not data and mandatory then
+			error("Missing " .. name .. " chunk.", 0)
+		end
+		return data
+	end
+
+	if getfour(file_array, 0) ~= "FORM" or getfour(file_array, 8) ~= "AAVM" then
+		error("Not an aastory file", 0)
+	end
+
+	local e = {
+		VER_MAJOR = 1,
+		VER_MINOR = 0,
+
+		SP_AUTO = 0,
+		SP_NOSPACE = 1,
+		SP_NBSP = 2,
+		SP_PENDING = 3,
+		SP_SPACE = 4,
+		SP_LINE = 5,
+		SP_PAR = 6,
+
+		head = findch("HEAD", true),
+		code = findch("CODE", true),
+		dict = findch("DICT", true),
+		init = findch("INIT", true),
+		lang = findch("LANG", true),
+		maps = findch("MAPS", true),
+		tags = findch("TAGS", false),
+		writ = findch("WRIT", true),
+		look = findch("LOOK", true),
+		meta = findch("META", false),
+		urls = findch("URLS", false),
+		files = findfiles(),
+
+		randomseed = seed,
+		strshift = 0,
+		extchars = 0,
+		esc_bits = 7,
+		esc_boundary = 0,
+		io = io_obj,
+		stopchars = {length = 0},
+		nospcbefore = {length = 0},
+		nospcafter = {length = 0},
+
+		reg = newbytes(64),
+		inst = 0, cont = 0, top = 0, env = 0, cho = 0, sim = 0xffff, aux = 0,
+		trl = 0, sta = 0, stc = 0, cwl = 0, spc = 0, nob = 0, ltb = 0, ltt = 0,
+
+		upper = false,
+		trace = false,
+		divs = {length = 0},
+		in_status = false,
+		n_statusdiv = 0,
+		n_span = 0,
+		n_link = 0,
+
+		undodata = {},
+		pruned_undo = false,
+		havequit = quit,
+		havetop = toparea,
+		haveinline = inlinearea,
+
+		tmp = 0
+	}
+
+	if (e.head[0] > e.VER_MAJOR) or (e.head[0] == e.VER_MAJOR and e.head[1] > e.VER_MINOR) then
+		error("Unsupported aastory file format version " .. e.head[0] .. "." .. e.head[1] .. "; this interpreter supports up to " .. e.VER_MAJOR .. "." .. e.VER_MINOR, 0)
+	end
+	if e.head[2] ~= 2 then
+		error("Unsupported word size " .. e.head[2] .. "; this interpreter only supports 2", 0)
+	end
+
+	e.heapdata = newbytes(get16(e.head, 16))
+	e.auxdata = newbytes(get16(e.head, 18))
+	e.ramdata = newbytes(get16(e.head, 20))
+	e.strshift = e.head[3]
+	e.extchars = get16(e.lang, 2)
+
+	if e.head[0] > 0 or e.head[1] >= 4 then
+		e.esc_boundary = e.lang[e.extchars] - 32
+		if e.esc_boundary < 0 then e.esc_boundary = 0 end
+		local i = e.esc_boundary + get16(e.dict, 0) - 1
+		e.esc_bits = 0
+		while i > 0 do
+			i = rshift(i, 1)
+			e.esc_bits = e.esc_bits + 1
+		end
+	end
+
+	local stopptr = get16(e.lang, 6)
+	local stopend = stopptr
+	while e.lang[stopend] ~= 0 do stopend = stopend + 1 end
+	e.stopchars = slice_bytes(e.lang, stopptr, stopend)
+	if e.head[0] > 0 or e.head[1] >= 4 then
+		stopptr = stopend + 1
+		stopend = stopptr
+		while e.lang[stopend] ~= 0 do stopend = stopend + 1 end
+		e.nospcbefore = slice_bytes(e.lang, stopptr, stopend)
+		stopptr = stopend + 1
+		stopend = stopptr
+		while e.lang[stopend] ~= 0 do stopend = stopend + 1 end
+		e.nospcafter = slice_bytes(e.lang, stopptr, stopend)
+	end
+
+	vm_reinit(e)
+	vm_reset(e, 0, true)
+	e.initstate = vm_capture_state(e, 1)
+	io_obj.reset()
+
+	return e
+end
+
+local function vm_proceed_with_input(e, str)
+	local cps = utf8_codepoints(str)
+	local n = cps.length
+	local chars = {length = n}
+	for i = 0, n - 1 do
+		local uchar = cps[i]
+		if uchar >= 0x41 and uchar <= 0x5a then
+			chars[i] = bxor(uchar, 0x20)
+		elseif uchar < 0x80 then
+			chars[i] = uchar
+		else
+			chars[i] = 0x3f
+			for j = e.lang[e.extchars] - 1, 0, -1 do
+				local entry = e.extchars + 1 + j * 5
+				if e.lang[entry + 2] == band(rshift(uchar, 16), 0xff)
+					and e.lang[entry + 3] == band(rshift(uchar, 8), 0xff)
+					and e.lang[entry + 4] == band(uchar, 0xff) then
+					chars[i] = e.lang[entry]
+					break
+				end
+			end
+		end
+	end
+
+	local words = {length = 0}
+	local start = 0
+	local i = 0
+	while i < n do
+		if chars[i] == 32 then
+			if i ~= start then arr_push(words, slice_bytes(chars, start, i)) end
+			start = i + 1
+		else
+			if bytes_includes(e.stopchars, chars[i]) then
+				if i ~= start then arr_push(words, slice_bytes(chars, start, i)) end
+				arr_push(words, slice_bytes(chars, i, i + 1))
+				start = i + 1
+			end
+		end
+		i = i + 1
+	end
+	if i ~= start then arr_push(words, slice_bytes(chars, start, i)) end
+
+	local v = 0x3f00
+	local ok, err = pcall(function()
+		for k = words.length - 1, 0, -1 do
+			v = create_pair(e, parse_word(e, words[k]), v)
+		end
+	end)
+	if not ok then
+		if err == HEAPFULL then
+			if e.spc < e.SP_LINE then e.io.line() end
+			vm_clear_divs(e)
+			vm_reset(e, err, false)
+			v = nil
+		else
+			error(err, 0)
+		end
+	end
+
+	e.spc = e.SP_LINE
+	return vm_run(e, v)
+end
+
+local function vm_proceed_with_key(e, code)
+	local v = 0
+	if code >= 0x20 and code < 0x7f then
+		if code >= 0x41 and code <= 0x5a then code = bxor(code, 0x20) end
+		v = code
+	end
+	if v == 0 then
+		for _, kc in pairs(keys) do
+			if code == kc then v = code; break end
+		end
+	end
+	if v == 0 then
+		local i = 0
+		while i < e.lang[e.extchars] do
+			local entry = 1 + i * 5
+			local cond = bor((code == lshift(e.lang[entry + 2], 16)) and 1 or 0, lshift(e.lang[entry + 3], 8), e.lang[entry + 4])
+			if cond ~= 0 then break end
+			i = i + 1
+		end
+		if i < e.lang[e.extchars] then
+			v = bor(0x80, e.lang[1 + i * 5])
+		end
+	end
+	if v == 0 then
+		return status.get_key
+	else
+		e.spc = e.SP_SPACE
+		if v >= 0x30 and v <= 0x39 then
+			v = v + 0x4000 - 0x30
+		else
+			v = bor(v, 0x3e00)
+		end
+		return vm_run(e, v)
+	end
+end
+
+-- Public API
+local instance_e
+
+local aaengine = {}
+
+function aaengine.prepare_story(file_array, io_obj, seed, quit, toparea, inlinearea)
+	instance_e = prepare_story(file_array, io_obj, seed, quit, toparea, inlinearea)
+	aaengine.keys = keys
+	aaengine.status = status
+	aaengine.opcodes = opcodes
+end
+
+function aaengine.get_styles()
+	return get_styles(instance_e)
+end
+
+function aaengine.get_metadata()
+	return get_metadata(instance_e)
+end
+
+function aaengine.get_file(name)
+	return instance_e.files[name]
+end
+
+function aaengine.get_resources()
+	return get_resources(instance_e)
+end
+
+function aaengine.get_story_key()
+	local m = get_metadata(instance_e)
+	local str = (m.title:gsub("[^a-zA-Z0-9]+", "-")) .. "-"
+	for i = 0, 5 do str = str .. decodechar(instance_e, instance_e.head[6 + i]) end
+	str = str .. "-"
+	for i = 0, 3 do
+		local hex = string.format("%x", instance_e.head[12 + i])
+		if #hex == 1 then hex = "0" .. hex end
+		str = str .. hex
+	end
+	return str
+end
+
+function aaengine.vm_start()
+	return vm_run(instance_e, nil)
+end
+
+function aaengine.vm_proceed_with_input(str)
+	return vm_proceed_with_input(instance_e, str)
+end
+
+function aaengine.vm_proceed_with_key(charcode)
+	return vm_proceed_with_key(instance_e, charcode)
+end
+
+function aaengine.vm_restore(filedata)
+	local v
+	if filedata then v = vm_unwrap_savefile(instance_e, filedata) end
+	if filedata and v then
+		vm_clear_divs(instance_e)
+		vm_reset(instance_e, 0, true)
+		vm_restore_state(instance_e, vm_rldec_state(instance_e.initstate, v))
+	end
+	instance_e.spc = instance_e.SP_LINE
+	return vm_run(instance_e, nil)
+end
+
+function aaengine.async_restart()
+	vm_clear_divs(instance_e)
+	vm_reset(instance_e, 0, true)
+	vm_restore_state(instance_e, instance_e.initstate)
+	instance_e.io.reset()
+	return vm_run(instance_e, nil)
+end
+
+function aaengine.async_save(st)
+	local state = vm_capture_state(instance_e, instance_e.inst - ((st == status.quit) and 2 or 1))
+	return vm_wrap_savefile(instance_e, vm_rlenc_state(instance_e.initstate, state))
+end
+
+function aaengine.async_restore(filedata)
+	local v = vm_unwrap_savefile(instance_e, filedata)
+	vm_reset(instance_e, 0, true)
+	vm_restore_state(instance_e, vm_rldec_state(instance_e.initstate, v))
+	instance_e.spc = instance_e.SP_LINE
+end
+
+function aaengine.async_resume()
+	return vm_run(instance_e, nil)
+end
+
+function aaengine.get_undo_array()
+	local out = {}
+	for i = 1, #instance_e.undodata do
+		out[i] = vm_wrap_savefile(instance_e, instance_e.undodata[i])
+	end
+	return out
+end
+
+function aaengine.set_undo_array(arr)
+	local out = {}
+	for i = 1, #arr do
+		out[i] = vm_unwrap_savefile(instance_e, arr[i])
+	end
+	instance_e.undodata = out
+end
+
+function aaengine.mem_info()
+	local e = instance_e
+	local h, a, lts = 0, 0, 0
+	for i = 0, e.heapdata.length - 1 do
+		if e.heapdata[i] ~= 0x3f3f then h = h + 1 end
+	end
+	for i = 0, e.auxdata.length - 1 do
+		if e.auxdata[i] ~= 0x3f3f then a = a + 1 end
+	end
+	for i = e.ltb, e.ramdata.length - 1 do
+		if e.ramdata[i] ~= 0x3f3f then lts = lts + 1 end
+	end
+	return {
+		heap = h,
+		aux = a,
+		lts = lts,
+		heapsize = e.heapdata.length,
+		auxsize = e.auxdata.length,
+		ltssize = e.ramdata.length - e.ltb
+	}
+end
+
+aaengine.keys = keys
+aaengine.status = status
+aaengine.opcodes = opcodes
+
+return aaengine

--- a/src/lua/frontend.lua
+++ b/src/lua/frontend.lua
@@ -1,0 +1,496 @@
+-- Å-machine LuaJIT terminal frontend, ported from src/js/nodefrontend.js.
+--
+-- Wraps the Lua engine (engine.lua) and handles word-wrapped terminal I/O.
+-- Demonstrates embedding the engine in a Lua project and is used to run the
+-- automated test suite. Output is byte-for-byte compatible with the Node
+-- frontend.
+
+local VERSION = "1.0.3"
+
+local lua_io = io
+local stdout = io.stdout
+local stdin = io.stdin
+local stderr = io.stderr
+
+-- On Windows the standard streams default to text mode, which rewrites "\n"
+-- into "\r\n" and corrupts the byte-exact transcript. Switch fd 0 and 1 to
+-- binary through the C runtime. macOS, Linux and other Unix platforms already
+-- use binary streams, so nothing platform-specific runs there.
+if jit and jit.os == "Windows" then
+	pcall(function()
+		local ffi = require("ffi")
+		ffi.cdef[[int _setmode(int fd, int mode);]]
+		ffi.C._setmode(0, 0x8000)
+		ffi.C._setmode(1, 0x8000)
+	end)
+end
+
+local function is_terminal()
+	local ok, ffi = pcall(require, "ffi")
+	if ok then
+		ffi.cdef[[int isatty(int fd); int fileno(void *stream);]]
+		return ffi.C.isatty(ffi.C.fileno(stdin)) == 1
+	end
+	return false
+end
+
+local script_dir = (arg[0] or ""):match("^(.*[/\\])") or "./"
+package.path = script_dir .. "?.lua;" .. package.path
+local aaengine = require("engine")
+
+local status
+local restore_status
+local io_tag_lines = false
+local quirks = false
+
+local function w(s)
+	stdout:write(s)
+end
+
+local function utf8_len(s)
+	local _, n = s:gsub("[%z\1-\127\194-\244]", "")
+	return n
+end
+
+local function bytes_from_string(s)
+	local a = {length = #s}
+	for i = 1, #s do a[i - 1] = string.byte(s, i) end
+	return a
+end
+
+local function codepoints(line)
+	local cps = {length = 0}
+	local i = 1
+	local len = #line
+	while i <= len do
+		local c = string.byte(line, i)
+		local cp, adv
+		if c < 0x80 then
+			cp = c; adv = 1
+		elseif c < 0xe0 then
+			cp = (c % 0x20) * 0x40 + (string.byte(line, i + 1) or 0) % 0x40; adv = 2
+		elseif c < 0xf0 then
+			cp = (c % 0x10) * 0x1000 + ((string.byte(line, i + 1) or 0) % 0x40) * 0x40 + (string.byte(line, i + 2) or 0) % 0x40; adv = 3
+		else
+			cp = (c % 0x08) * 0x40000 + ((string.byte(line, i + 1) or 0) % 0x40) * 0x1000 + ((string.byte(line, i + 2) or 0) % 0x40) * 0x40 + (string.byte(line, i + 3) or 0) % 0x40; adv = 4
+		end
+		cps[cps.length] = cp
+		cps.length = cps.length + 1
+		i = i + adv
+	end
+	return cps
+end
+
+local io = {
+	hidden = false,
+	newlines = 0,
+	pending_spaces = 0,
+	pword = "",
+	pwlen = 0,
+	xpos = 0,
+	width = 80
+}
+
+io.vspace_n = function(n)
+	n = math.floor(n) + 1
+	while io.newlines < n do
+		w("\n")
+		if io_tag_lines then w("  ") end
+		io.newlines = io.newlines + 1
+	end
+	io.xpos = 0
+	io.pending_spaces = 0
+end
+
+io.flush = function()
+	if io.width > 0 and io.xpos + io.pending_spaces + io.pwlen > io.width then
+		io.vspace_n(0)
+	end
+	while io.pending_spaces > 0 do
+		if io.xpos ~= 0 then
+			w(" ")
+			io.xpos = io.xpos + 1
+		end
+		io.pending_spaces = io.pending_spaces - 1
+	end
+	if io.pwlen > 0 then
+		w(io.pword)
+		io.xpos = io.xpos + io.pwlen
+		io.newlines = 0
+		io.pword = ""
+		io.pwlen = 0
+	end
+end
+
+io.reset = function()
+	io.hidden = false
+	io.pword = ""
+	io.pwlen = 0
+	io.pending_spaces = 0
+	io.xpos = 0
+	io.newlines = quirks and 999 or 1
+end
+
+io.clear = function() io.par() end
+io.clear_all = function() io.par() end
+io.clear_links = function() end
+io.clear_old = function() end
+io.clear_div = function() end
+io.clear_status = function() end
+
+io.print = function(str)
+	if not io.hidden then
+		for ch in str:gmatch("[%z\1-\127\194-\244][\128-\191]*") do
+			if ch == " " then
+				io.flush()
+				io.pending_spaces = io.pending_spaces + 1
+			elseif ch == "-" then
+				io.pword = io.pword .. ch
+				io.pwlen = io.pwlen + 1
+				io.flush()
+			else
+				io.pword = io.pword .. ch
+				io.pwlen = io.pwlen + 1
+			end
+		end
+	end
+end
+
+io.nbsp = function()
+	if not io.hidden then
+		io.pword = io.pword .. " "
+		io.pwlen = io.pwlen + 1
+	end
+end
+
+io.space = function()
+	if not io.hidden then
+		io.print(" ")
+	end
+end
+
+io.space_n = function(n)
+	if not io.hidden then
+		io.flush()
+		if io.width > 0 and n > io.width - io.xpos then
+			n = io.width - io.xpos
+		end
+		for _ = 1, n do
+			w(" ")
+			io.xpos = io.xpos + 1
+		end
+		io.newlines = 0
+	end
+end
+
+io.line = function()
+	if not io.hidden then
+		io.flush()
+		io.vspace_n(0)
+	end
+end
+
+io.par = function()
+	if not io.hidden then
+		io.flush()
+		io.vspace_n(1)
+	end
+end
+
+io.measure_dims = function(which)
+	if which == 0 then
+		return io.width > 0 and io.width or 0
+	else
+		return 0
+	end
+end
+
+io.setstyle = function(s) end
+io.resetstyle = function(s) end
+io.unstyle = function() end
+io.set_body = function(id) end
+
+io.parse_em = function(id, key, defvalue)
+	if id >= 0 then
+		local map = io.styles[id]
+		local str = map and map[key]
+		if str then
+			local num = str:match("^ *(%d+)em")
+			if num then return tonumber(num) end
+		end
+	end
+	return defvalue
+end
+
+io.enter_div = function(id)
+	if not io.hidden then
+		io.flush()
+		io.vspace_n(io.parse_em(id, "margin-top", 0))
+	end
+end
+
+io.leave_div = function(id)
+	if not io.hidden then
+		io.flush()
+		io.vspace_n(io.parse_em(id, "margin-bottom", 0))
+	end
+end
+
+io.enter_span = function(id) end
+io.leave_span = function() end
+
+io.enter_status = function(area, id)
+	io.line()
+	io.hidden = true
+end
+
+io.leave_status = function()
+	io.hidden = false
+end
+
+io.have_links = function() return false end
+io.enter_link = function(str) end
+io.leave_link = function() end
+io.enter_link_res = function(res) end
+io.leave_link_res = function() end
+io.enter_self_link = function() end
+io.leave_self_link = function() end
+
+io.leave_all = function()
+	io.line()
+	io.hidden = false
+end
+
+io.embed_res = function(res)
+	io.print("[")
+	io.print(res.alt)
+	io.print("]")
+end
+
+io.can_embed_res = function(res) return false end
+
+io.progressbar = function(p, total)
+	if not io.hidden then
+		local full
+		if io.width <= 0 then
+			full = 80 - 3
+		else
+			full = io.width - 3
+		end
+		local first = math.floor(full * (p / total) + 0.5)
+		local second = full - first
+		io.enter_div(-1)
+		io.print("[")
+		for _ = 1, first do io.print("=") end
+		for _ = 1, second do io.print(" ") end
+		io.print("]")
+		io.leave_div(-1)
+	end
+end
+
+io.trace = function(str)
+	if not io.hidden then
+		io.enter_div(-1)
+		w(str)
+		io.xpos = utf8_len(str)
+		io.newlines = 0
+		io.leave_div(-1)
+	end
+end
+
+io.script_on = function() return false end
+io.script_off = function() end
+io.script_active = function() return false end
+
+io.save = function(filedata)
+	local f = lua_io.open("saved-game.aasave", "wb")
+	if not f then return false end
+	local parts = {}
+	for i = 0, filedata.length - 1 do
+		parts[i + 1] = string.char(filedata[i])
+	end
+	f:write(table.concat(parts))
+	f:close()
+	return true
+end
+
+io.restore = function()
+	local data
+	local f = lua_io.open("saved-game.aasave", "rb")
+	if f then
+		local content = f:read("*a")
+		f:close()
+		if content then data = bytes_from_string(content) end
+	end
+	restore_status = aaengine.vm_restore(data)
+end
+
+io.have_styles = function() return false end
+io.have_color = function() return false end
+io.have_align = function() return false end
+
+local function add_tag()
+	if not io_tag_lines then return end
+	w("\n")
+	if status == aaengine.status.get_input then
+		w("> ")
+	elseif status == aaengine.status.get_key then
+		w(") ")
+	else
+		w("  ")
+	end
+end
+
+local function reconcile_restore()
+	if status == aaengine.status.restore and restore_status ~= nil then
+		status = restore_status
+		restore_status = nil
+	end
+end
+
+local function usage()
+	stdout:write("Usage: aamrun [OPTIONS] file.aastory\n")
+	stdout:write("    -s N            Set random seed.\n")
+	stdout:write("    -w N            Set screen width (default 80).\n")
+	stdout:write("    -h, --help      Show this message.\n")
+	stdout:write("    -v, -V          Show version and exit.\n")
+	stdout:write("    -T, --tag-lines Prepend output with \"  \", input with \"> \" or \") \".\n")
+	stdout:write("    -D, --dfrotz    Emulate dfrotz quirks.\n")
+end
+
+local seed, width, filename
+local show_version = false
+local show_help = false
+local positionals = 0
+
+local i = 1
+while i <= #arg do
+	local a = arg[i]
+	if a == "-s" then
+		i = i + 1; seed = tonumber(arg[i])
+	elseif a == "-w" then
+		i = i + 1; width = tonumber(arg[i])
+	elseif a == "-T" or a == "--tag-lines" then
+		io_tag_lines = true
+	elseif a == "-D" or a == "--dfrotz" then
+		quirks = true
+	elseif a == "-v" or a == "-V" then
+		show_version = true
+	elseif a == "-h" or a == "--help" then
+		show_help = true
+	else
+		filename = a
+		positionals = positionals + 1
+	end
+	i = i + 1
+end
+
+if show_version then
+	stdout:write("Å-machine Lua frontend version " .. VERSION .. "\n")
+	os.exit(0)
+end
+if positionals ~= 1 then
+	stderr:write("ERROR: Exactly one filename must be specified\n")
+	usage()
+	os.exit(1)
+end
+if show_help then
+	usage()
+	os.exit(0)
+end
+if seed == 0 then seed = nil end
+if width and width ~= 0 then io.width = width end
+
+local storyfile
+do
+	local f = lua_io.open(filename, "rb")
+	if not f then
+		stderr:write("ERROR: Unable to read file " .. filename .. "\n")
+		os.exit(1)
+	end
+	local content = f:read("*a")
+	f:close()
+	storyfile = bytes_from_string(content or "")
+end
+
+aaengine.prepare_story(storyfile, io, seed, true, false, false)
+io.styles = aaengine.get_styles()
+
+status = aaengine.vm_start()
+reconcile_restore()
+if status == aaengine.status.quit then
+	io.line()
+	io.flush()
+	os.exit(0)
+end
+add_tag()
+
+local function process_line(line)
+	if status == aaengine.status.get_key then
+		local cps = codepoints(line)
+		local ci = 0
+		while ci < cps.length and status == aaengine.status.get_key do
+			if io_tag_lines then w("  ") end
+			status = aaengine.vm_proceed_with_key(cps[ci])
+			reconcile_restore()
+			add_tag()
+			ci = ci + 1
+		end
+		if status == aaengine.status.get_key then
+			if io_tag_lines then w("  ") end
+			status = aaengine.vm_proceed_with_key(aaengine.keys.KEY_RETURN)
+			reconcile_restore()
+			add_tag()
+		end
+	elseif status == aaengine.status.get_input then
+		io.xpos = 0
+		io.pending_spaces = 0
+		io.newlines = quirks and 999 or 1
+		if io_tag_lines then w("  ") end
+		status = aaengine.vm_proceed_with_input(line)
+		reconcile_restore()
+		add_tag()
+	end
+
+	if status == aaengine.status.quit then
+		if quirks then io.par() else io.line() end
+		io.flush()
+		os.exit(0)
+	end
+end
+
+if is_terminal() then
+	while true do
+		local line = stdin:read("*l")
+		if line == nil then break end
+		line = line:gsub("\r$", "")
+		w(line)
+		w("\r\n")
+		process_line(line)
+	end
+else
+	local all = stdin:read("*a") or ""
+	local start = 1
+	while true do
+		local nl = all:find("\n", start, true)
+		if not nl then
+			if start <= #all then
+				local line = all:sub(start)
+				line = line:gsub("\r$", "")
+				w(line)
+				w("\r\n")
+				process_line(line)
+			end
+			break
+		end
+		local line = all:sub(start, nl - 1)
+		line = line:gsub("\r$", "")
+		w(line)
+		w("\r\n")
+		process_line(line)
+		start = nl + 1
+	end
+end
+
+io.line()
+io.flush()

--- a/test/aa-exercise/Makefile
+++ b/test/aa-exercise/Makefile
@@ -17,7 +17,7 @@ assemble:
 
 all: test
 
-test: test.js test.6502
+test: test.js test.6502 test.lua test.go
 
 test.js: aa-exercise.js.out
 	$(DIFF) aa-exercise.js.out aa-exercise.js.gold
@@ -31,7 +31,19 @@ test.6502: aa-exercise.6502.out
 aa-exercise.6502.out: aa-exercise.aastory $(AAMBOX) $(FRONTEND)
 	$(AAMBOX) -s 1234 $(FRONTEND) aa-exercise.aastory <aa-exercise.in >aa-exercise.6502.out
 
+test.lua: aa-exercise.lua.out
+	$(DIFF) aa-exercise.lua.out aa-exercise.lua.gold
+
+aa-exercise.lua.out: aa-exercise.aastory
+	luajit ../../src/lua/frontend.lua -s 1234 aa-exercise.aastory <aa-exercise.in >aa-exercise.lua.out
+
+test.go: aa-exercise.go.out
+	$(DIFF) aa-exercise.go.out aa-exercise.go.gold
+
+aa-exercise.go.out: aa-exercise.aastory
+	../../src/go/aamrun -s 1234 aa-exercise.aastory <aa-exercise.in >aa-exercise.go.out
+
 clean:
 	rm -f *.out
 
-.PHONY: all test test.js test.6502 clean
+.PHONY: all test test.js test.6502 test.lua test.go clean

--- a/test/aa-exercise/aa-exercise.go.gold
+++ b/test/aa-exercise/aa-exercise.go.gold
@@ -1,0 +1,82 @@
+Welcome to the Å-machine!
+
+This is a test suite designed to stress test the opcodes, and hopefully point
+out any bugs in a terp.
+
+This interpreter supports the following features:
+UNDO
+SAVEFILE
+QUIT
+
+Running tests:
+Choice backtrack: yes
+NOP: yes
+CONT SET: yes
+PROCEED: yes
+JMP: yes
+Multi-jump: yes
+Multi-query: yes
+Simple jump: yes
+Query: yes
+Tail call: yes
+Tail: yes
+Push ENV frame: yes
+Pop ENV frame: yes
+ENV pop proceed: yes
+Push CHO frame: yes
+Pop CHO frame: yes
+CHO pop push: yes
+Cut CHO frame: yes
+Get and set CHO frame: yes
+'() ASSIGN: yes
+Variable unification: yes
+Pair unification: yes
+Raw AUX push and pop: yes
+AUX push and pop: yes
+AUX pop check: yes
+AUX pop match: yes
+List splitting: yes
+Stoppable choice point: yes
+Store and load word: yes
+Store and load byte: yes
+Store and load value: yes
+Set and reset object flags: yes
+Unlink object field: yes
+Set object parent: yes
+Raw equality check: yes
+Bounded variable check: yes
+Empty list check: yes
+Number check: yes
+Pair check: yes
+Object check: yes
+Word check: yes
+Unrecognised word check: yes
+Unification check: yes
+(a > b) check: yes
+Equality check: yes
+Memory equality check: yes
+Object flag check: yes
+CWL check: yes
+Addition: yes
+Subtraction: yes
+Multiplication: yes
+Division: yes
+Division remainder: yes
+Random number generation: yes
+Number incrementation: yes
+Number decrementation: yes
+Raw incrementation: yes
+Raw decrementation: yes
+Displaying text: check below
+The (fixed) serial is 250101
+The quick brown fox jumps over the lazy dog,
+The dog thought the fox's exercise such a slog.
+While the fox trotted through the bog,
+The dog slept like a log.
+yes
+Persistent choicepoint environment: yes
+AUX list splitting: yes
+2-word comparison: yes
+Tail-call optimisation: yes
+
+Quitting the program...

--- a/test/aa-exercise/aa-exercise.lua.gold
+++ b/test/aa-exercise/aa-exercise.lua.gold
@@ -1,0 +1,87 @@
+Welcome to the Å-machine!
+
+This is a test suite designed to stress test the opcodes, and hopefully point
+out any bugs in a terp.
+
+This interpreter supports the following features:
+UNDO
+SAVEFILE
+QUIT
+
+Running tests:
+Choice backtrack: yes
+NOP: yes
+CONT SET: yes
+PROCEED: yes
+JMP: yes
+Multi-jump: yes
+Multi-query: yes
+Simple jump: yes
+Query: yes
+Tail call: yes
+Tail: yes
+Push ENV frame: yes
+Pop ENV frame: yes
+ENV pop proceed: yes
+Push CHO frame: yes
+Pop CHO frame: yes
+CHO pop push: yes
+Cut CHO frame: yes
+Get and set CHO frame: yes
+'() ASSIGN: yes
+Variable unification: yes
+Pair unification: yes
+Raw AUX push and pop: yes
+AUX push and pop: yes
+AUX pop check: yes
+AUX pop match: yes
+List splitting: yes
+Stoppable choice point: yes
+Store and load word: yes
+Store and load byte: yes
+Store and load value: yes
+Set and reset object flags: yes
+Unlink object field: yes
+Set object parent: yes
+Raw equality check: yes
+Bounded variable check: yes
+Empty list check: yes
+Number check: yes
+Pair check: yes
+Object check: yes
+Word check: yes
+Unrecognised word check: yes
+Unification check: yes
+(a > b) check: yes
+Equality check: yes
+Memory equality check: yes
+Object flag check: yes
+CWL check: yes
+Addition: yes
+Subtraction: yes
+Multiplication: yes
+Division: yes
+Division remainder: yes
+Random number generation: yes
+Number incrementation: yes
+Number decrementation: yes
+Raw incrementation: yes
+Raw decrementation: yes
+Displaying text: check below
+The (fixed) serial is 250101
+The quick brown fox jumps over the lazy dog,
+The dog thought the fox's exercise such a slog.
+While the fox trotted through the bog,
+The dog slept like a log.
+yes
+Persistent choicepoint environment: yes
+AUX list splitting: yes
+2-word comparison: yes
+Tail-call optimisation: 
+no (unsupported)
+This interpreter supports the following features:
+UNDO
+SAVEFILE
+QUIT
+
+Quitting the program...

--- a/test/body_not_status/Makefile
+++ b/test/body_not_status/Makefile
@@ -13,7 +13,7 @@ $(FRONTEND):
 
 all: test
 
-test: test.js test.6502
+test: test.js test.6502 test.lua test.go
 
 test.js: body_not_status.js.out
 	$(DIFF) body_not_status.js.out body_not_status.gold
@@ -27,7 +27,19 @@ test.6502: body_not_status.6502.out
 body_not_status.6502.out: body_not_status.aastory $(AAMBOX) $(FRONTEND)
 	$(AAMBOX) -s 1234 $(FRONTEND) body_not_status.aastory <body_not_status.in >body_not_status.6502.out
 
+test.lua: body_not_status.lua.out
+	$(DIFF) body_not_status.lua.out body_not_status.gold
+
+body_not_status.lua.out: body_not_status.aastory
+	luajit ../../src/lua/frontend.lua -s 1234 body_not_status.aastory <body_not_status.in >body_not_status.lua.out
+
+test.go: body_not_status.go.out
+	$(DIFF) body_not_status.go.out body_not_status.gold
+
+body_not_status.go.out: body_not_status.aastory
+	../../src/go/aamrun -s 1234 body_not_status.aastory <body_not_status.in >body_not_status.go.out
+
 clean:
 	rm -f *.out
 
-.PHONY:		all test test.js test.6502 clean
+.PHONY: all test test.js test.6502 test.lua test.go clean

--- a/test/body_not_status/body_not_status.go.gold
+++ b/test/body_not_status/body_not_status.go.gold
@@ -1,0 +1,4 @@
+
+Outside line 1.
+Outside line 2.
+Outside line 3. Outside line 4.

--- a/test/body_not_status/body_not_status.lua.gold
+++ b/test/body_not_status/body_not_status.lua.gold
@@ -1,0 +1,4 @@
+
+Outside line 1.
+Outside line 2.
+Outside line 3. Outside line 4.

--- a/test/gosling/Makefile
+++ b/test/gosling/Makefile
@@ -16,7 +16,7 @@ $(FRONTEND):
 
 all: test
 
-test: test.js test.6502
+test: test.js test.6502 test.lua test.go
 
 test.js: gosling.js.out
 	$(DIFF) gosling.js.out gosling.js.gold
@@ -30,7 +30,19 @@ test.6502: gosling.6502.out
 gosling.6502.out: gosling.aastory $(AAMBOX) $(FRONTEND)
 	$(AAMBOX) -s 1234 $(FRONTEND) gosling.aastory <gosling.in >gosling.6502.out
 
+test.lua: gosling.lua.out
+	$(DIFF) gosling.lua.out gosling.lua.gold
+
+gosling.lua.out: gosling.aastory
+	luajit ../../src/lua/frontend.lua -s 1234 gosling.aastory <gosling.in >gosling.lua.out
+
+test.go: gosling.go.out
+	$(DIFF) gosling.go.out gosling.go.gold
+
+gosling.go.out: gosling.aastory
+	../../src/go/aamrun -s 1234 gosling.aastory <gosling.in >gosling.go.out
+
 clean:
 	rm -f *.out
 
-.PHONY: all test test.js test.6502 clean
+.PHONY: all test test.js test.6502 test.lua test.go clean

--- a/test/gosling/gosling.go.gold
+++ b/test/gosling/gosling.go.gold
@@ -1,0 +1,4748 @@
+
+
+Dear me. What happened?
+
+Your vision is a bit blurry. Nothing hurts, at least. You can hear Watson
+barking. It’s bright, very bright, so it must be morning.
+
+The last thing you remember was coming down the stairs. Did you stumble and
+fall? Nigel would fuss and scold you over it, saying to be more careful at your
+age. Things are coming into focus now...
+
+Oh. Oh no.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+Your body lies at the bottom of the stairs.
+
+Ever-faithful Watson is crouched over it, whimpering faintly.
+
+> * *** Opening scene ***
+> x watson
+Watson is a wonderfully intelligent collie, and he’s been oh so much help in
+your past investigations. You’ve trained him quite well, if you do say so
+yourself.
+
+> x me
+Well, you feel fine. You don’t look any different, at least to your eyes. You
+seem to be wearing your favourite dress, the one with the pattern of little
+flowers on it, which you certainly weren’t when you fell. This sort of existence
+will certainly take some getting used to.
+
+“What’s this then?” Inspector Hughes strides into the hall, flanked by a little
+gaggle of lower-ranking constabulary. “Bloody hell...so this is how the old bird
+finally went. Never thought she’d meet her end in an accident, not after a
+career of dealing with crime.”
+
+> north
+You focus your thoughts, and try to go north, and yet nothing seems to happen...
+
+Watson looks up at you and blinks in surprise.
+
+Constable Phillips sets to work marking out where you’ve fallen, while his
+colleague Davis examines your body. Hughes strokes his moustache as he surveys
+the stairs. “Looks like an open-and-shut case. Look at ’er nightdress. Must have
+got up in the morning and took a tumble down the stairs.”
+
+The morning? No...no, that’s not right. It was just past midnight...you were
+trying to find your way downstairs with a torch...you had to get to...the
+telephone, wasn’t it? Everything is so fuzzy...
+
+> zxcvbn
+Your mind is still a bit fuzzy, and you can’t quite make sense of that idea at
+the moment.
+
+The Inspector turns to go. “For all we know, that bloody dog of hers might have
+given her a push.” Watson?! He would never! “I’ll get the coroner in. Davis, get
+a report written up and sent to Biddlecombe by the end of today. Looks like it
+really was an accident in the end.”
+
+No! That’s it! You woke up, you recognised those symptoms...the choking feeling,
+the burning in your stomach—how could you ever mistake the signs of white
+arsenic poisoning?
+
+You tried to get to the telephone, but the electricity had gone out again. You
+were making your way down with a torch...that’s it, the torch would prove it was
+the middle of the night, not the morning, now wouldn’t it? Now where in heaven’s
+name did it get off to?
+
+> watson, north
+Watson perks up, about to go north—until one of the constables grabs him by the
+collar.
+
+“For once, a nice, open-and-shut case.”
+
+Oh, that small-minded Inspector! Even a perfunctory investigation should find
+signs of poison! But he’s so sure it was your ordinary morning routine that he
+won’t even consider the possibility.
+
+> hughes, wait
+Inspector Hughes shows not the slightest hint of recognition. You might as well
+be talking to a brick wall.
+
+Hughes strides out while Davis finishes up her measurements. “And get that
+bloody creature out of our way!” Suddenly Phillips has grabbed Watson by the
+collar and is dragging him off to the sitting room.
+
+Watson’s eyes are fixed on you as he’s pulled away, whimpering and scrabbling at
+the carpet. Even if the police won’t listen, Watson will! So you imagine
+yourself following him, and the world around you changes... 
+
+
+Miss Gosling’s Last Case
+An interactive mystery by Daniel M. Stelzer.
+Release 3. Serial number 260201.
+VERSION. Library version 0.46 (modified).
+
+Sitting room
+The big south-facing windows in this room give it the best light in the house,
+so you always take your breakfast and tea here. Normally it would be half-filled
+with your potted plants, but you took those out for Alfred to look at last week,
+and you haven’t had a moment to move them back in yet. The room continues west
+from here, while the hall leads north over a small step to the rest of the
+house.
+
+Watson’s lead has been looped over the post of your favourite chair, keeping him
+from interfering in the crime scene.
+
+A rubber ball lies on the floor nearby.
+
+Your ill-conceived binocular stand is fixed in front of the bay window.
+
+In this state, you can’t do much yourself. The best you can do is LOOK around,
+EXAMINE something, or RECALL a person.
+
+Your score has gone up by one point.
+
+Exits: north west
+
+> * *** Test parser errors ***
+> zxcvbn
+Watson looks up at you with a sad little whine. He has no idea how to “zxcvbn”.
+
+Exits: north west
+
+> x zxcvbn
+Watson understands the instruction to examine something, but doesn’t understand
+what. In particular, the word “zxcvbn” seems to be confusing him.
+
+Exits: north west
+
+> sing zxcvbn
+Watson wags his tail happily, no comprehension at all in his eyes. In
+particular, the word “zxcvbn” seems to be confusing him.
+
+Exits: north west
+
+> * *** Escape ***
+> x ball
+It’s a hard rubber ball, the sort Watson loves to chew on. You’ve put a treat
+inside it for him to try to work out, a little puzzle for him to solve.
+
+Since you EXAMINE so many things in your investigations, you can abbreviate it
+to X.
+
+For anything more elaborate than that, you’ll have to rely on Watson. For
+example, tell him to TAKE THE BALL.
+
+Exits: north west
+
+> watson, take ball
+(You don’t have to mention Watson’s name explicitly; he’s the only one around
+who can hear your commands, after all.)
+Watson opens his mouth and carefully scoops up the rubber ball.
+
+If you say INVENTORY, Watson will show you what he’s holding.
+
+Exits: north west
+
+> inventory
+Watson holds up the rubber ball proudly for your inspection. His collar keeps
+him from moving more than four feet from the chair.
+
+“Take inventory” is one of the stranger tricks you’ve taught him, but it just
+feels more professional than “show me”.
+
+He can only hold one thing in his mouth at a time, but he’s very good at
+manipulating objects in various ways.
+
+You’ve taught Watson plenty of ways to manipulate objects: he can TAKE and DROP
+them, but also PUSH, PULL, OPEN, CLOSE, CLIMB, and SEARCH them, among others.
+
+Exits: north west
+
+> push ball
+Watson bats at the toy, but the treat doesn’t come out. It’ll take more force
+than that.
+
+The text will usually imply what actions will be useful for certain objects. But
+if you’re not sure what to do with something, HELP [OBJECT] (e.g. HELP BALL)
+will give suggestions.
+
+A few special commands are always available:
+    UNDO to take back your last action
+    SAVE and RESTORE to save your game
+    THINK to list the puzzles you’re facing and the ones you’ve already solved
+    HELP for a full list of commands
+    ABOUT for information about the game
+    MAP to see a map of the house
+    HINTS if you’re stuck on a puzzle
+    RESTART to start over from the beginning, or QUIT to exit the game
+completely
+
+Exits: north west
+
+> bite ball
+Watson gnaws happily at the toy, chomping on it at different angles until the
+treat inside pops out!
+
+Exits: north west
+
+> drop ball
+Watson sets the rubber ball carefully under your comfortable chair.
+
+Exits: north west
+
+> eat treat
+Watson doesn’t need telling twice. Soon there’s nothing left of the treat.
+
+Exits: north west
+
+> push chair
+In what direction?
+
+Exits: north west
+
+> w
+Watson tugs on his lead, and the chair on its wheels glides smoothly along
+behind. You drift after him to the west.
+
+The rubber ball proves too small to foul the wheels, and is left behind.
+
+Evening room
+Really this is just another part of the sitting room, but when the house was
+modernised and electrified, the west half was lit up and the east half left to
+its natural light. So you’ve taken to calling this the evening room, a
+comfortable place to sit after supper when you don’t want to brave the stairs to
+the library. The stairs themselves end to the north, up a small step.
+
+A layer of police tape blocks off the door to the north.
+
+Watson’s lead has been looped over the post of your favourite chair, keeping him
+from interfering in the crime scene.
+
+Your collection of mystery novels is kept on a high shelf, out of Watson’s
+reach.
+
+Some people do think it’s odd that you’ve taught him compass directions, but he
+would always get so confused between your right and his right. This just works
+out better all around.
+
+Exits: (north) east
+
+> x shelf
+You made sure to put the bookshelf high enough that Watson couldn’t reach it.
+It’s not that he’d chew on the books; no, he’s far too well-trained for that.
+But he has a tendency to knock things over in his excitement. Now your paperback
+murder mysteries are both safe, and within easy reach. Easy reach for a human,
+at least.
+
+Exits: (north) east
+
+> climb shelf
+Watson stretches his body, trying to reach the bookshelf, then settles back with
+a sad whimper.
+Messages like this, telling you why you can’t do something, often indicate
+puzzles to be solved. In this case, the shelf is too high for Watson to reach;
+perhaps he could reach it if he were higher up?
+
+Exits: (north) east
+
+> jump on chair
+Watson leaps up onto your comfortable chair.
+
+Exits: (north) east
+
+> jump on shelf
+Watson leaps up onto the bookshelf.
+
+Exits: (north) east
+
+> books
+Most of your books are kept in the library upstairs, of course, but you’ve
+turned this room into such a lovely place to read in the evenings, and the
+stairs have been getting harder to manage every year. So you’ve started a
+collection of paperback mystery novels down here, for when you’re in the mood
+for some light reading.
+
+Exits: (north) east
+
+> push books
+Watson gives the books a vigorous push, sending them off the edge to land on
+your comfortable chair.
+
+Exits: (north) east
+
+> down
+Watson leaps off the bookshelf and lands on your comfortable chair.
+
+Exits: (north) east
+
+> down
+Watson leaps off your comfortable chair.
+
+Exits: (north) east
+
+> push books
+The books tumble around and under the chair’s wheels in a messy pile.
+
+Exits: (north) east
+
+> east
+(pulling your comfortable chair along)
+Watson lopes back east, pulling the chair behind him...until it catches, pulling
+him up short. One of your books is trapped under the wheel! But he keeps
+pulling, and between the lead on the post pulling it forward and the caught
+wheel holding it back, it topples forward with a grand, stately crash.
+
+With the top posts now resting on the floor, the lead is within Watson’s reach,
+and with a look of doggy triumph he pulls it free!
+
+Watson is free, and it’s time to solve this case! First, you’ll have to get back
+to the scene of the crime: if you can find evidence that this happened at
+midnight instead of in the morning, maybe that will convince the constables that
+it wasn’t an accident.
+
+Good luck, detective!
+
+Your score has gone up by one point.
+
+Exits: (north) east
+
+> west
+Watson turns to look westward, then looks back to you with a puzzled whine. He
+doesn’t see any way to go that direction.
+
+Exits: (north) east
+
+> north
+Watson noses at the police tape, but can’t find a way past.
+
+Exits: (north) east
+
+> tape
+Bright yellow tape meant to keep people out of a crime scene. It’s thoroughly
+blocking the north door.
+
+Exits: (north) east
+
+> bite tape
+Watson chomps down on the police tape, taking a big chunk out of the middle and
+chewing it happily while the ends flutter to the ground.
+
+Exits: north east
+
+> north
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A layer of police tape blocks off the door to the north.
+
+Your body lies at the bottom of the stairs.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+Exits: (north) south east (west)
+
+> bite tape
+Watson chomps down on the police tape, taking a big chunk out of the middle and
+chewing it happily while the ends flutter to the ground.
+
+Exits: north south east (west)
+
+> tape to the north
+Bright yellow tape meant to keep people out of a crime scene. This one has been
+chewed to bits and won’t keep anyone out of anything.
+
+Exits: north south east (west)
+
+> north
+The dining room is that way, but best avoid it for now. If Watson makes a
+nuisance of himself, the constables will secure him better next time—you need to
+get to the crime scene and prove it was murder!
+
+Exits: north south east (west)
+
+> * *** Find torch ***
+> x torch
+Watson understands the instruction to examine something, but doesn’t understand
+what.
+
+Exits: north south east (west)
+
+> vent
+Things are always falling and getting lost in it. You kept meaning to put some
+sort of screen over it, but, well, you never quite found the time.
+
+Exits: north south east (west)
+
+> look in vent
+Watson works one paw into the grate and fishes around in there. But he turns up
+nothing but dust.
+
+Exits: north south east (west)
+
+> phone
+It is, even you have to admit, rather old-fashioned to have a telephone niche.
+Most people keep their telephones on tables now. But you always liked how it
+looked, so when you upgraded to a modern telephone, you kept it in the old
+niche. Things do occasionally roll under it and get lost.
+
+Exits: north south east (west)
+
+> look in phone
+Watson snuffles at the telephone niche, but there’s no room inside it.
+
+Exits: north south east (west)
+
+> look under phone
+Watson noses under the telephone niche, fishing around with one paw. But he
+retreats a moment later, nothing found.
+
+Exits: north south east (west)
+
+> newspaper
+You’ve gathered up the old ones here for Nigel to take the next time he comes
+by. There’s something he does with them, and he always takes them off your hands
+when they start piling up. It’s possible something could roll behind them.
+
+Exits: north south east (west)
+
+> search newspaper
+Watson pushes his nose into the stack, feeling around for anything behind it.
+Something clanks—he’s found your torch!
+
+Exits: north south east (west)
+
+> look in vent
+Watson snuffles around inside the grate, but turns up nothing.
+
+Exits: north south east (west)
+
+> get torch
+Best not to move it yet. The constables need to see that you dropped it when you
+fell, rather than Watson bringing it in later.
+
+Exits: north south east (west)
+
+> turn off torch
+Best not to move it yet. The constables need to see that you dropped it when you
+fell, rather than Watson bringing it in later.
+
+Exits: north south east (west)
+
+> bark
+Watson lets out a loud bark that echoes through the house, then looks up at you
+for approval, tail wagging happily.
+
+Off in the dining room, Davis sets aside her work with a sigh.
+
+Exits: north south east (west)
+
+> z
+Watson tries as hard as he can to demonstrate patience.
+
+Davis makes her way from the dining room to the bottom of the stairs (where you
+are).
+
+Exits: north south east (west)
+
+> z
+Watson tries as hard as he can to demonstrate patience.
+
+Davis scans the room for anything amiss. Nothing, nothing...then Watson barks
+again, sniffing at the stack of newspapers, and she takes a closer look.
+
+“What’s this? A torch?” She fishes it out, turning it over in her hand. “Still
+on, cells still good. Why would she ’ave had a torch at nine in the morning on a
+bright sunny day?”
+
+You watch as it clicks in her head, and she hurries to the telephone.
+“Something’s wrong here. I better ring the Inspector and tell the boys at the
+lab...” 
+
+
+“...results back from Fletcher at the lab. The Marsh test was positive. Arsenic
+poisoning, without a doubt.” Well, obviously; you could have told them yourself
+if you’d made it to the phone in time. The constables are gathered around your
+dining room table now, listening as Davis summarises the situation. “Given her
+experience with poisons, it’s unlikely this was an accident. I think we need to
+seriously consider the possibility of foul play.”
+
+Hughes is tugging at his moustache. “Hmph. Quite. Good catch with the torch;
+would have been a disgrace for the department if we’d missed that. Now that we
+know, we’re not going to leave a single stone unturned. Do we have a motive?
+Inheritance?”
+
+“It seems likely. We found a will in her library. Various bequests to charities
+and organizations, and four specific people who will benefit quite, well,
+substantially.”
+
+“Opportunity?”
+
+Phillips clears his throat. “I’ve been going through her diary.” Inevitable, you
+suppose—you would have done the same—but rude nonetheless. “Fletcher says death
+occurred between midnight and 2:00 AM, and the poison must have been
+consumed—orally—somewhere between four and twelve hours before that. That gives
+all four of them the opportunity.”
+
+Hughes furrows his bushy eyebrows. “Four to twelve hours? She had lunch with me
+at the King’s Arms yesterday. I’ll be asking some questions around there.”
+
+Davis lays her papers out on the table. “Each of those people had access to her
+food or drink within that timespan.” (“Or medication,” Phillips adds.)
+
+“First is her nephew Nigel. That afternoon, he was helping her go through some
+records in her attic. It seems she’s got a sort of a laboratory up there, and he
+could have tampered with her chemicals.” Nigel? He’d never have the stomach for
+it.
+
+“Second is Mrs Charlotte Peabody. Gosling had dinner with her that night, and
+specifically mentioned a one-peck bundle of carrots Peabody brought from the
+farmer’s market. Gosling ate plenty, but Peabody didn’t touch them.” Well, of
+course. Lottie can’t stand the smell of carrots, that’s why she gave them to you
+in the first place. “We need to find and test the remaining carrots.”
+
+“Third is Alfred Tucker, her gardener.” Preposterous. “After supper she drank an
+herbal tea made with green roses. They must have been gathered from one of her
+gardens. Arsenious oxide is sometimes used as a weed killer. If Tucker applied
+some to the flower petals, she’d be poisoned some time later, when she finally
+made tea from those ones.” Not at all his style. “We need to find the bush she
+took these from and test if it’s absorbed anything.”
+
+“Finally, there’s her aide, Emily Morris.” Emily? The girl never had a malicious
+thought in her life. “She arranged for all her medications, and could easily
+have tampered with them.”
+
+Hughes stands, smoothing out his now-frazzled moustache again. “Right then!
+Biddlecombe will be setting up in the library to handle communications.
+Phillips, I want you to find and test those medications first thing. They have
+to be somewhere in her room. Davis, track down the details on those suspects.
+We’ll be asking them a few questions. We’ll have this case cracked right open
+before it hits the papers!” He glares down at Watson, who’s snuffling curiously
+at his hand. “And get that bloody beast out of here!”
+
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+Your score has gone up by one point.
+
+Exits: south west southeast
+
+> * *** Dining Room ***
+> w
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+On the table are a tape recorder and your torch.
+
+Davis sets her sandwich aside as she pulls out another page.
+
+Exits: south east
+
+> cabinet
+You would never call yourself vain, or overly proud of your success. But you
+could never resist showing off a few of your best and most notable
+accomplishments. Right now, you have the evidence from the Disgybl Gwydion case
+laid out here, with some of your other cases displayed in the reception room and
+the upstairs balcony.
+
+Davis takes a bite of her sandwich.
+
+Exits: south east
+
+> evidence
+You normally wouldn’t include an unsolved case here...much less one where the
+constables never proved there was even a crime committed at all. But it did get
+a lot of press, and it did revolve around your house—and you kicked off the
+whole thing when you found this notebook during renovations. It seems one of the
+previous occupants called himself “Disgybl Gwydion”, claimed to be heir to the
+ancient Druids, performing strange rituals in the flower gardens and seeking
+eternal life.
+
+...ancestral spirits / lares and penates, bound through belief, worship? / no,
+alchemical process-congelation of the soul! See Petrus Catadesmicus, Liber
+Animarum / but held to the anchor, how to move and act? / Kizzuwatnan ritual,
+the kuwac hapanza - Father’s Encyclopedia vol K p 197 - replaces the nails or
+spikes! / must be in the right place... Perhaps the translation the constables
+gave you is faulty, or perhaps (as you’ve long suspected) it’s just nonsense.
+But it’s a reminder that sometimes there just aren’t answers to be found
+anywhere in this world.
+
+Davis sets her sandwich aside as she pulls out another page.
+
+Exits: south east
+
+> table
+It can seat six comfortably, but nowadays your dinners are usually for one or
+two. So you’ve made sure it’s not too big for that.
+
+Your torch is on the table.
+
+Davis flips one of the sheets over, tapping her pen against the table.
+
+Exits: south east
+
+> paperwork
+Poor dear, this looks like a real mess of paperwork. It can be much easier to
+work on cases when you’re not officially part of the constabulary.
+
+Davis sets her sandwich aside as she pulls out another page.
+
+Exits: south east
+
+> davis
+You’ve always seen promise in Davis, from when she was just starting out as a
+bright-eyed new recruit. But she’s got a certain earnestness you’ve never quite
+been able to sway her from. Now she spends most of her time taking every menial
+task that’s pushed onto her, thinking straightforward honesty is the best path
+to promotion. Eventually, something is bound to shake her enough to take some
+initiative of her own...or at least, that was always your hope.
+
+Davis flips one of the sheets over, tapping her pen against the table.
+
+Exits: south east
+
+> * *** Access Garden ***
+> get sandwich
+Watson opens his mouth and carefully plucks the sandwich off the table.
+
+“Oi! What’s that all about?” Davis blinks in surprise as her food is snatched
+away right in front of her eyes. She rises to her feet, ready to give chase!
+
+Exits: south east
+
+> show sandwich
+To whom?
+
+Exits: south east
+
+> davis
+Constable Davis looks sadly at her mangled sandwich, and unceremoniously
+disposes of it. She does give Watson a little pet of appreciation, though.
+
+Exits: south east
+
+> z
+Watson tries as hard as he can to demonstrate patience.
+
+Davis settles back into her chair and returns to work. Now bereft of her
+sandwich, she pulls a biscuit from a pack.
+
+Exits: south east
+
+> get biscuit
+Watson opens his mouth and carefully plucks the biscuit off the table.
+
+“Oi! What’s that all about?” Davis blinks in surprise as her food is snatched
+away right in front of her eyes. She rises to her feet, ready to give chase!
+
+Exits: south east
+
+> eat biscuit
+Watson doesn’t need telling twice. Soon there’s nothing left of the biscuit.
+
+“Gotcha!” Davis has finally cornered Watson, forcing him to open his mouth...to
+find no trace left of her food. Watson looks much happier than she does as she
+turns to leave, empty-handed.
+
+Exits: south east
+
+> z
+Watson tries as hard as he can to demonstrate patience.
+
+Exits: south east
+
+> z
+Watson tries as hard as he can to demonstrate patience.
+
+Davis settles back into her chair and returns to work.
+
+Exits: south east
+
+> get biscuit
+Watson opens his mouth and carefully plucks the biscuit off the table.
+
+“Oi! What’s that all about?” Davis blinks in surprise as her food is snatched
+away right in front of her eyes. She rises to her feet, ready to give chase!
+
+Exits: south east
+
+> e
+Watson scampers east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+Davis follows from the dining room to the kitchen (where you are), in hot
+pursuit.
+
+Exits: south west southeast
+
+> z
+Watson tries as hard as he can to demonstrate patience.
+
+“Gotcha!” Davis has finally cornered Watson, forcing him to open his mouth. She
+looks sadly at what’s become of her biscuit, and disposes of it as she turns to
+leave.
+
+Exits: south west southeast
+
+> w
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis’s seat stands conspicuously vacant.
+
+On the table are a tape recorder and your torch.
+
+Exits: south east
+
+> z
+Watson tries as hard as he can to demonstrate patience.
+
+Davis makes her way from the kitchen to the dining room (where you are).
+
+Exits: south east
+
+> z
+Watson tries as hard as he can to demonstrate patience.
+
+Davis settles back into her chair and returns to work.
+
+Exits: south east
+
+> get biscuit
+Watson opens his mouth and carefully plucks the biscuit off the table.
+
+“Oi! What’s that all about?” Davis blinks in surprise as her food is snatched
+away right in front of her eyes. She rises to her feet, ready to give chase!
+
+Exits: south east
+
+> e
+Watson scampers east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+Davis follows from the dining room to the kitchen (where you are), in hot
+pursuit.
+
+Exits: south west southeast
+
+> se
+Watson scampers southeast, and you drift along behind.
+
+Reception room
+You designed this room specifically for uninvited guests. Back when the front
+door was at the west end of the house, they’d have to wait awkwardly outside
+until you had the sitting room or dining room in order. Now, there’s a place to
+sit and take tea with them at a moment’s notice—and admire the framed case
+reports on the wall—and that can make witnesses ever so much more willing to
+open up. What used to be the back door of the house leads northwest to the
+kitchen, and the new front door leads out to the south.
+
+Today’s mail is scattered across the floor.
+
+Davis follows from the kitchen to the reception room (where you are), in hot
+pursuit.
+
+Exits: (south) northwest
+
+> eat biscuit
+Watson doesn’t need telling twice. Soon there’s nothing left of the biscuit.
+
+“Gotcha! Huh?” Davis looks down at Watson, then up at the front door. He lets
+his tail droop and gives her his best whine.
+
+“You want out, then? Here you go. That should get you off my arse for a bit.”
+She flips the lock and pushes the door open before retreating, bereft of food.
+
+Your score has gone up by one point.
+
+Exits: south northwest
+
+> * *** In Garden ***
+> s
+Watson saunters out the front door, and you drift along behind.
+
+Veranda
+A little refuge from the weather, for when you want the fresh outdoor air
+without all the sun and the rain, between the front door to the north and the
+lawn to the south.
+
+A bin in the corner collects any stray glass for recycling.
+
+Exits: north south
+
+> pull bin north
+Watson maneuvers the bin carefully north, with you following behind.
+
+Reception room
+You designed this room specifically for uninvited guests. Back when the front
+door was at the west end of the house, they’d have to wait awkwardly outside
+until you had the sitting room or dining room in order. Now, there’s a place to
+sit and take tea with them at a moment’s notice—and admire the framed case
+reports on the wall—and that can make witnesses ever so much more willing to
+open up. What used to be the back door of the house leads northwest to the
+kitchen, and the new front door leads out to the south.
+
+The recycling bin has been pushed here, looking rather out of place.
+
+Constable Davis is here, looking rather frazzled.
+
+Today’s mail is scattered across the floor.
+
+Davis makes her way from the reception room (where you are) to the kitchen.
+
+Exits: south northwest
+
+> push bin northwest
+Watson maneuvers the bin carefully northwest, with you following behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The recycling bin has been pushed here, looking rather out of place.
+
+Constable Davis is here, looking rather frazzled.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+Davis makes her way from the kitchen (where you are) to the dining room.
+
+Exits: south west southeast
+
+> push bin south
+Watson maneuvers the bin carefully south, with you following behind.
+
+Hall
+This narrow hallway is right at the centre of the house, linking the sitting
+room to the south to the kitchen to the north. To the west, dark stairs lead
+down to the cellar, and to the east used to be a closet until you had it turned
+into a tiny little lavatory.
+
+The recycling bin has been pushed here, looking rather out of place.
+
+Davis settles back into her chair and returns to work. She reaches for a
+biscuit, but the pack is empty. She disposes of it with a sigh.
+
+Exits: north south west
+
+> push bin south
+Watson maneuvers the bin carefully south, with you following behind.
+
+Sitting room
+The big south-facing windows in this room give it the best light in the house,
+so you always take your breakfast and tea here. Normally it would be half-filled
+with your potted plants, but you took those out for Alfred to look at last week,
+and you haven’t had a moment to move them back in yet. The room continues west
+from here, while the hall leads north over a small step to the rest of the
+house.
+
+The recycling bin has been pushed here, looking rather out of place.
+
+You see a rubber ball here.
+
+Your ill-conceived binocular stand is fixed in front of the bay window.
+
+Exits: north west
+
+> look through window
+From this angle, you have a beautiful view of the tea garden, with its six beds
+arranged around the fountain in the center. The lavender in the fountain is a
+beautiful deep blue, but to your eyes the rest of the plants are a uniform
+yellowish colour—you’ve never been any better than Watson at distinguishing reds
+from yellows from greens.
+
+  NW  NE  
+W   <>   E
+  SW  SE  
+
+Exits: north west
+
+> stand
+Watson thumps his tail, about to spring into action. Did you want him to:
+1. examine the binocular stand, or
+2. stand up?
+(Type the corresponding number)
+
+> 1
+You’d set up a little stand in front of your best window, hoping to attach your
+binoculars to it for birdwatching. But then it never quite worked, because you
+always wanted to move them around too much; they’re much better for spying on
+people than birds. Now it just collects dust while you try to think of something
+better to put on it.
+
+Exits: north west
+
+> x bin
+Alfred’s been so very into recycling recently, and he’s asked you to collect any
+stray glass you don’t need; he picks it up every week or so for processing.
+
+A squat bottle is in the bin.
+
+A narrow bottle is in the bin.
+
+Exits: north west
+
+> put squat on stand
+(first attempting to take the squat bottle)
+Watson opens his mouth and carefully plucks the squat bottle out of the bin.
+
+Watson sets the squat bottle carefully on the binocular stand.
+
+Exits: north west
+
+> look through squat
+Looking through the red glass, the garden beds in the northwest, northeast,
+west, and east are a vibrant white, while the ones in the centre, southwest, and
+southeast are featureless black.
+
+  WW  WW  
+WW  BB  WW
+  BB  BB  
+
+Exits: north west
+
+> put narrow on stand
+(first attempting to take the narrow bottle)
+Watson opens his mouth and carefully plucks the narrow bottle out of the bin.
+
+Watson sets the narrow bottle carefully on the binocular stand.
+
+Exits: north west
+
+> look through narrow
+Looking through the green glass, the garden beds in the northeast, east,
+southwest, and southeast are a vibrant white, while the ones in the centre,
+northwest, and west are featureless black.
+
+  BB  WW  
+BB  BB  WW
+  WW  WW  
+
+Your score has gone up by one point.
+
+Exits: north west
+
+> n
+Watson saunters north, and you drift along behind.
+
+Hall
+This narrow hallway is right at the centre of the house, linking the sitting
+room to the south to the kitchen to the north. To the west, dark stairs lead
+down to the cellar, and to the east used to be a closet until you had it turned
+into a tiny little lavatory.
+
+Exits: north south west
+
+> n
+Watson saunters north, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+Exits: south west southeast
+
+> se
+Watson saunters southeast, and you drift along behind.
+
+Reception room
+You designed this room specifically for uninvited guests. Back when the front
+door was at the west end of the house, they’d have to wait awkwardly outside
+until you had the sitting room or dining room in order. Now, there’s a place to
+sit and take tea with them at a moment’s notice—and admire the framed case
+reports on the wall—and that can make witnesses ever so much more willing to
+open up. What used to be the back door of the house leads northwest to the
+kitchen, and the new front door leads out to the south.
+
+Today’s mail is scattered across the floor.
+
+Exits: south northwest
+
+> s
+Watson saunters out the front door, and you drift along behind.
+
+Veranda
+A little refuge from the weather, for when you want the fresh outdoor air
+without all the sun and the rain, between the front door to the north and the
+lawn to the south.
+
+Exits: north south
+
+> s
+Watson saunters south, and you drift along behind.
+
+Lawn
+It’s really not big enough to be called the grounds, but you’ve always been
+proud of your lawn and gardens, encircling the house on all sides. The most
+important one right now is your tea garden, down to the south; the veranda is
+back to the north.
+
+Today’s newspaper lies in front of the porch steps.
+
+Exits: north south
+
+> s
+Watson saunters south, and you drift along behind.
+
+Tea garden, centre
+Your tea garden is nestled deep in the foundation of the old ruins, the stone
+walls rising up on every side to give the plants just the perfect amount of
+sunlight and shade. Here at the centre is where you placed that lovely fountain,
+and a sturdy chair, to sit in while you contemplate your options.
+
+The garden beds themselves are arranged in a ring around you, and the path north
+leads back to the lawn. You have a lovely view of the whole thing from your
+sitting room.
+
+On the garden chair are a pair of gardening gloves.
+
+Exits: north east west northeast northwest southwest southeast
+
+> x chair
+The perfect place to sit and appreciate the gardens.
+
+A pair of gardening gloves has been left on the chair.
+
+Exits: north east west northeast northwest southwest southeast
+
+> x gloves
+Alfred must have left them here, intending to keep working on these beds
+tomorrow. He’s a diligent, hard-working man, and you’ve never known him to take
+shortcuts on his work; he prefers to handle things with his own two hands.
+
+Exits: north east west northeast northwest southwest southeast
+
+> alfred
+Alfred Tucker has been your gardener for years. Ever diligent, with a good eye
+for aesthetics; it’s thanks to him that the colours of your flower beds go
+together so nicely. You could imagine him committing murder, perhaps, if he had
+the right motivation—but he would do it in anger, with his own hands. Cold,
+impersonal poison is not his style.
+
+Unfortunately, he isn’t anywhere near your house at the moment.
+
+Exits: north east west northeast northwest southwest southeast
+
+> ne
+Watson saunters northeast, and you drift along behind.
+
+Tea garden, northeast
+The garden bed under the old walls is just as neat and tidy as ever, as it
+should be. The calendula is flourishing, ready for your next cup of tea.
+
+Exits: west southwest southeast
+
+> se
+Watson saunters southeast, and you drift along behind.
+
+Tea garden, east
+The garden bed under the old walls is just as neat and tidy as ever, as it
+should be. The rosebush is flourishing, ready for your next cup of tea.
+
+Exits: west northwest southwest
+
+> sw
+Watson saunters southwest, and you drift along behind.
+
+Tea garden, southeast
+The garden bed under the old walls is just as neat and tidy as ever, as it
+should be. The mint is flourishing, ready for your next cup of tea.
+
+Exits: west northeast northwest
+
+> nw
+Watson saunters northwest, and you drift along behind.
+
+Tea garden, centre
+Your tea garden is nestled deep in the foundation of the old ruins, the stone
+walls rising up on every side to give the plants just the perfect amount of
+sunlight and shade. Here at the centre is where you placed that lovely fountain,
+and a sturdy chair, to sit in while you contemplate your options.
+
+The garden beds themselves are arranged in a ring around you, and the path north
+leads back to the lawn. You have a lovely view of the whole thing from your
+sitting room.
+
+On the garden chair are a pair of gardening gloves.
+
+Exits: north east west northeast northwest southwest southeast
+
+> nw
+Watson saunters northwest, and you drift along behind.
+
+Tea garden, northwest
+The garden bed under the old walls is just as neat and tidy as ever, as it
+should be. The rosebush is flourishing, ready for your next cup of tea.
+
+Exits: east southwest southeast
+
+> sw
+Watson saunters southwest, and you drift along behind.
+
+Tea garden, west
+The garden bed under the old walls is just as neat and tidy as ever, as it
+should be. The beebalm is flourishing, ready for your next cup of tea.
+
+Exits: east northeast southeast
+
+> se
+Watson saunters southeast, and you drift along behind.
+
+Tea garden, southwest
+The garden bed under the old walls is just as neat and tidy as ever, as it
+should be. The rosebush is flourishing, ready for your next cup of tea.
+
+Exits: east northeast northwest
+
+> ne
+Watson saunters northeast, and you drift along behind.
+
+Tea garden, centre
+Your tea garden is nestled deep in the foundation of the old ruins, the stone
+walls rising up on every side to give the plants just the perfect amount of
+sunlight and shade. Here at the centre is where you placed that lovely fountain,
+and a sturdy chair, to sit in while you contemplate your options.
+
+The garden beds themselves are arranged in a ring around you, and the path north
+leads back to the lawn. You have a lovely view of the whole thing from your
+sitting room.
+
+On the garden chair are a pair of gardening gloves.
+
+Exits: north east west northeast northwest southwest southeast
+
+> xyzzy
+As you speak the word, you feel a strange sensation pulling you southwest...
+Watson saunters southwest, and you drift along behind.
+
+Tea garden, southwest
+The garden bed under the old walls is just as neat and tidy as ever, as it
+should be. The rosebush is flourishing, ready for your next cup of tea.
+
+Exits: east northeast northwest
+
+> take rose
+Watson delicately closes his mouth around one of the buds, trying to tear it
+free of the stem without getting pricked on the thorns. Oh, your poor
+flowers...but he does succeed, in the end.
+
+Exits: east northeast northwest
+
+> go to dining room
+(attempting to go northeast)
+Watson saunters northeast, and you drift along behind.
+
+Tea garden, centre
+Your tea garden is nestled deep in the foundation of the old ruins, the stone
+walls rising up on every side to give the plants just the perfect amount of
+sunlight and shade. Here at the centre is where you placed that lovely fountain,
+and a sturdy chair, to sit in while you contemplate your options.
+
+The garden beds themselves are arranged in a ring around you, and the path north
+leads back to the lawn. You have a lovely view of the whole thing from your
+sitting room.
+
+On the garden chair are a pair of gardening gloves.
+
+(attempting to go north)
+Watson saunters north, and you drift along behind.
+
+Lawn
+It’s really not big enough to be called the grounds, but you’ve always been
+proud of your lawn and gardens, encircling the house on all sides. The most
+important one right now is your tea garden, down to the south; the veranda is
+back to the north.
+
+Today’s newspaper lies in front of the porch steps.
+
+(attempting to go north)
+Watson saunters north, and you drift along behind.
+
+Veranda
+A little refuge from the weather, for when you want the fresh outdoor air
+without all the sun and the rain, between the front door to the north and the
+lawn to the south.
+
+(attempting to go north)
+Watson saunters through the front door, and you drift along behind.
+
+Reception room
+You designed this room specifically for uninvited guests. Back when the front
+door was at the west end of the house, they’d have to wait awkwardly outside
+until you had the sitting room or dining room in order. Now, there’s a place to
+sit and take tea with them at a moment’s notice—and admire the framed case
+reports on the wall—and that can make witnesses ever so much more willing to
+open up. What used to be the back door of the house leads northwest to the
+kitchen, and the new front door leads out to the south.
+
+Today’s mail is scattered across the floor.
+
+(attempting to go northwest)
+Watson saunters northwest, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+(attempting to go west)
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+On the table are a tape recorder and your torch.
+
+Davis pulls out another page, cross-checking it against the last.
+
+Exits: south east
+
+> show rose to davis
+“Hm? What’s this?” The constable looks down at the torn branch in Watson’s
+mouth.
+
+“Wait—is this—?” She takes it carefully, avoiding the thorns and the dog
+slobber. “The green roses! This must be from the same bush as the tea she drank
+last night! The boffins at the lab will need a look at this.”
+
+Watson sits back and wags his tail happily as Davis hurries off. It will take
+some time for the laboratory tests to come back, but you already know what
+they’ll say: that the roses weren’t poisoned, and Alfred is innocent.
+
+Your score has gone up by one point.
+
+Exits: south east
+
+> * *** Access Cellar ***
+> e
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+Davis makes her way from the reception room to the kitchen (where you are).
+
+Exits: south west southeast
+
+> s
+Watson saunters south, and you drift along behind.
+
+Hall
+This narrow hallway is right at the centre of the house, linking the sitting
+room to the south to the kitchen to the north. To the west, dark stairs lead
+down to the cellar, and to the east used to be a closet until you had it turned
+into a tiny little lavatory.
+
+Davis makes her way from the kitchen to the dining room.
+
+Exits: north south west
+
+> d
+Watson saunters down the cellar stairs, and you drift along behind.
+
+Landing
+The stairs turn around sharply here at a little wooden landing, just a foot or
+so above the ground. The pump here is supposed to keep your cellar from
+flooding, but with the electricity out, you have to fear the worst. The cellar
+proper is down to the northeast, in total darkness without the light from the
+hall windows, or you can go back up to the east.
+
+That photo album Lottie brought has been set in the corner for when she comes
+back.
+
+Davis settles back into her chair and returns to work.
+
+Exits: east northeast
+
+> album
+Lottie left it when she was over for dinner, filled with photos of her trip out
+to the Orient. Her son is some sort of archaeologist out there, with his wife,
+and she loved talking about all the intricate details of what they were doing.
+Fiddly details have always been her favourite thing, and she kept pushing you to
+keep working on those constabulary records that weren’t lining up—she just had a
+feeling it was a sign of something worse.
+
+Exits: east northeast
+
+> lottie
+Lottie—that is, Mrs Charlotte Peabody—is your closest friend in the area, and
+her regular visits for tea and gossip are a highlight of your week. She’s a
+meticulous, analytical sort, always picking out the flaws in a plan; if she
+turned her mind to murder, she would have a better alibi and a less obvious
+method.
+
+Unfortunately, she isn’t anywhere near your house at the moment.
+
+Exits: east northeast
+
+> ne
+Watson saunters northeast, and you drift along behind.
+
+Pantry (in the dark)
+It’s pitch dark, and you can barely see a thing. You can make out light to the
+southwest.
+
+Exits: southwest
+
+> s
+(first attempting to open the root cellar door to the south)
+The root cellar should be that way, but in the darkness you can’t seem to locate
+the door.
+
+Exits: southwest
+
+> door
+It should be somewhere in the south wall, but in the darkness you can’t quite
+find it.
+
+Exits: southwest
+
+> water
+Cold and wet, you have to imagine, though Watson is putting on a brave face and
+you yourself can’t feel it at all.
+
+Exits: southwest
+
+> go to dining room
+(attempting to go southwest)
+Watson noses his way southwest, and you drift along behind.
+
+Landing
+The stairs turn around sharply here at a little wooden landing, just a foot or
+so above the ground. The pump here is supposed to keep your cellar from
+flooding, but with the electricity out, you now know it’s thoroughly failed at
+that. The cellar proper is down to the northeast, in total darkness without the
+light from the hall windows, or you can go back up to the east.
+
+That photo album Lottie brought has been set in the corner for when she comes
+back.
+
+(attempting to go east)
+Watson saunters up the cellar stairs, and you drift along behind.
+
+Hall
+This narrow hallway is right at the centre of the house, linking the sitting
+room to the south to the kitchen to the north. To the west, dark stairs lead
+down to the cellar, and to the east used to be a closet until you had it turned
+into a tiny little lavatory.
+
+(attempting to go north)
+Watson saunters north, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+(attempting to go west)
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+On the table are a tape recorder and your torch.
+
+Davis runs her hands through her hair with a sigh.
+
+Exits: south east
+
+> get torch
+Watson opens his mouth and carefully plucks your torch off the table.
+
+Davis has no objection to the theft of your torch. She doesn’t seem to care what
+Watson does, as long as it doesn’t interfere with her paperwork or her lunch.
+
+Exits: south east
+
+> turn it on
+Watson paws at your torch, and it switches on!
+
+Davis pulls out another page, cross-checking it against the last.
+
+Exits: south east
+
+> go to pantry
+(attempting to go east)
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+(attempting to go south)
+Watson saunters south, and you drift along behind.
+
+Hall
+This narrow hallway is right at the centre of the house, linking the sitting
+room to the south to the kitchen to the north. To the west, dark stairs lead
+down to the cellar, and to the east used to be a closet until you had it turned
+into a tiny little lavatory.
+
+(attempting to go west)
+Watson saunters down the cellar stairs, and you drift along behind.
+
+Landing
+The stairs turn around sharply here at a little wooden landing, just a foot or
+so above the ground. The pump here is supposed to keep your cellar from
+flooding, but with the electricity out, you now know it’s thoroughly failed at
+that. The cellar proper is down to the northeast, in total darkness without the
+light from the hall windows, or you can go back up to the east.
+
+That photo album Lottie brought has been set in the corner for when she comes
+back.
+
+(attempting to go northeast)
+Watson saunters northeast, and you drift along behind.
+
+Pantry
+In the torchlight, your fears are confirmed: Watson is standing in at least
+three inches of water. Oh, what a mess...
+
+The door to the root cellar is now visible to the south.
+
+The dumbwaiter shaft ends here, well above Watson’s head.
+
+Exits: (south) southwest
+
+> s
+(first attempting to open the root cellar door to the south)
+Watson whines, and holds up your torch. This door needs to be pulled open, and
+he can’t do that with his mouth occupied.
+
+Exits: (south) southwest
+
+> drop torch
+Best not. It’s not waterproof, and with the electricity out, it’s your only
+source of light.
+
+Exits: (south) southwest
+
+> go to kitchen
+(attempting to go southwest)
+Watson saunters southwest, and you drift along behind.
+
+Landing
+The stairs turn around sharply here at a little wooden landing, just a foot or
+so above the ground. The pump here is supposed to keep your cellar from
+flooding, but with the electricity out, you now know it’s thoroughly failed at
+that. The cellar proper is down to the northeast, in total darkness without the
+light from the hall windows, or you can go back up to the east.
+
+That photo album Lottie brought has been set in the corner for when she comes
+back.
+
+(attempting to go east)
+Watson saunters up the cellar stairs, and you drift along behind.
+
+Hall
+This narrow hallway is right at the centre of the house, linking the sitting
+room to the south to the kitchen to the north. To the west, dark stairs lead
+down to the cellar, and to the east used to be a closet until you had it turned
+into a tiny little lavatory.
+
+(attempting to go north)
+Watson saunters north, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+Exits: south west southeast
+
+> push wheel
+The dumbwaiter sinks into sight.
+
+Exits: south west southeast
+
+> put torch in dumbwaiter
+Watson sets your torch carefully in the dumbwaiter.
+
+Exits: south west southeast
+
+> w
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+On the table is a tape recorder.
+
+Davis runs her hands through her hair with a sigh.
+
+Exits: south east
+
+> get recorder
+Watson opens his mouth and carefully plucks the tape recorder off the table.
+
+Davis flips one of the sheets over, tapping her pen against the table.
+
+Exits: south east
+
+> push play
+The recorder clicks on, and a tinny voice starts to play. Some sort of
+testimony, from the sound of it.
+
+Hearing the whine of the tape recorder, Davis reaches over and shuts it off.
+
+Exits: south east
+
+> e
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter is here, with your torch in it.
+
+The stove is tucked away to one side.
+
+Exits: south west southeast
+
+> put recorder in dumbwaiter
+Watson sets the tape recorder carefully in the dumbwaiter.
+
+Exits: south west southeast
+
+> play
+The recorder clicks on, and a tinny voice starts to play. Some sort of
+testimony, from the sound of it.
+
+“...their country-place, Styles Court, had been purchased by Mr Cavendish early
+in their married life...”
+
+Exits: south west southeast
+
+> push wheel
+The dumbwaiter sinks out of sight.
+
+Exits: south west southeast
+
+> go to pantry
+(attempting to go south)
+Watson saunters south, and you drift along behind.
+
+Hall
+This narrow hallway is right at the centre of the house, linking the sitting
+room to the south to the kitchen to the north. To the west, dark stairs lead
+down to the cellar, and to the east used to be a closet until you had it turned
+into a tiny little lavatory.
+
+(attempting to go west)
+Watson saunters down the cellar stairs, and you drift along behind.
+
+Landing
+The stairs turn around sharply here at a little wooden landing, just a foot or
+so above the ground. The pump here is supposed to keep your cellar from
+flooding, but with the electricity out, you now know it’s thoroughly failed at
+that. The cellar proper is down to the northeast, in near-total darkness without
+the light from the hall windows, or you can go back up to the east.
+
+That photo album Lottie brought has been set in the corner for when she comes
+back.
+
+(attempting to go northeast)
+Watson saunters northeast, and you drift along behind.
+
+Pantry
+In the torchlight, your fears are confirmed: Watson is standing in at least
+three inches of water. Oh, what a mess...
+
+The door to the root cellar is now visible to the south.
+
+The dumbwaiter hangs well above Watson’s head, with a tape recorder and your
+torch in it.
+
+“...he had been completely under his wife’s ascendancy, so much so that, on
+dying, he left the place to her for her lifetime...”
+
+Exits: (south) southwest
+
+> s
+(first attempting to open the root cellar door to the south)
+Watson noses the root cellar door open.
+
+“...as well as the larger part of his income; an arrangement that was distinctly
+unfair to his two sons...”
+
+Watson saunters through the root cellar door, and you drift along behind.
+
+Root cellar (in the dark)
+It’s pitch dark, and you can barely see a thing. You can make out light to the
+north.
+
+The door to the root cellar swings closed again.
+
+Your score has gone up by one point.
+
+Exits: (north) south east west northeast northwest southwest southeast
+
+> * *** In Cellar ***
+> smell
+Watson splashes through the water as he snuffles around, before stopping a few
+feet off to the northwest.
+
+Exits: (north) south east west northeast northwest southwest southeast
+
+> xyzzy
+As you speak the word, you feel a strange sensation pulling you northwest...
+Watson splashes away to the northwest, and you try your best to follow...until
+his paw hits something with a soft thump. He must have found the carrots!
+
+Depths of the root cellar (in the dark)
+It’s pitch dark, and you can barely see a thing. You can’t even make out any
+exits.
+
+From the sound of Watson’s snuffling, there’s something at your feet.
+
+Exits: north south east west northeast northwest southwest southeast
+
+> carrots
+A one-peck bundle of carrots, fresh from the farmer’s market. Lottie picked them
+up as part of a good deal on onions, but she can’t stand the smell, so she
+brought them over for you and Watson to enjoy. They should be good, even if
+they’re mildly soggy now.
+
+Exits: north south east west northeast northwest southwest southeast
+
+> get it
+Watson opens his mouth and carefully scoops up the bundle of carrots.
+
+Your score has gone up by one point.
+
+Exits: north south east west northeast northwest southwest southeast
+
+> listen
+Watson is silent for a moment, listening intently, before you hear him move to
+the west. There seems to be some source of noise that way!
+
+Exits: north south east west northeast northwest southwest southeast
+
+> xyzzy
+As you speak the word, you feel a strange sensation pulling you west... Watson
+splashes away to the west, and you try your best to follow...until suddenly a
+hint of light is visible in the darkness.
+
+Root cellar (in the dark)
+It’s pitch dark, and you can barely see a thing. You can make out light to the
+north.
+
+Exits: (north) south east west northeast northwest southwest southeast
+
+> north
+(first attempting to open the root cellar door to the north)
+Watson noses the root cellar door open.
+
+Watson noses his way out the root cellar door, and you drift along behind.
+
+Pantry
+In the torchlight, your fears are confirmed: Watson is standing in at least
+three inches of water. Oh, what a mess...
+
+The door to the root cellar is now visible to the south.
+
+The dumbwaiter hangs well above Watson’s head, with a tape recorder and your
+torch in it.
+
+The door to the root cellar swings closed again.
+
+“...their step-mother, however, had always been most generous to them...”
+
+Exits: (south) southwest
+
+> go to dining room
+(attempting to go southwest)
+Watson saunters southwest, and you drift along behind.
+
+Landing
+The stairs turn around sharply here at a little wooden landing, just a foot or
+so above the ground. The pump here is supposed to keep your cellar from
+flooding, but with the electricity out, you now know it’s thoroughly failed at
+that. The cellar proper is down to the northeast, in near-total darkness without
+the light from the hall windows, or you can go back up to the east.
+
+That photo album Lottie brought has been set in the corner for when she comes
+back.
+
+(attempting to go east)
+Watson saunters up the cellar stairs, and you drift along behind.
+
+Hall
+This narrow hallway is right at the centre of the house, linking the sitting
+room to the south to the kitchen to the north. To the west, dark stairs lead
+down to the cellar, and to the east used to be a closet until you had it turned
+into a tiny little lavatory.
+
+(attempting to go north)
+Watson saunters north, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+(attempting to go west)
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis runs her hands through her hair with a sigh.
+
+Exits: south east
+
+> xyzzy
+That’s that “magic word” Nigel was on about, from some new game he found? You
+don’t understand any of it, really, but he seems to enjoy it at least.
+
+Davis flips one of the sheets over, tapping her pen against the table.
+
+Exits: south east
+
+> give carrots to davis
+Davis looks down at Watson, and winces at the sight of water being dripped all
+over your rug. (Well, it can’t be helped.) It takes her a moment more to realise
+what exactly it’s dripping from.
+
+“The carrots!” Watson lets go obligingly as she heaves the bundle up onto the
+table, trying to keep it from soaking her paperwork. “Don’t know how you knew we
+needed these, but I’ll get them to the lab right away. Thanks, boy.”
+
+Watson sits back with a proud smile as Davis makes the arrangements, though he
+seems a bit sad not to be given a carrot himself for his efforts. The lab tests
+will take a while, but you’re confident they’ll come back clean. Lottie is
+innocent.
+
+Your score has gone up by one point.
+
+Exits: south east
+
+> * *** Access Attic ***
+> s
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+Your body lies at the bottom of the stairs.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+Davis makes her way from the reception room to the kitchen.
+
+Exits: north south east (west)
+
+> up
+Watson saunters up the stairs, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+From the sound of it, Phillips is hard at work in the suite to the south.
+
+Davis makes her way from the kitchen to the dining room.
+
+Exits: (north) (south) west northwest
+
+> nw
+Watson saunters northwest, and you drift along behind.
+
+Upstairs hall
+The hall runs alongside the staircase here before bending sharply at the end,
+with a little balcony to the south overlooking the first floor. The top of the
+stairs is back to the southeast, and the guest room will be to the north—once
+it’s been properly repainted and made livable, at least.
+
+A dangling cord marks the location of the trapdoor to the attic.
+
+A mattress is propped up against one wall, for lack of anywhere better to put
+it.
+
+Davis settles back into her chair and returns to work.
+
+Exits: south southeast (up)
+
+> cord
+The cord hangs down just above Watson’s head, easily within reach.
+
+Exits: south southeast (up)
+
+> pull it
+Watson leaps upward and catches the cord in his teeth, trying to hold onto it
+with all his strength. For a moment it doesn’t seem like his weight will be
+enough...but with a steady groan the trapdoor opens and the stairs swing
+downward. His momentum carries him off to the south, depositing him with a
+gentle thump on the balcony.
+
+Balcony
+The hallway ends with a narrow balcony, connecting your bedroom to the south
+with everything else to the north. The railing to the east protects you from a
+dizzying drop to the bottom of the stairs. Evidence from another of your past
+cases is displayed proudly on the wall.
+
+The trapdoor to the attic is open, blocking off the passage to the north.
+Unfortunately, the stairs are on the other side.
+
+Exits: (south)
+
+> n
+The stairs to the attic block off that hallway completely.
+
+Exits: (south)
+
+> jump
+Watson peers over the edge, then look up at you with a scared whimper. He’s
+always been a good jumper, but after what happened last night, you can’t really
+blame him.
+
+Exits: (south)
+
+> push stairs
+Watson shoves his face and paws under the bottom step, rolling over onto his
+back and pushing with all his might. It only moves a little, but that’s enough
+for the mechanism to take over, and it snaps up into the ceiling.
+
+Exits: north (south)
+
+> n
+Watson saunters north, and you drift along behind.
+
+Upstairs hall
+The hall runs alongside the staircase here before bending sharply at the end,
+with a little balcony to the south overlooking the first floor. The top of the
+stairs is back to the southeast, and the guest room will be to the north—once
+it’s been properly repainted and made livable, at least.
+
+A dangling cord marks the location of the trapdoor to the attic.
+
+A mattress is propped up against one wall, for lack of anywhere better to put
+it.
+
+Exits: south southeast (up)
+
+> push mattress south
+Watson maneuvers the mattress carefully south, with you following behind.
+
+Balcony
+The hallway ends with a narrow balcony, connecting your bedroom to the south
+with everything else to the north. The railing to the east protects you from a
+dizzying drop to the bottom of the stairs. Evidence from another of your past
+cases is displayed proudly on the wall.
+
+A dangling cord marks the location of the trapdoor to the attic.
+
+A mattress is propped up against one wall, for lack of anywhere better to put
+it.
+
+Exits: north (south)
+
+> push mattress east
+With a mighty heave, Watson shoves the mattress over the edge! It tumbles end-
+over-end in a rush of air, the corners of the fabric fluttering wildly, until it
+lands with a mighty whomp at the foot of the stairs.
+
+Well, at least you won’t have to look at your own corpse any more.
+
+Exits: north (south)
+
+> pull cord
+Watson leaps upward and catches the cord in his teeth, trying to hold onto it
+with all his strength. For a moment it doesn’t seem like his weight will be
+enough...but with a steady groan the trapdoor opens and the stairs swing
+downward, carrying Watson with them and depositing him with a gentle thump on
+the balcony.
+
+Balcony
+The hallway ends with a narrow balcony, connecting your bedroom to the south
+with everything else to the north. The railing to the east protects you from a
+dizzying drop to the bottom of the stairs. Evidence from another of your past
+cases is displayed proudly on the wall.
+
+The trapdoor to the attic is open, blocking off the passage to the north.
+Unfortunately, the stairs are on the other side.
+
+Exits: (south)
+
+> jump
+Watson braces himself on the edge for a moment, steeling his nerves. Then with a
+mighty leap, he launches himself up and over the balcony! You find yourself
+drifting down with him as he plummets down the stairs and lands with a whump on
+the mattress below.
+
+Bottom of the stairs (on the mattress)
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+Exits: north south east (west)
+
+> up
+(first attempting to get off the mattress)
+Watson leaps off the mattress.
+
+Watson saunters up the stairs, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+From the sound of it, Phillips is hard at work in the suite to the south.
+
+Exits: (north) (south) west northwest
+
+> nw
+Watson saunters northwest, and you drift along behind.
+
+Upstairs hall
+The hall runs alongside the staircase here before bending sharply at the end,
+with a little balcony to the south overlooking the first floor. The top of the
+stairs is back to the southeast, and the guest room will be to the north—once
+it’s been properly repainted and made livable, at least.
+
+The trapdoor to the attic is open, the collapsible steps leading up to the
+south.
+
+Exits: southeast up
+
+> s
+The stairs to the attic block off that hallway completely.
+
+Exits: southeast up
+
+> u
+Watson clambers up the attic stairs, and you drift along behind.
+
+Attic, west (in the dark)
+It’s pitch dark, and you can barely see a thing. You can make out light below.
+
+The collapsible stairs lead down through the trapdoor to the rest of the house.
+
+A faint hint of light outlines the heavy shutters blocking the window.
+
+Off to the northeast, you can almost make out a victrola.
+
+Off to the southeast, you can almost make out a grandfather clock.
+
+Your score has gone up by one point.
+
+Exits: northeast southeast down
+
+> * *** In Attic ***
+> go to kitchen
+(attempting to go down)
+Watson clambers down the attic stairs, and you drift along behind.
+
+Upstairs hall
+The hall runs alongside the staircase here before bending sharply at the end,
+with a little balcony to the south overlooking the first floor. The top of the
+stairs is back to the southeast, and the guest room will be to the north—once
+it’s been properly repainted and made livable, at least.
+
+The trapdoor to the attic is open, the collapsible steps leading up to the
+south.
+
+(attempting to go southeast)
+Watson saunters southeast, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+From the sound of it, Phillips is hard at work in the suite to the south.
+
+(attempting to go west)
+Watson saunters down the stairs, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+(attempting to go north)
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis runs her hands through her hair with a sigh.
+
+(attempting to go east)
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+Exits: south west southeast
+
+> push wheel
+The dumbwaiter rises into sight, bringing you a tape recorder and your torch.
+
+“...indeed, they were so young at the time of their father’s remarriage that
+they always thought of her as their own mother...”
+
+Exits: south west southeast
+
+> off
+The recorder clicks off.
+
+Exits: south west southeast
+
+> push wheel
+The dumbwaiter rises out of sight.
+
+Exits: south west southeast
+
+> push wheel
+The cables glide along their tracks, sending the dumbwaiter to the attic.
+
+Exits: south west southeast
+
+> go to attic west
+(attempting to go west)
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis pulls out another page, cross-checking it against the last.
+
+(attempting to go south)
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+(attempting to go east)
+Watson saunters up the stairs, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+From the sound of it, Phillips is hard at work in the suite to the south.
+
+(attempting to go northwest)
+Watson saunters northwest, and you drift along behind.
+
+Upstairs hall
+The hall runs alongside the staircase here before bending sharply at the end,
+with a little balcony to the south overlooking the first floor. The top of the
+stairs is back to the southeast, and the guest room will be to the north—once
+it’s been properly repainted and made livable, at least.
+
+The trapdoor to the attic is open, the collapsible steps leading up to the
+south.
+
+(attempting to go up)
+Watson clambers up the attic stairs, and you drift along behind.
+
+Attic, west (in the dark)
+It’s pitch dark, and you can barely see a thing. You can make out light to the
+northeast and below.
+
+The collapsible stairs lead down through the trapdoor to the rest of the house.
+
+A faint hint of light outlines the heavy shutters blocking the window.
+
+Off to the northeast, you can clearly see a victrola. Watson might be able to
+leap to it, from the right starting point.
+
+Off to the southeast, you can almost make out a grandfather clock.
+
+Exits: northeast southeast down
+
+> n
+Watson noses his way northeast, and you drift along behind.
+
+Attic, north
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the north side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+Outside your little circle of torchlight, who knows what might be hidden in the
+darkness?
+
+A faint hint of light outlines the heavy shutters blocking the window.
+
+The dumbwaiter is here, with a tape recorder and your torch in it.
+
+Your old victrola rests under the dumbwaiter.
+
+Off to the southeast, you can almost make out an organ.
+
+Exits: southwest southeast
+
+> clutter
+Too many things to even list—not that that’s stopped Nigel from trying. He wants
+to make a proper inventory of it at some point, and that sort of fastidiousness
+is what he lives for.
+
+Exits: southwest southeast
+
+> nigel
+Your nephew Nigel is such a dear. He worries about everything, and at your age,
+you have to admit it’s not entirely without cause. You wouldn’t put it past him
+to contemplate murder, perhaps, but he’d immediately talk himself out of it.
+
+Unfortunately, he isn’t anywhere near your house at the moment.
+
+Exits: southwest southeast
+
+> get torch
+Watson opens his mouth and carefully plucks your torch out of the dumbwaiter.
+
+Exits: southwest southeast
+
+> vents
+There are vents set into the floor under the carpet, to keep your laboratory
+well-ventilated, but the torchlight isn’t bright enough to pick them out.
+
+Exits: southwest southeast
+
+> jump on victrola
+Watson leaps up onto the victrola.
+
+Exits: southwest southeast
+
+> jump on organ
+Watson peers toward the organ in the east side of the attic, then whimpers
+nervously. He’s a great leaper and could probably cross the distance, but he
+can’t see it well enough in the dark to be sure of his landing.
+
+Exits: southwest southeast
+
+> e
+(first attempting to get off the victrola)
+Watson leaps off the victrola.
+
+Watson saunters southeast, and you drift along behind.
+
+Attic, east
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the east side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+Outside your little circle of torchlight, who knows what might be hidden in the
+darkness?
+
+The door to your laboratory stands to the west.
+
+A faint hint of light outlines the heavy shutters blocking the window.
+
+A reed organ is positioned against the inner wall.
+
+Off to the northwest, you can almost make out a victrola.
+
+Off to the southwest, you can almost make out a grandfather clock.
+
+Exits: (west) northwest southwest
+
+> open windows
+Watson looks up at the chains, and flops down forlornly. They’re a good eight
+feet above the ground, far too high for him to jump.
+
+Exits: (west) northwest southwest
+
+> get on organ
+Watson can just barely get his paws up on top, but it’s a bit too tall to jump
+to from the ground.
+
+Exits: (west) northwest southwest
+
+> put torch on organ
+Watson sets your torch carefully on the organ.
+
+Exits: (west) northwest southwest
+
+> n
+Watson saunters northwest, and you drift along behind.
+
+Attic, north (in the dark)
+It’s pitch dark, and you can barely see a thing. You can make out light to the
+southeast.
+
+A faint hint of light outlines the heavy shutters blocking the window.
+
+You can dimly make out the shape of your old victrola, pushed back against the
+wall.
+
+Off to the southeast, you can clearly see an organ. Watson might be able to leap
+to it, from the right starting point.
+
+Exits: southwest southeast
+
+> get on victrola
+Watson leaps up onto the victrola.
+
+Exits: southwest southeast
+
+> jump on organ
+Watson focuses intently on the organ, gauging the distance for a moment. Then
+with a mighty leap, he launches himself across the gap!
+
+Attic, east (on the organ)
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the east side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+Outside your little circle of torchlight, who knows what might be hidden in the
+darkness?
+
+The door to your laboratory stands to the west.
+
+A faint hint of light outlines the heavy shutters blocking the window.
+
+A reed organ is positioned against the inner wall.
+
+Your torch is on the organ.
+
+Off to the northwest, you can almost make out a victrola.
+
+Off to the southwest, you can almost make out a grandfather clock.
+
+Exits: (west) northwest southwest
+
+> jump on clock
+Watson peers toward the grandfather clock in the south side of the attic, then
+whimpers nervously. He’s a great leaper and could probably cross the distance,
+but he can’t see it well enough in the dark to be sure of his landing.
+
+Exits: (west) northwest southwest
+
+> throw torch
+(first attempting to take your torch)
+Watson opens his mouth and carefully scoops up your torch.
+
+In which direction?
+
+Exits: (west) northwest southwest
+
+> southwest
+With a sharp flick of his head, Watson flings your torch southwestward, sending
+it sailing to the south side of the attic.
+
+Exits: northwest southwest
+
+> jump on clock
+Watson focuses intently on the grandfather clock, gauging the distance for a
+moment. Then with a mighty leap, he launches himself across the gap!
+
+Attic, south (on the grandfather clock)
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the south side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+Outside your little circle of torchlight, who knows what might be hidden in the
+darkness?
+
+A faint hint of light outlines the heavy shutters blocking the window.
+
+You see your torch here.
+
+The grandfather clock looms just under the windows.
+
+Off to the northeast, you can almost make out an organ.
+
+Exits: northeast northwest
+
+> get torch
+Watson stretches his body, trying to reach your torch, then settles back with a
+sad whimper.
+
+Exits: northeast northwest
+
+> open windows
+From his perch atop the clock, Watson stretches up and catches the chain in his
+mouth. With a sharp tug the shutters all around the attic snap open, and the
+afternoon sunlight streams in.
+
+Attic, south (on the grandfather clock)
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the south side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+In the afternoon sunlight, you can just barely trace the outline of the vents
+under the carpet.
+
+You see your torch here.
+
+The grandfather clock looms just under the windows.
+
+Off to the northeast, you can clearly see an organ. Watson could probably make
+that leap.
+
+Your score has gone up by one point.
+
+Exits: northeast northwest
+
+> get in vent
+Watson stretches his body, trying to reach the floor vents, then settles back
+with a sad whimper.
+
+Exits: northeast northwest
+
+> down
+Watson leaps off the grandfather clock.
+
+Exits: northeast northwest
+
+> get in vent
+Watson tries, but there’s a layer of carpet in the way. He’ll have to get
+through that first.
+
+Exits: northeast northwest
+
+> open vent
+Watson paws at the carpet for a moment, but can’t find a way to open it without
+just chewing through. And surely that’s not what you want.
+
+Exits: northeast northwest
+
+> chew carpet
+You kneel down and guide Watson’s nose to the right place, and he starts
+scratching at the carpet with furious intensity. He doesn’t get the opportunity
+to dig very often, and he’s determined to make the most of this moment. Soon a
+corner tears free, revealing the vent hidden underneath.
+
+Exits: northeast northwest
+
+> get in vent
+Watson launches himself into the floor vents, and you follow along behind.
+
+Exits: north northeast northwest
+
+> north
+You can’t see Watson moving, but as he scrabbles through the vents, you find
+yourself pulled along to the north.
+
+Laboratory (in the floor vents)
+At the very center of the attic is the laboratory, where you spend your spare
+time tinkering with chemicals. Nigel jokes that you’re a fairy-tale witch
+updated to the twentieth century, but it’s been plenty of help with cases in the
+past—and besides, everyone needs a hobby.
+
+The door leads out to the east, thankfully easier to open from this side.
+
+In the afternoon sunlight, you can just barely trace the outline of the vents
+under the carpet.
+
+Your box of poisons lies in the midst of the equipment, clearly labelled for
+safety.
+
+Exits: north south east west
+
+> equipment
+It’s probably a bit antiquated, by modern standards, but you’ve found it very
+serviceable.
+
+Exits: north south east west
+
+> out
+Watson tries, but there’s a layer of carpet in the way. He’ll have to get
+through that first.
+
+Exits: north south east west
+
+> chew carpet
+There’s a scratching, scrabbling noise as Watson struggles to get his teeth and
+claws into the carpet—followed by a loud, satisfying rip. His head emerges from
+the floor, tongue lolling out happily.
+
+Exits: north south east west
+
+> push carpet
+Watson nudges the carpet, and it flops loosely, not posing much of an obstacle
+now.
+
+Exits: north south east west
+
+> out
+Watson leaps out of the floor vents.
+
+Exits: (east)
+
+> get poisons
+Watson opens his mouth and carefully scoops up the box of poisons.
+
+Exits: (east)
+
+> open door
+Watson noses the laboratory door open.
+
+Exits: east
+
+> out
+Watson saunters out the laboratory door, and you drift along behind.
+
+Attic, east
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the east side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+The door to your laboratory stands open to the west.
+
+In the afternoon sunlight, you can just barely trace the outline of the vents
+under the carpet.
+
+A reed organ is positioned against the inner wall.
+
+Off to the northwest, you can clearly see a victrola. Watson might be able to
+leap to it, from the right starting point.
+
+Off to the southwest, you can clearly see a grandfather clock. Watson might be
+able to leap to it, from the right starting point.
+
+Exits: west northwest southwest
+
+> go to dining room
+(attempting to go southwest)
+Watson saunters southwest, and you drift along behind.
+
+Attic, south
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the south side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+The carpet has been torn up to reveal the vent underneath.
+
+You see your torch here.
+
+The grandfather clock looms just under the windows.
+
+Off to the northeast, you can clearly see an organ. Watson might be able to leap
+to it, from the right starting point.
+
+(attempting to go northwest)
+Watson saunters northwest, and you drift along behind.
+
+Attic, west
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the west side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+The collapsible stairs lead down through the trapdoor to the rest of the house.
+
+In the afternoon sunlight, you can just barely trace the outline of the vents
+under the carpet.
+
+Off to the northeast, you can clearly see a victrola. Watson might be able to
+leap to it, from the right starting point.
+
+Off to the southeast, you can clearly see a grandfather clock. Watson might be
+able to leap to it, from the right starting point.
+
+(attempting to go down)
+Watson clambers down the attic stairs, and you drift along behind.
+
+Upstairs hall
+The hall runs alongside the staircase here before bending sharply at the end,
+with a little balcony to the south overlooking the first floor. The top of the
+stairs is back to the southeast, and the guest room will be to the north—once
+it’s been properly repainted and made livable, at least.
+
+The trapdoor to the attic is open, the collapsible steps leading up to the
+south.
+
+(attempting to go southeast)
+Watson saunters southeast, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+From the sound of it, Phillips is hard at work in the suite to the south.
+
+(attempting to go west)
+Watson saunters down the stairs, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+(attempting to go north)
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis runs her hands through her hair with a sigh.
+
+Exits: south east
+
+> give poisons to davis
+“What’s this now?” Watson pushes the box insistently into Davis’s hands, and she
+has to turn it around to read it. “Poisons? Now where on earth did you get
+this?” She extricates it carefully from his mouth, and opens it to see the
+assortment of carefully-labelled vials inside. “This would be from her
+laboratory, then? The nephew could have tampered with them—you,” she looks
+severely at Watson, “need to be more careful! It could have poisoned you too.”
+
+She seals the box again. “The fingerprints will tell us one way or another.” But
+you already know the answer; Nigel isn’t the sort to do a thing like that. The
+tests will prove him innocent.
+
+Your score has gone up by one point.
+
+Exits: south east
+
+> * *** Access Upstairs ***
+> e
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+Davis makes her way from the reception room to the kitchen (where you are).
+
+Exits: south west southeast
+
+> se
+Watson saunters southeast, and you drift along behind.
+
+Reception room
+You designed this room specifically for uninvited guests. Back when the front
+door was at the west end of the house, they’d have to wait awkwardly outside
+until you had the sitting room or dining room in order. Now, there’s a place to
+sit and take tea with them at a moment’s notice—and admire the framed case
+reports on the wall—and that can make witnesses ever so much more willing to
+open up. What used to be the back door of the house leads northwest to the
+kitchen, and the new front door leads out to the south.
+
+Today’s mail is scattered across the floor.
+
+Davis makes her way from the kitchen to the dining room.
+
+Exits: south northwest
+
+> get mail
+Watson opens his mouth and carefully scoops up the mail.
+
+Davis settles back into her chair and returns to work.
+
+Exits: south northwest
+
+> nw
+Watson saunters northwest, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+Exits: south west southeast
+
+> put mail on stove
+Watson sets the mail carefully on the stove.
+
+Exits: south west southeast
+
+> turn on stove
+The lighter makes a clicking sound as Watson paws at the dials, until finally he
+catches it just right, and the flame takes hold. It’s not long before the mail
+on top starts to fill the room with smoke. Really, you suppose, that’s the best
+you can expect from a dog’s cooking.
+
+Exits: south west southeast
+
+> w
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+A haze of smoke clouds the air.
+
+The smoke alarm begins to shriek. As the alarm starts to blare, Davis puts aside
+her work with a groan.
+
+Exits: south east
+
+> get alarm
+Watson stretches his body, trying to reach the smoke detector, then settles back
+with a sad whimper.
+
+Exits: south east
+
+> jump on table
+Watson leaps up onto the table.
+
+A haze of smoke clouds the air.
+
+The smoke alarm continues to shriek.
+
+“Down from there! Now!” Davis gives Watson a little shove, and he hops down with
+a whimper.
+
+Exits: south east
+
+> z
+Watson tries as hard as he can to demonstrate patience.
+
+A haze of smoke clouds the air.
+
+The smoke alarm continues to shriek.
+
+Davis gets up from her chair.
+
+Exits: south east
+
+> z
+Watson tries as hard as he can to demonstrate patience.
+
+A haze of smoke clouds the air.
+
+The smoke alarm continues to shriek.
+
+Davis makes her way from the dining room (where you are) to the kitchen.
+
+Exits: south east
+
+> jump on table
+Watson leaps up onto the table.
+
+A haze of smoke clouds the air.
+
+The smoke alarm continues to shriek.
+
+Following the smoke to the kitchen, Davis is confronted with the horrors of the
+smoldering mail, and immediately turns off the stove.
+
+Exits: south east
+
+> get alarm
+Balancing on his hind legs and stretching to his full length, Watson manages to
+knock the smoke detector down from its perch and scoop it into his mouth.
+
+A haze of smoke clouds the air.
+
+The smoke alarm continues to shriek.
+
+Exits: south east
+
+> s
+(first attempting to get off the table)
+Watson leaps off the table.
+
+A haze of smoke clouds the air.
+
+The smoke alarm continues to shriek.
+
+Davis makes her way from the kitchen to the dining room (where you are).
+
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+A haze of smoke clouds the air.
+
+The smoke alarm continues to shriek.
+
+Davis settles back into her chair and returns to work.
+
+Exits: north south east (west)
+
+> up
+Watson saunters up the stairs, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+From the sound of it, Phillips is hard at work in the suite to the south.
+
+The alarm falls silent, and Watson can finally relax again.
+
+Exits: (north) (south) west northwest
+
+> drop alarm
+Watson sets the smoke detector carefully on the ground.
+
+Exits: (north) (south) west northwest
+
+> down
+Watson saunters down the stairs, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+Exits: north south east (west)
+
+> n
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis sets the last sheet aside, turning to the next.
+
+Exits: south east
+
+> e
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side. On the stove is some mail.
+
+Exits: south west southeast
+
+> turn on stove
+The lighter makes a clicking sound as Watson paws at the dials, until finally he
+catches it just right, and the flame takes hold. It’s not long before the mail
+on top starts to fill the room with smoke. Really, you suppose, that’s the best
+you can expect from a dog’s cooking.
+
+Exits: south west southeast
+
+> w
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+A haze of smoke clouds the air.
+
+At the telltale smell of smoke, Davis puts aside her work with a groan.
+
+Exits: south east
+
+> s
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+A haze of smoke clouds the air.
+
+Davis gets up from her chair.
+
+Exits: north south east (west)
+
+> up
+Watson saunters up the stairs, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+From the sound of it, Phillips is hard at work in the suite to the south.
+
+You see a smoke detector here.
+
+A haze of smoke clouds the air.
+
+The smoke alarm begins to shriek.
+
+The sound of an emergency alarm is finally enough to pull Constable Phillips
+away from his work. He throws open the door to the suite and launches himself
+down the stairs.
+
+Davis makes her way from the dining room to the kitchen.
+
+Your score has gone up by one point.
+
+Exits: (north) south west northwest
+
+> s
+Watson saunters through the suite door, and you drift along behind.
+
+Master suite
+Such a grand name for what amounts to five feet of hallway-slash-closet,
+connecting your bedroom to the west to your bathroom to the northeast. The door
+to the north leads out to the rest of the house.
+
+Your racks of clothes stand in disarray, methodically ransacked by the
+constables.
+
+A haze of smoke clouds the air.
+
+In the top of the stairs, the smoke alarm continues to shriek. Phillips hurries
+through the dining room to the kitchen.
+
+Following the smoke to the kitchen, Davis is confronted with the horrors of the
+smoldering mail, and immediately turns off the stove.
+
+Exits: north west northeast
+
+> phillips
+“Fastidious” is perhaps the best word to describe the young constable, so
+insistent on doing everything by the book. You always appreciate his
+thoroughness in searching for clues, now that you’re in no state to be bending
+down and dusting for fingerprints under automobiles and such, but he’ll never be
+promoted if he can’t learn to put the pieces together himself. When he’s set
+himself to a task, nothing short of an absolute emergency will sway him from his
+course.
+
+Currently, he should be in the kitchen.
+
+In the top of the stairs, the smoke alarm continues to shriek. Phillips sprints
+out to the veranda, finally pausing to see if the alarm continues.
+
+Exits: north west northeast
+
+> * *** In Upstairs ***
+> clothes
+What could the constables have been searching for in here? You keep your
+medicines locked in the bathroom, and the keys on the nightstand in your
+bedroom.
+
+The alarm falls silent, and Watson can finally relax again. Phillips heads off
+to investigate this false alarm.
+
+Davis makes her way from the kitchen to the dining room.
+
+Exits: north west northeast
+
+> search them
+Watson noses through the racks, but finds nothing except more clothes.
+
+Davis settles back into her chair and returns to work.
+
+Exits: north west northeast
+
+> w
+Watson saunters west, and you drift along behind.
+
+Bedroom
+As your age advances, the little luxuries of your bedroom have suffered for it.
+Even with Emily’s help, you’ve had to recognise the difficulties in day-to-day
+life, and the room is now designed around being cared for rather than
+comfortable. The suite opens out to the east, and a door to the north leads out
+to the rest of the house.
+
+Your bed stands in equal disarray. You’d given no thought to tidying it up.
+
+The nightstand is placed next to the head of the bed, entirely devoid of keys.
+
+Exits: (north) east
+
+> bed
+Not quite as soft as you would like it, sadly; at your age, getting into and out
+of it easily has become more of a priority. Now the mattress is too firm and
+there’s an unattractively large gap underneath.
+
+Exits: (north) east
+
+> look under bed
+Watson snuffles around under your bed and turns up a truncheon. He looks up at
+you proudly.
+
+Exits: (north) east
+
+> truncheon
+You got this from the constables, at Emily’s insistence; she maintains that
+someone you exposed will eventually want revenge, and having a weapon on hand
+will make them think twice about coming into your house. She means well, but
+she’s never quite understood how these things actually happen—you have no idea
+how to use something like this effectively, and a person bent on murder won’t be
+dissuaded by it.
+
+Exits: (north) east
+
+> emily
+You used to feel a bit ashamed to admit it, but a companion really is a
+necessity at your age. She checks in on you periodically, arranges your
+medicines, and handles any problems before they come up; not the brightest girl,
+perhaps, but a very good heart. She’d be horrified by the very idea of murder,
+and probably end up in tears for even thinking about it.
+
+Unfortunately, she isn’t anywhere near your house at the moment.
+
+Exits: (north) east
+
+> get truncheon
+Watson opens his mouth and carefully plucks the truncheon out from under your
+bed.
+
+Exits: (north) east
+
+> e
+Watson saunters east, and you drift along behind.
+
+Master suite
+Such a grand name for what amounts to five feet of hallway-slash-closet,
+connecting your bedroom to the west to your bathroom to the northeast. The door
+to the north leads out to the rest of the house.
+
+Your racks of clothes stand in disarray, methodically ransacked by the
+constables.
+
+Exits: north west northeast
+
+> ne
+Watson saunters northeast, and you drift along behind.
+
+Bathroom
+Watson is far more excited about this room than you are—it’s normally off-limits
+to him, and the sink, bath, and toilet are all mysterious and new. The only exit
+leads back southwest.
+
+You keep your medicines in a mirrored cabinet to one side.
+
+Exits: southwest
+
+> turn on sink
+Watson paws at the sink, and it switches on!
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> turn on bath
+Watson paws at the bath, and it switches on!
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> flush toilet
+Watson noses at the handle, and the toilet does its best to flush. But something
+seems to be clogging it. These old pipes jam up so easily.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> drink bath
+Watson laps happily at the bath.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> mirror
+More a functional piece of furniture than a beautiful one, it works as both a
+full-length mirror and a place to keep your medicines and toiletries. You don’t
+normally lock it, though; what would be the point, in your own bathroom?
+
+You only wish it could be set into the wall, instead of free-standing. The
+baseboards keep it from standing quite flush, leaving an inch or so of space
+behind it, and you can see a glint of something caught back there.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> look behind mirror
+Watson snuffles around behind the standing mirror and turns up an earring. He
+looks up at you proudly.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> put truncheon behind mirror
+Watson manages to work the handle end into the little gap behind the cabinet,
+leaving it sticking out at an odd angle.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> push truncheon
+Watson gives the truncheon a vigorous tug, and for a moment, it seems like
+nothing will happen. But he tugs again, and the cabinet wavers—and slowly begins
+to topple forward! He darts out of the way as the whole cabinet comes crashing
+down, the mirror shattering into hundreds of pieces on the tiles.
+
+Your medicine box now lies amid the wreckage.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Your score has gone up by one point.
+
+Exits: southwest
+
+> push mirror
+That seems a bit gratuitous at this point, doesn’t it?
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> mirror
+More a functional piece of furniture than a beautiful one, it works as both a
+full-length mirror and a place to keep your medicines and toiletries. Or at
+least, it used to.
+
+Your medicine chest is buried in the shards.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> get chest
+Watson opens his mouth and carefully plucks the medicine chest out of the
+shattered mirror.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> sw
+Watson saunters southwest, and you drift along behind.
+
+Master suite
+Such a grand name for what amounts to five feet of hallway-slash-closet,
+connecting your bedroom to the west to your bathroom to the northeast. The door
+to the north leads out to the rest of the house.
+
+Your racks of clothes stand in disarray, methodically ransacked by the
+constables.
+
+Exits: north west northeast
+
+> n
+Watson saunters out the suite door, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+You see a smoke detector here.
+
+Exits: (north) south west northwest
+
+> throw chest down
+Bracing his paws on the banister, Watson flings the medicine chest over the
+edge! The box tumbles downward, landing with a soft flump on the mattress.
+
+Exits: (north) south west northwest
+
+> down
+Watson saunters down the stairs, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell. On the mattress is
+a medicine chest.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+Exits: north south east (west)
+
+> get chest
+Watson opens his mouth and carefully plucks the medicine chest off the mattress.
+
+Exits: north south east (west)
+
+> up
+Watson saunters up the stairs, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+You see a smoke detector here.
+
+Exits: (north) south west northwest
+
+> nw
+Watson saunters northwest, and you drift along behind.
+
+Upstairs hall
+The hall runs alongside the staircase here before bending sharply at the end,
+with a little balcony to the south overlooking the first floor. The top of the
+stairs is back to the southeast, and the guest room will be to the north—once
+it’s been properly repainted and made livable, at least.
+
+The trapdoor to the attic is open, the collapsible steps leading up to the
+south.
+
+Exits: southeast up
+
+> up
+Watson clambers up the attic stairs, and you drift along behind.
+
+Attic, west
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the west side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+The collapsible stairs lead down through the trapdoor to the rest of the house.
+
+In the afternoon sunlight, you can just barely trace the outline of the vents
+under the carpet.
+
+Off to the northeast, you can clearly see a victrola. Watson might be able to
+leap to it, from the right starting point.
+
+Off to the southeast, you can clearly see a grandfather clock. Watson might be
+able to leap to it, from the right starting point.
+
+Exits: northeast southeast down
+
+> ne
+Watson saunters northeast, and you drift along behind.
+
+Attic, north
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the north side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+In the afternoon sunlight, you can just barely trace the outline of the vents
+under the carpet.
+
+The dumbwaiter is here, with a tape recorder in it.
+
+Your old victrola rests under the dumbwaiter.
+
+Off to the southeast, you can clearly see an organ. Watson might be able to leap
+to it, from the right starting point.
+
+Exits: southwest southeast
+
+> push wheel
+The dumbwaiter sinks out of sight.
+
+Exits: southwest southeast
+
+> push wheel
+The cables glide along their tracks, sending the dumbwaiter to the ground floor.
+
+Exits: southwest southeast
+
+> put chest in shaft
+Watson drops the medicine chest into the shaft, and it falls away into the
+darkness. A moment later, you hear a clang from below. With, perhaps, a hint of
+cracking glass as well?
+
+Exits: southwest southeast
+
+> go to kitchen
+(attempting to go southwest)
+Watson saunters southwest, and you drift along behind.
+
+Attic, west
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the west side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+The collapsible stairs lead down through the trapdoor to the rest of the house.
+
+In the afternoon sunlight, you can just barely trace the outline of the vents
+under the carpet.
+
+Off to the northeast, you can clearly see a victrola. Watson might be able to
+leap to it, from the right starting point.
+
+Off to the southeast, you can clearly see a grandfather clock. Watson might be
+able to leap to it, from the right starting point.
+
+(attempting to go down)
+Watson clambers down the attic stairs, and you drift along behind.
+
+Upstairs hall
+The hall runs alongside the staircase here before bending sharply at the end,
+with a little balcony to the south overlooking the first floor. The top of the
+stairs is back to the southeast, and the guest room will be to the north—once
+it’s been properly repainted and made livable, at least.
+
+The trapdoor to the attic is open, the collapsible steps leading up to the
+south.
+
+(attempting to go southeast)
+Watson saunters southeast, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+You see a smoke detector here.
+
+(attempting to go west)
+Watson saunters down the stairs, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+(attempting to go north)
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis runs her hands through her hair with a sigh.
+
+(attempting to go east)
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter is here, with a broken medicine chest and a tape recorder in it.
+
+The stove is tucked away to one side. On the stove is some mail.
+
+Exits: south west southeast
+
+> chest
+You keep your various medicines locked in a little frosted-glass box, just in
+case anyone tries to tamper with them—you’ve seen the effects of that sort of
+thing far too often in your work. After that fall, it’s not securing anything
+any more.
+
+Your pill box is hidden inside.
+
+Exits: south west southeast
+
+> get pills
+Watson opens his mouth and carefully plucks the pill box out of the broken
+medicine chest.
+
+Exits: south west southeast
+
+> w
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis flips one of the sheets over, tapping her pen against the table.
+
+Exits: south east
+
+> give pills to davis
+Watson has to nudge Davis’s hand a few times with the pill box before she hears
+it rattling. “What’s this? Is this—are these the pills Phillips was turning the
+bedroom upside down for?” She actually laughs as he drops it in her hand. “How
+did you find these before he did? Such a good dog!” She opens the box and counts
+out the remaining pills. “I’ll get these down to the lab, and they’ll know if
+anyone tampered with them.” They didn’t, of course; Emily is the only one to
+have the opportunity, and she’s too diligent to make that mistake. But this will
+confirm it, and rule her out once and for all.
+
+* *** Finale ***
+Some time later, Davis is back in the dining room, going over the files. “This
+doesn’t make sense. There were only four people with a motive and an
+opportunity...but no evidence pointing toward any of them. How else could it
+’ave happened?”
+
+She looks down at Watson, as if he’s going to have an answer for her, then
+stands. “I’m getting the other two. We need a new direction.” Biddlecombe is
+promptly summoned down from the library, and Phillips from wherever he’s gotten
+off to; soon all three of them are huddled together around the table, comparing
+notes.
+
+Your score has gone up by one point.
+
+Exits: south east
+
+> look
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+All three constables have convened around the table.
+
+Biddlecombe and Davis are having a heated debate about the evidence. Phillips is
+off in the corner, running his hands through his hair.
+
+Exits: south east
+
+> s
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+Exits: north south east (west)
+
+> up
+Watson saunters up the stairs, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+You see a smoke detector here.
+
+Exits: north south west northwest
+
+> n
+Watson saunters through the library door, and you drift along behind.
+
+Library
+Nobody else ever likes this room. They say the carpets and the drapes clash
+horribly with the bookshelves, and they can never find what they’re looking for.
+But that really doesn’t matter; it’s a place for you to work, study, and read,
+and to your eyes, the colours are perfectly fine. The only door leads back to
+the south.
+
+The dumbwaiter used to run through here, but you covered over the shaft when you
+turned the room into a library. There was just too much risk of something
+spilling out.
+
+Exits: south
+
+> drapes
+Apparently they’re an odd mixture of purple, orange, and red that clashes
+horribly with the shelves, but to you, they go together very well.
+
+Exits: south
+
+> shelves
+The shelves line every wall, leaving no real place to work—your desk, after all,
+is hidden in the niche behind them. All you have to do now is open it.
+
+Exits: south
+
+> open them
+It’s very simple, if you know the trick. You direct Watson to pull one
+particular book off the shelf, then a second, then a third—and as the last one
+falls, the cases swing silently outward to reveal your desk in the niche behind
+them. It’s still covered with those ledgers and files from last week; you kept
+meaning to get back to that investigation...
+
+Exits: south
+
+> desk
+It is, perhaps, not truly necessary to hide your desk behind a bookcase. But
+when you came across a mechanism like this in one of your investigations, you
+simply couldn’t resist. Now your workspace is tucked away behind the shelves
+when it’s not being used.
+
+Exits: south
+
+> ledgers
+Dozens of records and ledgers from the constabulary are laid out here, carefully
+arranged so you can compare them side by side. This isn’t the sort of business
+you normally do, but the Inspector had remarked a few weeks back that their
+auditors couldn’t make heads nor tails of the discrepancies, and you thought it
+might be linked to something deeper. Really, you started to regret it by the
+third page, which is why you left it sitting here for a week and a half.
+
+But being murdered does tend to lend some urgency to things. You settle yourself
+over the desk and direct Watson how to push the papers around, letting you look
+for the patterns you need. It’s tedious work, but you don’t seem to grow tired
+the way you used to.
+
+None of these discrepancies make sense. Their bookkeeping isn’t just atrocious:
+it seems designed to be as confusing as possible. But the only person with the
+authority to cause that sort of snarl...
+
+...would be the Inspector himself.
+
+Your score has gone up by one point.
+
+Exits: south
+
+> bark
+Watson lets out a loud bark that echoes through the house, then looks up at you
+for approval, tail wagging happily.
+
+Off in the dining room, Davis steadfastly ignores the sound. She’s investigating
+a murder now, and can’t be distracted by barking dogs!
+
+Exits: south
+
+> close shelves
+Watson tugs as hard as he can, but it scarcely moves—it takes significantly more
+force to close than to open. But the counterweighting does make it swing open oh
+so beautifully.
+
+Exits: south
+
+> s
+Watson saunters through the library door, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+You see a smoke detector here.
+
+Exits: north south west northwest
+
+> down
+Watson saunters down the stairs, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+Exits: north south east (west)
+
+> n
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis is hurriedly gathering up the most important files. “I have to get this
+all in order—the Inspector is on his way!” She spares Watson a quick, apologetic
+glance, then hurries out of the room.
+
+So Hughes is coming. He’ll never let the other constables see the evidence now.
+But this isn’t time to panic; it’s time to act.
+
+You know exactly where he’s going to be: in the library, destroying the ledgers.
+You have a chance. Push him hard enough and he’ll slip—and give you the evidence
+you need for a conviction.
+
+Exits: south east
+
+> e
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter is here, with a broken medicine chest and a tape recorder in it.
+
+The stove is tucked away to one side. On the stove is some mail.
+
+Exits: south west southeast
+
+> record
+The recorder clicks on, and begins to record.
+
+Exits: south west southeast
+
+> w
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis’s seat stands conspicuously vacant.
+
+Exits: south east
+
+> s
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+Exits: north south east (west)
+
+> up
+Watson saunters up the stairs, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+You see a smoke detector here.
+
+Exits: north south west northwest
+
+> n
+Watson saunters through the library door, and you drift along behind.
+
+Library
+Nobody else ever likes this room. They say the carpets and the drapes clash
+horribly with the bookshelves, and they can never find what they’re looking for.
+But that really doesn’t matter; it’s a place for you to work, study, and read,
+and to your eyes, the colours are perfectly fine. The only door leads back to
+the south.
+
+Your desk is now visible behind the secret door, covered with various ledgers
+and files.
+
+The dumbwaiter used to run through here, but you covered over the shaft when you
+turned the room into a library. There was just too much risk of something
+spilling out.
+
+Exits: south
+
+> push wheel
+The cables glide along their tracks, sending the dumbwaiter to the cellar.
+
+Exits: south
+
+> push wheel
+The cables glide along their tracks, sending the dumbwaiter to the ground floor.
+
+Exits: south
+
+> push wheel
+The cables glide along their tracks, sending the dumbwaiter to the first floor.
+
+Barely a moment later the door slams open and Inspector Hughes strides in, his
+bulky frame wrapped in an enormous overcoat. “None of the suspects, she says.
+All four of the theories ruled out. Have to look deeper. And Biddlecombe doesn’t
+find a single bloody thing. It’s time to take care of this myself.”
+
+Your score has gone up by one point.
+
+Exits: south
+
+> hughes
+You have a long history with Basil Hughes, and it’s in no small part thanks to
+your investigations that he’s risen through the ranks from Constable to
+Inspector. He has his eye on Chief Inspector now, but really, well...the man is
+far too close-minded, far too quick to jump to the obvious conclusion. Large and
+stout, with an immaculate uniform and an impressive moustache, he tries to look
+every bit the image of the modern constabulary.
+
+“Now, what have we here?” Hughes sets his briefcase on the desk.
+
+Exits: south
+
+> bite hughes
+You’ve trained Watson well not to get aggressive with people, but he’s smart
+enough to understand the anger behind that command—he leaps at the Inspector
+with a growl, teeth bared to bite! Hughes does his best to fend him off, but his
+Inverness coat now has some dramatic new tears.
+
+“Shoo! Get out of here! Go!” With a hiss of displeasure, Hughes turns back to
+the desk.
+
+Exits: south
+
+> undo
+Undoing the last turn (bite hughes).
+Library
+
+Exits: south
+
+> kiss hughes
+Watson needs very little encouragement to throw himself upon the Inspector,
+lavishing him with distinctly unwanted canine affection. Hughes tries his
+hardest to push him away, but Watson is undeterred, and by the time the
+Inspector fights free his face and hands are thoroughly wet.
+
+“Shoo! Get out of here! Go!” With a hiss of displeasure, Hughes turns back to
+the desk.
+
+Exits: south
+
+> undo
+Undoing the last turn (kiss hughes).
+Library
+
+Exits: south
+
+> vomit
+You’ve trained Watson well not to do such things in the house, but you’ve also
+trained him to recognise an emergency—and this certainly qualifies. Hughes
+freezes in his work as he hears the telltale sound behind him.
+
+“Shoo! Get out of here! Go!” With a hiss of displeasure, Hughes turns back to
+the desk.
+
+Exits: south
+
+> undo
+Undoing the last turn (vomit).
+Library
+
+Exits: south
+
+> get briefcase
+The moment Hughes’s back is turned, Watson reaches up and gives his briefcase a
+mighty shove, sending it to the floor. The Inspector whirls around a moment too
+late to stop him from snatching it up, and he’s off on a merry chase!
+
+Watson manages to evade the constable for a good while before Hughes eventually
+manages to snag his case back, puffing and panting for breath.
+
+“Shoo! Get out of here! Go!” With a hiss of displeasure, Hughes turns back to
+the desk.
+
+Exits: south
+
+> get briefcase
+“Bad!” Hughes shoves Watson away before he can get hold of the case again.
+
+Hughes flips through another ledger, grumbling under his breath.
+
+Exits: south
+
+> jump on desk
+Watson’s tail wags for a moment, and the Inspector has only a moment of warning
+before he leaps up onto the desk, papers flying everywhere! Hughes shouts
+something incoherent and tries to push him aside, his work now scattered all
+over the room.
+
+“Wretched mutt! You’re as bad as she was!” Hughes visibly composes himself for a
+moment before going back to his task.
+
+Exits: south
+
+> bark
+Positioning himself right behind Hughes’s work, Watson waits for the perfect
+moment to let out a thunderous bark. The Inspector jumps, clenching his hand so
+hard on a pen that it snaps in half.
+
+“ENOUGH!” Hughes whirls on Watson, rage burning on his face. “You confounded
+beast! I had it all arranged! There was no evidence to be found! We’d file it as
+an accident and close the case, or send Davis and Phillips on a snipe hunt until
+the case went cold! But you, you had to get in my way at every single turn!”
+
+He snatches up a stack of papers and starts to shred them between his hands.
+“But it’s not enough. This was the last evidence of the motive, and without it,
+they’ll never even begin to investigate. This house is going up for auction, and
+you’re going to the pound!”
+
+He aims a petty kick at Watson as he flings the door open and storms out of the
+room.
+
+Your score has gone up by one point.
+
+Exits: south
+
+> look
+Library
+Nobody else ever likes this room. They say the carpets and the drapes clash
+horribly with the bookshelves, and they can never find what they’re looking for.
+But that really doesn’t matter; it’s a place for you to work, study, and read,
+and to your eyes, the colours are perfectly fine. The only door leads back to
+the south.
+
+Your desk is now visible behind the secret door, stripped clean of evidence.
+
+The dumbwaiter used to run through here, but you covered over the shaft when you
+turned the room into a library. There was just too much risk of something
+spilling out.
+
+You can hear the Inspector storming out, almost bowling over Constable Davis in
+the process. She tries in vain to apologise as he slams the front door behind
+him.
+
+Exits: south
+
+> s
+Watson saunters through the library door, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+You see a smoke detector here.
+
+Davis makes her way from the reception room to the kitchen.
+
+Exits: north south west northwest
+
+> down
+Watson saunters down the stairs, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+Davis makes her way from the kitchen to the dining room.
+
+Exits: north south east (west)
+
+> n
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis is here, looking rather frazzled.
+
+Davis settles back into her chair and returns to work.
+
+Exits: south east
+
+> e
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side. On the stove is some mail.
+
+Exits: south west southeast
+
+> push wheel
+The dumbwaiter sinks into sight, bringing you a broken medicine chest and a tape
+recorder.
+
+Exits: south west southeast
+
+> off
+The recorder clicks off.
+
+Exits: south west southeast
+
+> get recorder
+Watson opens his mouth and carefully plucks the tape recorder out of the
+dumbwaiter.
+
+Exits: south west southeast
+
+> w
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis sets the last sheet aside, turning to the next.
+
+Exits: south east
+
+> give recorder to davis
+“Hm? What’s’at?” Davis sounds exhausted as she looks down at the recorder. “Ah,
+you found this for us. Thanks, dog.” She checks the tape, then rewinds it and
+taps ‘play’.
+
+There’s a minute of muffled silence, the sounds of someone rifling around in the
+library, and Davis frowns. But then Hughes’s voice comes through loud and clear.
+I had it all arranged! There was no evidence to be found! We’d file it as an
+accident and close the case, or send Davis and Phillips on a snipe hunt until
+the case went cold!
+
+The recorder falls from the constable’s hand with a crash. “Inspector Hughes?
+He—why—”
+
+Watson sits back on his haunches, panting happily as Davis grabs the recorder
+and sprints off. Finally taking her own initiative, for once in her life; you
+wish you could tell her you were proud. She’s the sort who will dot all the i’s
+and cross all the t’s, and with a confession like that, Hughes has no way to
+wiggle out of it.
+
+The front door slams, and you’re left alone in the silence. Davis will get the
+credit, of course, but you don’t mind that; you’ve had plenty of glory in your
+time. Someone else can get the accolades for solving your own murder. And Nigel
+will take good care of Watson; your will is explicit on that point.
+
+The real question is—what comes next for you?
+
+     *** The End ***
+
+You scored 18 points out of 18.
+
+Would you like to:
+     UNDO the last move,
+     RESTORE a saved position,
+     see your SCORE,
+     QUIT the program,
+     or RESTART from the beginning?
+> score
+You currently have 18 points out of a maximum of 18, in 334 turns.
+
+You’ve earned points for:
+- Finding a way to interact with the world
+- Escaping the armchair
+- Proving it was murder
+- Gaining access to the gardens
+- Identifying the green roses
+- Exculpating your gardener Alfred
+- Gaining access to the attic
+- Opening the attic windows
+- Exculpating your nephew Nigel
+- Gaining access to the root cellar
+- Finding the carrots
+- Exculpating your friend Charlotte
+- Gaining access to your bedroom suite
+- Opening the medicine cabinet
+- Exculpating your companion Emily
+- Discovering the real identity of the murderer
+- Hiding a tape recorder
+- Recording Hughes’s confession
+
+Your work here is finished.
+
+Would you like to:
+     UNDO the last move,
+     RESTORE a saved position,
+     see your SCORE,
+     QUIT the program,
+     or RESTART from the beginning?
+> * *** Metapuzzle secrets ***
+> undo
+Undoing the last turn (give recorder to davis).
+Dining room
+
+Exits: south east
+
+> drop recorder
+Watson sets the tape recorder carefully on the ground.
+
+Davis pulls out another page, cross-checking it against the last.
+
+Exits: south east
+
+> find mail
+Watson leaps up and sprints off in hot pursuit of the mail, heading for the
+kitchen.
+
+(attempting to go east)
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter is here, with a broken medicine chest in it.
+
+The stove is tucked away to one side. On the stove is some mail.
+
+Exits: south west southeast
+
+> get mail
+Watson opens his mouth and carefully plucks the mail off the stove.
+
+Exits: south west southeast
+
+> find bath
+Watson leaps up and sprints off in hot pursuit of the bath, heading for the
+bathroom.
+
+(attempting to go west)
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+You see a tape recorder here.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis sets the last sheet aside, turning to the next.
+
+(attempting to go south)
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+(attempting to go east)
+Watson saunters up the stairs, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+You see a smoke detector here.
+
+(attempting to go south)
+Watson saunters through the suite door, and you drift along behind.
+
+Master suite
+Such a grand name for what amounts to five feet of hallway-slash-closet,
+connecting your bedroom to the west to your bathroom to the northeast. The door
+to the north leads out to the rest of the house.
+
+Your racks of clothes stand in disarray, methodically ransacked by the
+constables.
+
+(attempting to go northeast)
+Watson saunters northeast, and you drift along behind.
+
+Bathroom
+Watson is far more excited about this room than you are—it’s normally off-limits
+to him, and the sink, bath, and toilet are all mysterious and new. The only exit
+leads back southwest.
+
+You see an earring here.
+
+You see a truncheon here.
+
+The mirrored cabinet lies on the floor, shattered.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> turn on bath
+Watson paws at the bath, but it is already on.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> get in bath
+Watson launches himself into the bath, and you follow along behind.
+
+Water pours from the bathtub faucet, thoroughly soaking Watson’s fur.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> go to reception room
+(attempting to go southwest)
+(first attempting to get out of the bath)
+Watson leaps out of the bath.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Watson saunters southwest, and you drift along behind.
+
+Master suite
+Such a grand name for what amounts to five feet of hallway-slash-closet,
+connecting your bedroom to the west to your bathroom to the northeast. The door
+to the north leads out to the rest of the house.
+
+Your racks of clothes stand in disarray, methodically ransacked by the
+constables.
+
+(attempting to go north)
+Watson saunters out the suite door, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+You see a smoke detector here.
+
+(attempting to go west)
+Watson saunters down the stairs, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+(attempting to go north)
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+You see a tape recorder here.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis looks for her biscuit, realises she’s run out, and sighs.
+
+(attempting to go east)
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter is here, with a broken medicine chest in it.
+
+The stove is tucked away to one side.
+
+(attempting to go southeast)
+Watson saunters southeast, and you drift along behind.
+
+Reception room
+You designed this room specifically for uninvited guests. Back when the front
+door was at the west end of the house, they’d have to wait awkwardly outside
+until you had the sitting room or dining room in order. Now, there’s a place to
+sit and take tea with them at a moment’s notice—and admire the framed case
+reports on the wall—and that can make witnesses ever so much more willing to
+open up. What used to be the back door of the house leads northwest to the
+kitchen, and the new front door leads out to the south.
+
+Exits: (south) northwest
+
+> open door
+Watson noses the front door open.
+
+Exits: south northwest
+
+> find calendulas
+Watson leaps up and sprints off in hot pursuit of the calendula, heading for the
+northeast bed.
+
+(attempting to go south)
+Watson saunters out the front door, and you drift along behind.
+
+Veranda
+A little refuge from the weather, for when you want the fresh outdoor air
+without all the sun and the rain, between the front door to the north and the
+lawn to the south.
+
+(attempting to go south)
+Watson saunters south, and you drift along behind.
+
+Lawn
+It’s really not big enough to be called the grounds, but you’ve always been
+proud of your lawn and gardens, encircling the house on all sides. The most
+important one right now is your tea garden, down to the south; the veranda is
+back to the north.
+
+Today’s newspaper lies in front of the porch steps.
+
+(attempting to go south)
+Watson saunters south, and you drift along behind.
+
+Tea garden, centre
+Your tea garden is nestled deep in the foundation of the old ruins, the stone
+walls rising up on every side to give the plants just the perfect amount of
+sunlight and shade. Here at the centre is where you placed that lovely fountain,
+and a sturdy chair, to sit in while you contemplate your options.
+
+The garden beds themselves are arranged in a ring around you, and the path north
+leads back to the lawn. You have a lovely view of the whole thing from your
+sitting room.
+
+On the garden chair are a pair of gardening gloves.
+
+(attempting to go northeast)
+Watson saunters northeast, and you drift along behind.
+
+Tea garden, northeast
+The garden bed under the old walls is just as neat and tidy as ever, as it
+should be. The calendula is flourishing, ready for your next cup of tea.
+
+Exits: west southwest southeast
+
+> dig calendulas
+Normally, Watson would be too well-trained to obey an order like that. He knows
+perfectly well that your garden is not for digging. And yet...he knows that
+there’s something odd here, different from all the rest.
+
+He throws himself into the work with great enthusiasm, uprooting your poor
+calendulas left and right, until with an awful lurch the garden bed collapses in
+on itself and sinks down into something underneath! This must be where the old
+cistern was, long ago; you’d been told the house had one when you bought it, but
+you never saw it yourself.
+
+Exits: west southwest southeast down
+
+> down
+Watson clambers down the messy tunnel, and you drift along behind.
+
+Old cistern
+The old cistern isn’t especially large, and if you still had a body, you
+wouldn’t be able to stand up without hitting your head. Lichen covers the old
+stones, and in one corner they’ve crumbled away entirely into some sort of
+cavern beneath.
+
+A messy hole leads back to the garden above.
+
+Your score has gone up by one point.
+
+Exits: up down
+
+> down
+Watson clambers down, and you drift along behind.
+
+Ancient chamber
+This place cannot exist. It simply can’t. You can’t even stop your cellar from
+flooding, for goodness’ sake; how could a chamber like this possibly stay dry?
+For that matter, how can you even see Watson three feet in front of you, with no
+light coming down from the surface?
+
+And yet somehow it does, fifteen feet wide and round like a dome, the ancient
+walls crumbling with lichen. A roughly-hewn slab of stone stands right in the
+middle.
+
+Exits: up
+
+> get on altar
+Watson leaps up onto the stone slab.
+
+Exits: up
+
+> bite mail
+You’re not quite sure what to expect when Watson sinks his teeth into the mail.
+Some part of you remains convinced that it’s all nonsense. Another part is being
+steadily forced to accept the existence of ghosts, which you have steadfastly
+refused to accept as an explanation for murder for the past fifty-some years.
+
+Whatever you expected, it wasn’t this.
+
+It feels like your whole spirit is being forced through a funnel just over your
+heart, drawn out and twisted into a cord, needled through the mail like a thread
+through cloth. You become your name, and your name becomes you, and Watson—
+
+Nothing has changed, and at the same time, everything has changed. You feel no
+more solid than before. But in some strange way, you’re more real. More certain
+that your story isn’t quite yet reaching its end.
+
+Your score has gone up by one point.
+
+Exits: up
+
+> drop mail
+Watson sets the mail carefully on the stone slab.
+
+Exits: up
+
+> find davis
+Watson leaps up and sprints off in hot pursuit of Constable Davis, heading for
+the dining room.
+
+(attempting to go up)
+(first attempting to get off the stone slab)
+Watson leaps off the stone slab.
+
+Watson clambers up, and you drift along behind.
+
+Old cistern
+The old cistern isn’t especially large, and if you still had a body, you
+wouldn’t be able to stand up without hitting your head. Lichen covers the old
+stones, and in one corner they’ve crumbled away entirely into some sort of
+cavern beneath.
+
+A messy hole leads back to the garden above.
+
+(attempting to go up)
+Watson clambers up the messy tunnel, and you drift along behind.
+
+Tea garden, northeast
+The garden bed under the old walls is just as neat and tidy as ever, as it
+should be. The calendula is flourishing, ready for your next cup of tea.
+
+A large sinkhole in the middle of the garden bed thoroughly disrupts the
+aesthetic.
+
+(attempting to go southwest)
+Watson saunters southwest, and you drift along behind.
+
+Tea garden, centre
+Your tea garden is nestled deep in the foundation of the old ruins, the stone
+walls rising up on every side to give the plants just the perfect amount of
+sunlight and shade. Here at the centre is where you placed that lovely fountain,
+and a sturdy chair, to sit in while you contemplate your options.
+
+The garden beds themselves are arranged in a ring around you, and the path north
+leads back to the lawn. You have a lovely view of the whole thing from your
+sitting room.
+
+On the garden chair are a pair of gardening gloves.
+
+(attempting to go north)
+Watson saunters north, and you drift along behind.
+
+Lawn
+It’s really not big enough to be called the grounds, but you’ve always been
+proud of your lawn and gardens, encircling the house on all sides. The most
+important one right now is your tea garden, down to the south; the veranda is
+back to the north.
+
+Today’s newspaper lies in front of the porch steps.
+
+(attempting to go north)
+Watson saunters north, and you drift along behind.
+
+Veranda
+A little refuge from the weather, for when you want the fresh outdoor air
+without all the sun and the rain, between the front door to the north and the
+lawn to the south.
+
+(attempting to go north)
+Watson saunters through the front door, and you drift along behind.
+
+Reception room
+You designed this room specifically for uninvited guests. Back when the front
+door was at the west end of the house, they’d have to wait awkwardly outside
+until you had the sitting room or dining room in order. Now, there’s a place to
+sit and take tea with them at a moment’s notice—and admire the framed case
+reports on the wall—and that can make witnesses ever so much more willing to
+open up. What used to be the back door of the house leads northwest to the
+kitchen, and the new front door leads out to the south.
+
+(attempting to go northwest)
+Watson saunters northwest, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter is here, with a broken medicine chest in it.
+
+The stove is tucked away to one side.
+
+(attempting to go west)
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+You see a tape recorder here.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis pulls out another page, cross-checking it against the last.
+
+Exits: south east
+
+> get recorder
+Watson opens his mouth and carefully scoops up the tape recorder.
+
+Davis looks for her biscuit, realises she’s run out, and sighs.
+
+Exits: south east
+
+> give recorder to davis
+“Hm? What’s’at?” Davis sounds exhausted as she looks down at the recorder. “Ah,
+you found this for us. Thanks, dog.” She checks the tape, then rewinds it and
+taps ‘play’.
+
+There’s a minute of muffled silence, the sounds of someone rifling around in the
+library, and Davis frowns. But then Hughes’s voice comes through loud and clear.
+I had it all arranged! There was no evidence to be found! We’d file it as an
+accident and close the case, or send Davis and Phillips on a snipe hunt until
+the case went cold!
+
+The recorder falls from the constable’s hand with a crash. “Inspector Hughes?
+He—why—”
+
+Watson sits back on his haunches, panting happily as Davis grabs the recorder
+and sprints off. Finally taking her own initiative, for once in her life; you
+wish you could tell her you were proud. She’s the sort who will dot all the i’s
+and cross all the t’s, and with a confession like that, Hughes has no way to
+wiggle out of it.
+
+The front door slams, and you’re left alone in the silence. Davis will get the
+credit, of course, but you don’t mind that; you’ve had plenty of glory in your
+time. Someone else can get the accolades for solving your own murder.
+
+The real question is—what comes next for you? That odd ritual seems to have
+bound your soul to Watson, and that binding shows no signs of fading. You look
+down at Watson, who’s sitting back on his haunches, panting happily. You might
+not know what the next chapter in your story will bring, but it certainly won’t
+be the last.
+Congratulations on solving the metapuzzle and reaching the true ending! This
+puzzle was run as a competition during IFComp 2024, with the prize won by S. V.
+Linwood.
+
+- Daniel Stelzer, N. Cormier, Emery Joyce, Ben Jackson, and Phil Riley
+
+     *** The End ***
+
+You scored 20 points out of 20.
+
+Would you like to:
+     UNDO the last move,
+     RESTORE a saved position,
+     see your SCORE,
+     QUIT the program,
+     or RESTART from the beginning?
+> score
+You currently have 20 points out of a maximum of 20, in 372 turns.
+
+You’ve earned points for:
+- Finding a way to interact with the world
+- Escaping the armchair
+- Proving it was murder
+- Gaining access to the gardens
+- Identifying the green roses
+- Exculpating your gardener Alfred
+- Gaining access to the attic
+- Opening the attic windows
+- Exculpating your nephew Nigel
+- Gaining access to the root cellar
+- Finding the carrots
+- Exculpating your friend Charlotte
+- Gaining access to your bedroom suite
+- Opening the medicine cabinet
+- Exculpating your companion Emily
+- Discovering the real identity of the murderer
+- Hiding a tape recorder
+- Recording Hughes’s confession
+- Discovering the secrets buried under your garden (?)
+- Performing a Druidic ritual (?!)
+
+Your work here is finished.
+
+Would you like to:
+     UNDO the last move,
+     RESTORE a saved position,
+     see your SCORE,
+     QUIT the program,
+     or RESTART from the beginning?
+> 

--- a/test/gosling/gosling.lua.gold
+++ b/test/gosling/gosling.lua.gold
@@ -1,0 +1,4765 @@
+
+
+Dear me. What happened?
+
+Your vision is a bit blurry. Nothing hurts, at least. You can hear Watson
+barking. It’s bright, very bright, so it must be morning.
+
+The last thing you remember was coming down the stairs. Did you stumble and
+fall? Nigel would fuss and scold you over it, saying to be more careful at your
+age. Things are coming into focus now...
+
+Oh. Oh no.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+Your body lies at the bottom of the stairs.
+
+Ever-faithful Watson is crouched over it, whimpering faintly.
+
+> * *** Opening scene ***
+> x watson
+Watson is a wonderfully intelligent collie, and he’s been oh so much help in
+your past investigations. You’ve trained him quite well, if you do say so
+yourself.
+
+> x me
+Well, you feel fine. You don’t look any different, at least to your eyes. You
+seem to be wearing your favourite dress, the one with the pattern of little
+flowers on it, which you certainly weren’t when you fell. This sort of existence
+will certainly take some getting used to.
+
+“What’s this then?” Inspector Hughes strides into the hall, flanked by a little
+gaggle of lower-ranking constabulary. “Bloody hell...so this is how the old bird
+finally went. Never thought she’d meet her end in an accident, not after a
+career of dealing with crime.”
+
+> north
+You focus your thoughts, and try to go north, and yet nothing seems to happen...
+
+Watson looks up at you and blinks in surprise.
+
+Constable Phillips sets to work marking out where you’ve fallen, while his
+colleague Davis examines your body. Hughes strokes his moustache as he surveys
+the stairs. “Looks like an open-and-shut case. Look at ’er nightdress. Must have
+got up in the morning and took a tumble down the stairs.”
+
+The morning? No...no, that’s not right. It was just past midnight...you were
+trying to find your way downstairs with a torch...you had to get to...the
+telephone, wasn’t it? Everything is so fuzzy...
+
+> zxcvbn
+Your mind is still a bit fuzzy, and you can’t quite make sense of that idea at
+the moment.
+
+The Inspector turns to go. “For all we know, that bloody dog of hers might have
+given her a push.” Watson?! He would never! “I’ll get the coroner in. Davis, get
+a report written up and sent to Biddlecombe by the end of today. Looks like it
+really was an accident in the end.”
+
+No! That’s it! You woke up, you recognised those symptoms...the choking feeling,
+the burning in your stomach—how could you ever mistake the signs of white
+arsenic poisoning?
+
+You tried to get to the telephone, but the electricity had gone out again. You
+were making your way down with a torch...that’s it, the torch would prove it was
+the middle of the night, not the morning, now wouldn’t it? Now where in heaven’s
+name did it get off to?
+
+> watson, north
+Watson perks up, about to go north—until one of the constables grabs him by the
+collar.
+
+“For once, a nice, open-and-shut case.”
+
+Oh, that small-minded Inspector! Even a perfunctory investigation should find
+signs of poison! But he’s so sure it was your ordinary morning routine that he
+won’t even consider the possibility.
+
+> hughes, wait
+Inspector Hughes shows not the slightest hint of recognition. You might as well
+be talking to a brick wall.
+
+Hughes strides out while Davis finishes up her measurements. “And get that
+bloody creature out of our way!” Suddenly Phillips has grabbed Watson by the
+collar and is dragging him off to the sitting room.
+
+Watson’s eyes are fixed on you as he’s pulled away, whimpering and scrabbling at
+the carpet. Even if the police won’t listen, Watson will! So you imagine
+yourself following him, and the world around you changes... 
+
+
+Miss Gosling’s Last Case
+An interactive mystery by Daniel M. Stelzer.
+Release 3. Serial number 260201.
+VERSION. Library version 0.46 (modified).
+
+Sitting room
+The big south-facing windows in this room give it the best light in the house,
+so you always take your breakfast and tea here. Normally it would be half-filled
+with your potted plants, but you took those out for Alfred to look at last week,
+and you haven’t had a moment to move them back in yet. The room continues west
+from here, while the hall leads north over a small step to the rest of the
+house.
+
+Watson’s lead has been looped over the post of your favourite chair, keeping him
+from interfering in the crime scene.
+
+A rubber ball lies on the floor nearby.
+
+Your ill-conceived binocular stand is fixed in front of the bay window.
+
+In this state, you can’t do much yourself. The best you can do is LOOK around,
+EXAMINE something, or RECALL a person.
+
+Your score has gone up by one point.
+
+Exits: north west
+
+> * *** Test parser errors ***
+> zxcvbn
+Watson looks up at you with a sad little whine. He has no idea how to “zxcvbn”.
+
+Exits: north west
+
+> x zxcvbn
+Watson understands the instruction to examine something, but doesn’t understand
+what. In particular, the word “zxcvbn” seems to be confusing him.
+
+Exits: north west
+
+> sing zxcvbn
+Watson wags his tail happily, no comprehension at all in his eyes. In
+particular, the word “zxcvbn” seems to be confusing him.
+
+Exits: north west
+
+> * *** Escape ***
+> x ball
+It’s a hard rubber ball, the sort Watson loves to chew on. You’ve put a treat
+inside it for him to try to work out, a little puzzle for him to solve.
+
+Since you EXAMINE so many things in your investigations, you can abbreviate it
+to X.
+
+For anything more elaborate than that, you’ll have to rely on Watson. For
+example, tell him to TAKE THE BALL.
+
+Exits: north west
+
+> watson, take ball
+(You don’t have to mention Watson’s name explicitly; he’s the only one around
+who can hear your commands, after all.)
+Watson opens his mouth and carefully scoops up the rubber ball.
+
+If you say INVENTORY, Watson will show you what he’s holding.
+
+Exits: north west
+
+> inventory
+Watson holds up the rubber ball proudly for your inspection. His collar keeps
+him from moving more than four feet from the chair.
+
+“Take inventory” is one of the stranger tricks you’ve taught him, but it just
+feels more professional than “show me”.
+
+He can only hold one thing in his mouth at a time, but he’s very good at
+manipulating objects in various ways.
+
+You’ve taught Watson plenty of ways to manipulate objects: he can TAKE and DROP
+them, but also PUSH, PULL, OPEN, CLOSE, CLIMB, and SEARCH them, among others.
+
+Exits: north west
+
+> push ball
+Watson bats at the toy, but the treat doesn’t come out. It’ll take more force
+than that.
+
+The text will usually imply what actions will be useful for certain objects. But
+if you’re not sure what to do with something, HELP [OBJECT] (e.g. HELP BALL)
+will give suggestions.
+
+A few special commands are always available:
+    UNDO to take back your last action
+    SAVE and RESTORE to save your game
+    THINK to list the puzzles you’re facing and the ones you’ve already solved
+    HELP for a full list of commands
+    ABOUT for information about the game
+    MAP to see a map of the house
+    HINTS if you’re stuck on a puzzle
+    RESTART to start over from the beginning, or QUIT to exit the game
+completely
+
+Exits: north west
+
+> bite ball
+Watson gnaws happily at the toy, chomping on it at different angles until the
+treat inside pops out!
+
+Exits: north west
+
+> drop ball
+Watson sets the rubber ball carefully under your comfortable chair.
+
+Exits: north west
+
+> eat treat
+Watson doesn’t need telling twice. Soon there’s nothing left of the treat.
+
+Exits: north west
+
+> push chair
+In what direction?
+
+Exits: north west
+
+> w
+Watson tugs on his lead, and the chair on its wheels glides smoothly along
+behind. You drift after him to the west.
+
+The rubber ball proves too small to foul the wheels, and is left behind.
+
+Evening room
+Really this is just another part of the sitting room, but when the house was
+modernised and electrified, the west half was lit up and the east half left to
+its natural light. So you’ve taken to calling this the evening room, a
+comfortable place to sit after supper when you don’t want to brave the stairs to
+the library. The stairs themselves end to the north, up a small step.
+
+A layer of police tape blocks off the door to the north.
+
+Watson’s lead has been looped over the post of your favourite chair, keeping him
+from interfering in the crime scene.
+
+Your collection of mystery novels is kept on a high shelf, out of Watson’s
+reach.
+
+Some people do think it’s odd that you’ve taught him compass directions, but he
+would always get so confused between your right and his right. This just works
+out better all around.
+
+Exits: (north) east
+
+> x shelf
+You made sure to put the bookshelf high enough that Watson couldn’t reach it.
+It’s not that he’d chew on the books; no, he’s far too well-trained for that.
+But he has a tendency to knock things over in his excitement. Now your paperback
+murder mysteries are both safe, and within easy reach. Easy reach for a human,
+at least.
+
+Exits: (north) east
+
+> climb shelf
+Watson stretches his body, trying to reach the bookshelf, then settles back with
+a sad whimper.
+
+Messages like this, telling you why you can’t do something, often indicate
+puzzles to be solved. In this case, the shelf is too high for Watson to reach;
+perhaps he could reach it if he were higher up?
+
+Exits: (north) east
+
+> jump on chair
+Watson leaps up onto your comfortable chair.
+
+Exits: (north) east
+
+> jump on shelf
+Watson leaps up onto the bookshelf.
+
+Exits: (north) east
+
+> books
+Most of your books are kept in the library upstairs, of course, but you’ve
+turned this room into such a lovely place to read in the evenings, and the
+stairs have been getting harder to manage every year. So you’ve started a
+collection of paperback mystery novels down here, for when you’re in the mood
+for some light reading.
+
+Exits: (north) east
+
+> push books
+Watson gives the books a vigorous push, sending them off the edge to land on
+your comfortable chair.
+
+Exits: (north) east
+
+> down
+Watson leaps off the bookshelf and lands on your comfortable chair.
+
+Exits: (north) east
+
+> down
+Watson leaps off your comfortable chair.
+
+Exits: (north) east
+
+> push books
+The books tumble around and under the chair’s wheels in a messy pile.
+
+Exits: (north) east
+
+> east
+(pulling your comfortable chair along)
+Watson lopes back east, pulling the chair behind him...until it catches, pulling
+him up short. One of your books is trapped under the wheel! But he keeps
+pulling, and between the lead on the post pulling it forward and the caught
+wheel holding it back, it topples forward with a grand, stately crash.
+
+With the top posts now resting on the floor, the lead is within Watson’s reach,
+and with a look of doggy triumph he pulls it free!
+
+Watson is free, and it’s time to solve this case! First, you’ll have to get back
+to the scene of the crime: if you can find evidence that this happened at
+midnight instead of in the morning, maybe that will convince the constables that
+it wasn’t an accident.
+
+Good luck, detective!
+
+Your score has gone up by one point.
+
+Exits: (north) east
+
+> west
+Watson turns to look westward, then looks back to you with a puzzled whine. He
+doesn’t see any way to go that direction.
+
+Exits: (north) east
+
+> north
+Watson noses at the police tape, but can’t find a way past.
+
+Exits: (north) east
+
+> tape
+Bright yellow tape meant to keep people out of a crime scene. It’s thoroughly
+blocking the north door.
+
+Exits: (north) east
+
+> bite tape
+Watson chomps down on the police tape, taking a big chunk out of the middle and
+chewing it happily while the ends flutter to the ground.
+
+Exits: north east
+
+> north
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A layer of police tape blocks off the door to the north.
+
+Your body lies at the bottom of the stairs.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+Exits: (north) south east (west)
+
+> bite tape
+Watson chomps down on the police tape, taking a big chunk out of the middle and
+chewing it happily while the ends flutter to the ground.
+
+Exits: north south east (west)
+
+> tape to the north
+Bright yellow tape meant to keep people out of a crime scene. This one has been
+chewed to bits and won’t keep anyone out of anything.
+
+Exits: north south east (west)
+
+> north
+The dining room is that way, but best avoid it for now. If Watson makes a
+nuisance of himself, the constables will secure him better next time—you need to
+get to the crime scene and prove it was murder!
+
+Exits: north south east (west)
+
+> * *** Find torch ***
+> x torch
+Watson understands the instruction to examine something, but doesn’t understand
+what.
+
+Exits: north south east (west)
+
+> vent
+Things are always falling and getting lost in it. You kept meaning to put some
+sort of screen over it, but, well, you never quite found the time.
+
+Exits: north south east (west)
+
+> look in vent
+Watson works one paw into the grate and fishes around in there. But he turns up
+nothing but dust.
+
+Exits: north south east (west)
+
+> phone
+It is, even you have to admit, rather old-fashioned to have a telephone niche.
+Most people keep their telephones on tables now. But you always liked how it
+looked, so when you upgraded to a modern telephone, you kept it in the old
+niche. Things do occasionally roll under it and get lost.
+
+Exits: north south east (west)
+
+> look in phone
+Watson snuffles at the telephone niche, but there’s no room inside it.
+
+Exits: north south east (west)
+
+> look under phone
+Watson noses under the telephone niche, fishing around with one paw. But he
+retreats a moment later, nothing found.
+
+Exits: north south east (west)
+
+> newspaper
+You’ve gathered up the old ones here for Nigel to take the next time he comes
+by. There’s something he does with them, and he always takes them off your hands
+when they start piling up. It’s possible something could roll behind them.
+
+Exits: north south east (west)
+
+> search newspaper
+Watson pushes his nose into the stack, feeling around for anything behind it.
+Something clanks—he’s found your torch!
+
+Exits: north south east (west)
+
+> look in vent
+Watson snuffles around inside the grate, but turns up nothing.
+
+Exits: north south east (west)
+
+> get torch
+Best not to move it yet. The constables need to see that you dropped it when you
+fell, rather than Watson bringing it in later.
+
+Exits: north south east (west)
+
+> turn off torch
+Best not to move it yet. The constables need to see that you dropped it when you
+fell, rather than Watson bringing it in later.
+
+Exits: north south east (west)
+
+> bark
+Watson lets out a loud bark that echoes through the house, then looks up at you
+for approval, tail wagging happily.
+
+Off in the dining room, Davis sets aside her work with a sigh.
+
+Exits: north south east (west)
+
+> z
+Watson tries as hard as he can to demonstrate patience.
+
+Davis makes her way from the dining room to the bottom of the stairs (where you
+are).
+
+Exits: north south east (west)
+
+> z
+Watson tries as hard as he can to demonstrate patience.
+
+Davis scans the room for anything amiss. Nothing, nothing...then Watson barks
+again, sniffing at the stack of newspapers, and she takes a closer look.
+
+“What’s this? A torch?” She fishes it out, turning it over in her hand. “Still
+on, cells still good. Why would she ’ave had a torch at nine in the morning on a
+bright sunny day?”
+
+You watch as it clicks in her head, and she hurries to the telephone.
+“Something’s wrong here. I better ring the Inspector and tell the boys at the
+lab...” 
+
+
+“...results back from Fletcher at the lab. The Marsh test was positive. Arsenic
+poisoning, without a doubt.” Well, obviously; you could have told them yourself
+if you’d made it to the phone in time. The constables are gathered around your
+dining room table now, listening as Davis summarises the situation. “Given her
+experience with poisons, it’s unlikely this was an accident. I think we need to
+seriously consider the possibility of foul play.”
+
+Hughes is tugging at his moustache. “Hmph. Quite. Good catch with the torch;
+would have been a disgrace for the department if we’d missed that. Now that we
+know, we’re not going to leave a single stone unturned. Do we have a motive?
+Inheritance?”
+
+“It seems likely. We found a will in her library. Various bequests to charities
+and organizations, and four specific people who will benefit quite, well,
+substantially.”
+
+“Opportunity?”
+
+Phillips clears his throat. “I’ve been going through her diary.” Inevitable, you
+suppose—you would have done the same—but rude nonetheless. “Fletcher says death
+occurred between midnight and 2:00 AM, and the poison must have been
+consumed—orally—somewhere between four and twelve hours before that. That gives
+all four of them the opportunity.”
+
+Hughes furrows his bushy eyebrows. “Four to twelve hours? She had lunch with me
+at the King’s Arms yesterday. I’ll be asking some questions around there.”
+
+Davis lays her papers out on the table. “Each of those people had access to her
+food or drink within that timespan.” (“Or medication,” Phillips adds.)
+
+“First is her nephew Nigel. That afternoon, he was helping her go through some
+records in her attic. It seems she’s got a sort of a laboratory up there, and he
+could have tampered with her chemicals.” Nigel? He’d never have the stomach for
+it.
+
+“Second is Mrs Charlotte Peabody. Gosling had dinner with her that night, and
+specifically mentioned a one-peck bundle of carrots Peabody brought from the
+farmer’s market. Gosling ate plenty, but Peabody didn’t touch them.” Well, of
+course. Lottie can’t stand the smell of carrots, that’s why she gave them to you
+in the first place. “We need to find and test the remaining carrots.”
+
+“Third is Alfred Tucker, her gardener.” Preposterous. “After supper she drank an
+herbal tea made with green roses. They must have been gathered from one of her
+gardens. Arsenious oxide is sometimes used as a weed killer. If Tucker applied
+some to the flower petals, she’d be poisoned some time later, when she finally
+made tea from those ones.” Not at all his style. “We need to find the bush she
+took these from and test if it’s absorbed anything.”
+
+“Finally, there’s her aide, Emily Morris.” Emily? The girl never had a malicious
+thought in her life. “She arranged for all her medications, and could easily
+have tampered with them.”
+
+Hughes stands, smoothing out his now-frazzled moustache again. “Right then!
+Biddlecombe will be setting up in the library to handle communications.
+Phillips, I want you to find and test those medications first thing. They have
+to be somewhere in her room. Davis, track down the details on those suspects.
+We’ll be asking them a few questions. We’ll have this case cracked right open
+before it hits the papers!” He glares down at Watson, who’s snuffling curiously
+at his hand. “And get that bloody beast out of here!”
+
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+Your score has gone up by one point.
+
+Exits: south west southeast
+
+> * *** Dining Room ***
+> w
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+On the table are a tape recorder and your torch.
+
+Davis sets her sandwich aside as she pulls out another page.
+
+Exits: south east
+
+> cabinet
+You would never call yourself vain, or overly proud of your success. But you
+could never resist showing off a few of your best and most notable
+accomplishments. Right now, you have the evidence from the Disgybl Gwydion case
+laid out here, with some of your other cases displayed in the reception room and
+the upstairs balcony.
+
+Davis takes a bite of her sandwich.
+
+Exits: south east
+
+> evidence
+You normally wouldn’t include an unsolved case here...much less one where the
+constables never proved there was even a crime committed at all. But it did get
+a lot of press, and it did revolve around your house—and you kicked off the
+whole thing when you found this notebook during renovations. It seems one of the
+previous occupants called himself “Disgybl Gwydion”, claimed to be heir to the
+ancient Druids, performing strange rituals in the flower gardens and seeking
+eternal life.
+
+...ancestral spirits / lares and penates, bound through belief, worship? / no,
+alchemical process-congelation of the soul! See Petrus Catadesmicus, Liber
+Animarum / but held to the anchor, how to move and act? / Kizzuwatnan ritual,
+the kuwac hapanza - Father’s Encyclopedia vol K p 197 - replaces the nails or
+spikes! / must be in the right place... Perhaps the translation the constables
+gave you is faulty, or perhaps (as you’ve long suspected) it’s just nonsense.
+But it’s a reminder that sometimes there just aren’t answers to be found
+anywhere in this world.
+
+Davis sets her sandwich aside as she pulls out another page.
+
+Exits: south east
+
+> table
+It can seat six comfortably, but nowadays your dinners are usually for one or
+two. So you’ve made sure it’s not too big for that.
+
+Your torch is on the table.
+
+Davis flips one of the sheets over, tapping her pen against the table.
+
+Exits: south east
+
+> paperwork
+Poor dear, this looks like a real mess of paperwork. It can be much easier to
+work on cases when you’re not officially part of the constabulary.
+
+Davis sets her sandwich aside as she pulls out another page.
+
+Exits: south east
+
+> davis
+You’ve always seen promise in Davis, from when she was just starting out as a
+bright-eyed new recruit. But she’s got a certain earnestness you’ve never quite
+been able to sway her from. Now she spends most of her time taking every menial
+task that’s pushed onto her, thinking straightforward honesty is the best path
+to promotion. Eventually, something is bound to shake her enough to take some
+initiative of her own...or at least, that was always your hope.
+
+Davis flips one of the sheets over, tapping her pen against the table.
+
+Exits: south east
+
+> * *** Access Garden ***
+> get sandwich
+Watson opens his mouth and carefully plucks the sandwich off the table.
+
+“Oi! What’s that all about?” Davis blinks in surprise as her food is snatched
+away right in front of her eyes. She rises to her feet, ready to give chase!
+
+Exits: south east
+
+> show sandwich
+To whom?
+
+Exits: south east
+
+> davis
+Constable Davis looks sadly at her mangled sandwich, and unceremoniously
+disposes of it. She does give Watson a little pet of appreciation, though.
+
+Exits: south east
+
+> z
+Watson tries as hard as he can to demonstrate patience.
+
+Davis settles back into her chair and returns to work. Now bereft of her
+sandwich, she pulls a biscuit from a pack.
+
+Exits: south east
+
+> get biscuit
+Watson opens his mouth and carefully plucks the biscuit off the table.
+
+“Oi! What’s that all about?” Davis blinks in surprise as her food is snatched
+away right in front of her eyes. She rises to her feet, ready to give chase!
+
+Exits: south east
+
+> eat biscuit
+Watson doesn’t need telling twice. Soon there’s nothing left of the biscuit.
+
+“Gotcha!” Davis has finally cornered Watson, forcing him to open his mouth...to
+find no trace left of her food. Watson looks much happier than she does as she
+turns to leave, empty-handed.
+
+Exits: south east
+
+> z
+Watson tries as hard as he can to demonstrate patience.
+
+Exits: south east
+
+> z
+Watson tries as hard as he can to demonstrate patience.
+
+Davis settles back into her chair and returns to work.
+
+Exits: south east
+
+> get biscuit
+Watson opens his mouth and carefully plucks the biscuit off the table.
+
+“Oi! What’s that all about?” Davis blinks in surprise as her food is snatched
+away right in front of her eyes. She rises to her feet, ready to give chase!
+
+Exits: south east
+
+> e
+Watson scampers east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+Davis follows from the dining room to the kitchen (where you are), in hot
+pursuit.
+
+Exits: south west southeast
+
+> z
+Watson tries as hard as he can to demonstrate patience.
+
+“Gotcha!” Davis has finally cornered Watson, forcing him to open his mouth. She
+looks sadly at what’s become of her biscuit, and disposes of it as she turns to
+leave.
+
+Exits: south west southeast
+
+> w
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis’s seat stands conspicuously vacant.
+
+On the table are a tape recorder and your torch.
+
+Exits: south east
+
+> z
+Watson tries as hard as he can to demonstrate patience.
+
+Davis makes her way from the kitchen to the dining room (where you are).
+
+Exits: south east
+
+> z
+Watson tries as hard as he can to demonstrate patience.
+
+Davis settles back into her chair and returns to work.
+
+Exits: south east
+
+> get biscuit
+Watson opens his mouth and carefully plucks the biscuit off the table.
+
+“Oi! What’s that all about?” Davis blinks in surprise as her food is snatched
+away right in front of her eyes. She rises to her feet, ready to give chase!
+
+Exits: south east
+
+> e
+Watson scampers east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+Davis follows from the dining room to the kitchen (where you are), in hot
+pursuit.
+
+Exits: south west southeast
+
+> se
+Watson scampers southeast, and you drift along behind.
+
+Reception room
+You designed this room specifically for uninvited guests. Back when the front
+door was at the west end of the house, they’d have to wait awkwardly outside
+until you had the sitting room or dining room in order. Now, there’s a place to
+sit and take tea with them at a moment’s notice—and admire the framed case
+reports on the wall—and that can make witnesses ever so much more willing to
+open up. What used to be the back door of the house leads northwest to the
+kitchen, and the new front door leads out to the south.
+
+Today’s mail is scattered across the floor.
+
+Davis follows from the kitchen to the reception room (where you are), in hot
+pursuit.
+
+Exits: (south) northwest
+
+> eat biscuit
+Watson doesn’t need telling twice. Soon there’s nothing left of the biscuit.
+
+“Gotcha! Huh?” Davis looks down at Watson, then up at the front door. He lets
+his tail droop and gives her his best whine.
+
+“You want out, then? Here you go. That should get you off my arse for a bit.”
+She flips the lock and pushes the door open before retreating, bereft of food.
+
+Your score has gone up by one point.
+
+Exits: south northwest
+
+> * *** In Garden ***
+> s
+Watson saunters out the front door, and you drift along behind.
+
+Veranda
+A little refuge from the weather, for when you want the fresh outdoor air
+without all the sun and the rain, between the front door to the north and the
+lawn to the south.
+
+A bin in the corner collects any stray glass for recycling.
+
+Exits: north south
+
+> pull bin north
+Watson maneuvers the bin carefully north, with you following behind.
+
+Reception room
+You designed this room specifically for uninvited guests. Back when the front
+door was at the west end of the house, they’d have to wait awkwardly outside
+until you had the sitting room or dining room in order. Now, there’s a place to
+sit and take tea with them at a moment’s notice—and admire the framed case
+reports on the wall—and that can make witnesses ever so much more willing to
+open up. What used to be the back door of the house leads northwest to the
+kitchen, and the new front door leads out to the south.
+
+The recycling bin has been pushed here, looking rather out of place.
+
+Constable Davis is here, looking rather frazzled.
+
+Today’s mail is scattered across the floor.
+
+Davis makes her way from the reception room (where you are) to the kitchen.
+
+Exits: south northwest
+
+> push bin northwest
+Watson maneuvers the bin carefully northwest, with you following behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The recycling bin has been pushed here, looking rather out of place.
+
+Constable Davis is here, looking rather frazzled.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+Davis makes her way from the kitchen (where you are) to the dining room.
+
+Exits: south west southeast
+
+> push bin south
+Watson maneuvers the bin carefully south, with you following behind.
+
+Hall
+This narrow hallway is right at the centre of the house, linking the sitting
+room to the south to the kitchen to the north. To the west, dark stairs lead
+down to the cellar, and to the east used to be a closet until you had it turned
+into a tiny little lavatory.
+
+The recycling bin has been pushed here, looking rather out of place.
+
+Davis settles back into her chair and returns to work. She reaches for a
+biscuit, but the pack is empty. She disposes of it with a sigh.
+
+Exits: north south west
+
+> push bin south
+Watson maneuvers the bin carefully south, with you following behind.
+
+Sitting room
+The big south-facing windows in this room give it the best light in the house,
+so you always take your breakfast and tea here. Normally it would be half-filled
+with your potted plants, but you took those out for Alfred to look at last week,
+and you haven’t had a moment to move them back in yet. The room continues west
+from here, while the hall leads north over a small step to the rest of the
+house.
+
+The recycling bin has been pushed here, looking rather out of place.
+
+You see a rubber ball here.
+
+Your ill-conceived binocular stand is fixed in front of the bay window.
+
+Exits: north west
+
+> look through window
+From this angle, you have a beautiful view of the tea garden, with its six beds
+arranged around the fountain in the center. The lavender in the fountain is a
+beautiful deep blue, but to your eyes the rest of the plants are a uniform
+yellowish colour—you’ve never been any better than Watson at distinguishing reds
+from yellows from greens.
+
+  NW  NE  
+W   <>   E
+  SW  SE  
+
+Exits: north west
+
+> stand
+Watson thumps his tail, about to spring into action. Did you want him to:
+1. examine the binocular stand, or
+2. stand up?
+
+(Type the corresponding number)
+
+> 1
+You’d set up a little stand in front of your best window, hoping to attach your
+binoculars to it for birdwatching. But then it never quite worked, because you
+always wanted to move them around too much; they’re much better for spying on
+people than birds. Now it just collects dust while you try to think of something
+better to put on it.
+
+Exits: north west
+
+> x bin
+Alfred’s been so very into recycling recently, and he’s asked you to collect any
+stray glass you don’t need; he picks it up every week or so for processing.
+
+A squat bottle is in the bin.
+
+A narrow bottle is in the bin.
+
+Exits: north west
+
+> put squat on stand
+(first attempting to take the squat bottle)
+Watson opens his mouth and carefully plucks the squat bottle out of the bin.
+
+Watson sets the squat bottle carefully on the binocular stand.
+
+Exits: north west
+
+> look through squat
+Looking through the red glass, the garden beds in the northwest, northeast,
+west, and east are a vibrant white, while the ones in the centre, southwest, and
+southeast are featureless black.
+
+  WW  WW  
+WW  BB  WW
+  BB  BB  
+
+Exits: north west
+
+> put narrow on stand
+(first attempting to take the narrow bottle)
+Watson opens his mouth and carefully plucks the narrow bottle out of the bin.
+
+Watson sets the narrow bottle carefully on the binocular stand.
+
+Exits: north west
+
+> look through narrow
+Looking through the green glass, the garden beds in the northeast, east,
+southwest, and southeast are a vibrant white, while the ones in the centre,
+northwest, and west are featureless black.
+
+  BB  WW  
+BB  BB  WW
+  WW  WW  
+
+Your score has gone up by one point.
+
+Exits: north west
+
+> n
+Watson saunters north, and you drift along behind.
+
+Hall
+This narrow hallway is right at the centre of the house, linking the sitting
+room to the south to the kitchen to the north. To the west, dark stairs lead
+down to the cellar, and to the east used to be a closet until you had it turned
+into a tiny little lavatory.
+
+Exits: north south west
+
+> n
+Watson saunters north, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+Exits: south west southeast
+
+> se
+Watson saunters southeast, and you drift along behind.
+
+Reception room
+You designed this room specifically for uninvited guests. Back when the front
+door was at the west end of the house, they’d have to wait awkwardly outside
+until you had the sitting room or dining room in order. Now, there’s a place to
+sit and take tea with them at a moment’s notice—and admire the framed case
+reports on the wall—and that can make witnesses ever so much more willing to
+open up. What used to be the back door of the house leads northwest to the
+kitchen, and the new front door leads out to the south.
+
+Today’s mail is scattered across the floor.
+
+Exits: south northwest
+
+> s
+Watson saunters out the front door, and you drift along behind.
+
+Veranda
+A little refuge from the weather, for when you want the fresh outdoor air
+without all the sun and the rain, between the front door to the north and the
+lawn to the south.
+
+Exits: north south
+
+> s
+Watson saunters south, and you drift along behind.
+
+Lawn
+It’s really not big enough to be called the grounds, but you’ve always been
+proud of your lawn and gardens, encircling the house on all sides. The most
+important one right now is your tea garden, down to the south; the veranda is
+back to the north.
+
+Today’s newspaper lies in front of the porch steps.
+
+Exits: north south
+
+> s
+Watson saunters south, and you drift along behind.
+
+Tea garden, centre
+Your tea garden is nestled deep in the foundation of the old ruins, the stone
+walls rising up on every side to give the plants just the perfect amount of
+sunlight and shade. Here at the centre is where you placed that lovely fountain,
+and a sturdy chair, to sit in while you contemplate your options.
+
+The garden beds themselves are arranged in a ring around you, and the path north
+leads back to the lawn. You have a lovely view of the whole thing from your
+sitting room.
+
+On the garden chair are a pair of gardening gloves.
+
+Exits: north east west northeast northwest southwest southeast
+
+> x chair
+The perfect place to sit and appreciate the gardens.
+
+A pair of gardening gloves has been left on the chair.
+
+Exits: north east west northeast northwest southwest southeast
+
+> x gloves
+Alfred must have left them here, intending to keep working on these beds
+tomorrow. He’s a diligent, hard-working man, and you’ve never known him to take
+shortcuts on his work; he prefers to handle things with his own two hands.
+
+Exits: north east west northeast northwest southwest southeast
+
+> alfred
+Alfred Tucker has been your gardener for years. Ever diligent, with a good eye
+for aesthetics; it’s thanks to him that the colours of your flower beds go
+together so nicely. You could imagine him committing murder, perhaps, if he had
+the right motivation—but he would do it in anger, with his own hands. Cold,
+impersonal poison is not his style.
+
+Unfortunately, he isn’t anywhere near your house at the moment.
+
+Exits: north east west northeast northwest southwest southeast
+
+> ne
+Watson saunters northeast, and you drift along behind.
+
+Tea garden, northeast
+The garden bed under the old walls is just as neat and tidy as ever, as it
+should be. The calendula is flourishing, ready for your next cup of tea.
+
+Exits: west southwest southeast
+
+> se
+Watson saunters southeast, and you drift along behind.
+
+Tea garden, east
+The garden bed under the old walls is just as neat and tidy as ever, as it
+should be. The rosebush is flourishing, ready for your next cup of tea.
+
+Exits: west northwest southwest
+
+> sw
+Watson saunters southwest, and you drift along behind.
+
+Tea garden, southeast
+The garden bed under the old walls is just as neat and tidy as ever, as it
+should be. The mint is flourishing, ready for your next cup of tea.
+
+Exits: west northeast northwest
+
+> nw
+Watson saunters northwest, and you drift along behind.
+
+Tea garden, centre
+Your tea garden is nestled deep in the foundation of the old ruins, the stone
+walls rising up on every side to give the plants just the perfect amount of
+sunlight and shade. Here at the centre is where you placed that lovely fountain,
+and a sturdy chair, to sit in while you contemplate your options.
+
+The garden beds themselves are arranged in a ring around you, and the path north
+leads back to the lawn. You have a lovely view of the whole thing from your
+sitting room.
+
+On the garden chair are a pair of gardening gloves.
+
+Exits: north east west northeast northwest southwest southeast
+
+> nw
+Watson saunters northwest, and you drift along behind.
+
+Tea garden, northwest
+The garden bed under the old walls is just as neat and tidy as ever, as it
+should be. The rosebush is flourishing, ready for your next cup of tea.
+
+Exits: east southwest southeast
+
+> sw
+Watson saunters southwest, and you drift along behind.
+
+Tea garden, west
+The garden bed under the old walls is just as neat and tidy as ever, as it
+should be. The beebalm is flourishing, ready for your next cup of tea.
+
+Exits: east northeast southeast
+
+> se
+Watson saunters southeast, and you drift along behind.
+
+Tea garden, southwest
+The garden bed under the old walls is just as neat and tidy as ever, as it
+should be. The rosebush is flourishing, ready for your next cup of tea.
+
+Exits: east northeast northwest
+
+> ne
+Watson saunters northeast, and you drift along behind.
+
+Tea garden, centre
+Your tea garden is nestled deep in the foundation of the old ruins, the stone
+walls rising up on every side to give the plants just the perfect amount of
+sunlight and shade. Here at the centre is where you placed that lovely fountain,
+and a sturdy chair, to sit in while you contemplate your options.
+
+The garden beds themselves are arranged in a ring around you, and the path north
+leads back to the lawn. You have a lovely view of the whole thing from your
+sitting room.
+
+On the garden chair are a pair of gardening gloves.
+
+Exits: north east west northeast northwest southwest southeast
+
+> xyzzy
+As you speak the word, you feel a strange sensation pulling you southwest...
+Watson saunters southwest, and you drift along behind.
+
+Tea garden, southwest
+The garden bed under the old walls is just as neat and tidy as ever, as it
+should be. The rosebush is flourishing, ready for your next cup of tea.
+
+Exits: east northeast northwest
+
+> take rose
+Watson delicately closes his mouth around one of the buds, trying to tear it
+free of the stem without getting pricked on the thorns. Oh, your poor
+flowers...but he does succeed, in the end.
+
+Exits: east northeast northwest
+
+> go to dining room
+(attempting to go northeast)
+Watson saunters northeast, and you drift along behind.
+
+Tea garden, centre
+Your tea garden is nestled deep in the foundation of the old ruins, the stone
+walls rising up on every side to give the plants just the perfect amount of
+sunlight and shade. Here at the centre is where you placed that lovely fountain,
+and a sturdy chair, to sit in while you contemplate your options.
+
+The garden beds themselves are arranged in a ring around you, and the path north
+leads back to the lawn. You have a lovely view of the whole thing from your
+sitting room.
+
+On the garden chair are a pair of gardening gloves.
+
+(attempting to go north)
+Watson saunters north, and you drift along behind.
+
+Lawn
+It’s really not big enough to be called the grounds, but you’ve always been
+proud of your lawn and gardens, encircling the house on all sides. The most
+important one right now is your tea garden, down to the south; the veranda is
+back to the north.
+
+Today’s newspaper lies in front of the porch steps.
+
+(attempting to go north)
+Watson saunters north, and you drift along behind.
+
+Veranda
+A little refuge from the weather, for when you want the fresh outdoor air
+without all the sun and the rain, between the front door to the north and the
+lawn to the south.
+
+(attempting to go north)
+Watson saunters through the front door, and you drift along behind.
+
+Reception room
+You designed this room specifically for uninvited guests. Back when the front
+door was at the west end of the house, they’d have to wait awkwardly outside
+until you had the sitting room or dining room in order. Now, there’s a place to
+sit and take tea with them at a moment’s notice—and admire the framed case
+reports on the wall—and that can make witnesses ever so much more willing to
+open up. What used to be the back door of the house leads northwest to the
+kitchen, and the new front door leads out to the south.
+
+Today’s mail is scattered across the floor.
+
+(attempting to go northwest)
+Watson saunters northwest, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+(attempting to go west)
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+On the table are a tape recorder and your torch.
+
+Davis pulls out another page, cross-checking it against the last.
+
+Exits: south east
+
+> show rose to davis
+“Hm? What’s this?” The constable looks down at the torn branch in Watson’s
+mouth.
+
+“Wait—is this—?” She takes it carefully, avoiding the thorns and the dog
+slobber. “The green roses! This must be from the same bush as the tea she drank
+last night! The boffins at the lab will need a look at this.”
+
+Watson sits back and wags his tail happily as Davis hurries off. It will take
+some time for the laboratory tests to come back, but you already know what
+they’ll say: that the roses weren’t poisoned, and Alfred is innocent.
+
+Your score has gone up by one point.
+
+Exits: south east
+
+> * *** Access Cellar ***
+> e
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+Davis makes her way from the reception room to the kitchen (where you are).
+
+Exits: south west southeast
+
+> s
+Watson saunters south, and you drift along behind.
+
+Hall
+This narrow hallway is right at the centre of the house, linking the sitting
+room to the south to the kitchen to the north. To the west, dark stairs lead
+down to the cellar, and to the east used to be a closet until you had it turned
+into a tiny little lavatory.
+
+Davis makes her way from the kitchen to the dining room.
+
+Exits: north south west
+
+> d
+Watson saunters down the cellar stairs, and you drift along behind.
+
+Landing
+The stairs turn around sharply here at a little wooden landing, just a foot or
+so above the ground. The pump here is supposed to keep your cellar from
+flooding, but with the electricity out, you have to fear the worst. The cellar
+proper is down to the northeast, in total darkness without the light from the
+hall windows, or you can go back up to the east.
+
+That photo album Lottie brought has been set in the corner for when she comes
+back.
+
+Davis settles back into her chair and returns to work.
+
+Exits: east northeast
+
+> album
+Lottie left it when she was over for dinner, filled with photos of her trip out
+to the Orient. Her son is some sort of archaeologist out there, with his wife,
+and she loved talking about all the intricate details of what they were doing.
+Fiddly details have always been her favourite thing, and she kept pushing you to
+keep working on those constabulary records that weren’t lining up—she just had a
+feeling it was a sign of something worse.
+
+Exits: east northeast
+
+> lottie
+Lottie—that is, Mrs Charlotte Peabody—is your closest friend in the area, and
+her regular visits for tea and gossip are a highlight of your week. She’s a
+meticulous, analytical sort, always picking out the flaws in a plan; if she
+turned her mind to murder, she would have a better alibi and a less obvious
+method.
+
+Unfortunately, she isn’t anywhere near your house at the moment.
+
+Exits: east northeast
+
+> ne
+Watson saunters northeast, and you drift along behind.
+
+Pantry (in the dark)
+It’s pitch dark, and you can barely see a thing. You can make out light to the
+southwest.
+
+Exits: southwest
+
+> s
+(first attempting to open the root cellar door to the south)
+The root cellar should be that way, but in the darkness you can’t seem to locate
+the door.
+
+Exits: southwest
+
+> door
+It should be somewhere in the south wall, but in the darkness you can’t quite
+find it.
+
+Exits: southwest
+
+> water
+Cold and wet, you have to imagine, though Watson is putting on a brave face and
+you yourself can’t feel it at all.
+
+Exits: southwest
+
+> go to dining room
+(attempting to go southwest)
+Watson noses his way southwest, and you drift along behind.
+
+Landing
+The stairs turn around sharply here at a little wooden landing, just a foot or
+so above the ground. The pump here is supposed to keep your cellar from
+flooding, but with the electricity out, you now know it’s thoroughly failed at
+that. The cellar proper is down to the northeast, in total darkness without the
+light from the hall windows, or you can go back up to the east.
+
+That photo album Lottie brought has been set in the corner for when she comes
+back.
+
+(attempting to go east)
+Watson saunters up the cellar stairs, and you drift along behind.
+
+Hall
+This narrow hallway is right at the centre of the house, linking the sitting
+room to the south to the kitchen to the north. To the west, dark stairs lead
+down to the cellar, and to the east used to be a closet until you had it turned
+into a tiny little lavatory.
+
+(attempting to go north)
+Watson saunters north, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+(attempting to go west)
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+On the table are a tape recorder and your torch.
+
+Davis runs her hands through her hair with a sigh.
+
+Exits: south east
+
+> get torch
+Watson opens his mouth and carefully plucks your torch off the table.
+
+Davis has no objection to the theft of your torch. She doesn’t seem to care what
+Watson does, as long as it doesn’t interfere with her paperwork or her lunch.
+
+Exits: south east
+
+> turn it on
+Watson paws at your torch, and it switches on!
+
+Davis pulls out another page, cross-checking it against the last.
+
+Exits: south east
+
+> go to pantry
+(attempting to go east)
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+(attempting to go south)
+Watson saunters south, and you drift along behind.
+
+Hall
+This narrow hallway is right at the centre of the house, linking the sitting
+room to the south to the kitchen to the north. To the west, dark stairs lead
+down to the cellar, and to the east used to be a closet until you had it turned
+into a tiny little lavatory.
+
+(attempting to go west)
+Watson saunters down the cellar stairs, and you drift along behind.
+
+Landing
+The stairs turn around sharply here at a little wooden landing, just a foot or
+so above the ground. The pump here is supposed to keep your cellar from
+flooding, but with the electricity out, you now know it’s thoroughly failed at
+that. The cellar proper is down to the northeast, in total darkness without the
+light from the hall windows, or you can go back up to the east.
+
+That photo album Lottie brought has been set in the corner for when she comes
+back.
+
+(attempting to go northeast)
+Watson saunters northeast, and you drift along behind.
+
+Pantry
+In the torchlight, your fears are confirmed: Watson is standing in at least
+three inches of water. Oh, what a mess...
+
+The door to the root cellar is now visible to the south.
+
+The dumbwaiter shaft ends here, well above Watson’s head.
+
+Exits: (south) southwest
+
+> s
+(first attempting to open the root cellar door to the south)
+Watson whines, and holds up your torch. This door needs to be pulled open, and
+he can’t do that with his mouth occupied.
+
+Exits: (south) southwest
+
+> drop torch
+Best not. It’s not waterproof, and with the electricity out, it’s your only
+source of light.
+
+Exits: (south) southwest
+
+> go to kitchen
+(attempting to go southwest)
+Watson saunters southwest, and you drift along behind.
+
+Landing
+The stairs turn around sharply here at a little wooden landing, just a foot or
+so above the ground. The pump here is supposed to keep your cellar from
+flooding, but with the electricity out, you now know it’s thoroughly failed at
+that. The cellar proper is down to the northeast, in total darkness without the
+light from the hall windows, or you can go back up to the east.
+
+That photo album Lottie brought has been set in the corner for when she comes
+back.
+
+(attempting to go east)
+Watson saunters up the cellar stairs, and you drift along behind.
+
+Hall
+This narrow hallway is right at the centre of the house, linking the sitting
+room to the south to the kitchen to the north. To the west, dark stairs lead
+down to the cellar, and to the east used to be a closet until you had it turned
+into a tiny little lavatory.
+
+(attempting to go north)
+Watson saunters north, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+Exits: south west southeast
+
+> push wheel
+The dumbwaiter sinks into sight.
+
+Exits: south west southeast
+
+> put torch in dumbwaiter
+Watson sets your torch carefully in the dumbwaiter.
+
+Exits: south west southeast
+
+> w
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+On the table is a tape recorder.
+
+Davis runs her hands through her hair with a sigh.
+
+Exits: south east
+
+> get recorder
+Watson opens his mouth and carefully plucks the tape recorder off the table.
+
+Davis flips one of the sheets over, tapping her pen against the table.
+
+Exits: south east
+
+> push play
+The recorder clicks on, and a tinny voice starts to play. Some sort of
+testimony, from the sound of it.
+
+Hearing the whine of the tape recorder, Davis reaches over and shuts it off.
+
+Exits: south east
+
+> e
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter is here, with your torch in it.
+
+The stove is tucked away to one side.
+
+Exits: south west southeast
+
+> put recorder in dumbwaiter
+Watson sets the tape recorder carefully in the dumbwaiter.
+
+Exits: south west southeast
+
+> play
+The recorder clicks on, and a tinny voice starts to play. Some sort of
+testimony, from the sound of it.
+
+“...their country-place, Styles Court, had been purchased by Mr Cavendish early
+in their married life...”
+
+Exits: south west southeast
+
+> push wheel
+The dumbwaiter sinks out of sight.
+
+Exits: south west southeast
+
+> go to pantry
+(attempting to go south)
+Watson saunters south, and you drift along behind.
+
+Hall
+This narrow hallway is right at the centre of the house, linking the sitting
+room to the south to the kitchen to the north. To the west, dark stairs lead
+down to the cellar, and to the east used to be a closet until you had it turned
+into a tiny little lavatory.
+
+(attempting to go west)
+Watson saunters down the cellar stairs, and you drift along behind.
+
+Landing
+The stairs turn around sharply here at a little wooden landing, just a foot or
+so above the ground. The pump here is supposed to keep your cellar from
+flooding, but with the electricity out, you now know it’s thoroughly failed at
+that. The cellar proper is down to the northeast, in near-total darkness without
+the light from the hall windows, or you can go back up to the east.
+
+That photo album Lottie brought has been set in the corner for when she comes
+back.
+
+(attempting to go northeast)
+Watson saunters northeast, and you drift along behind.
+
+Pantry
+In the torchlight, your fears are confirmed: Watson is standing in at least
+three inches of water. Oh, what a mess...
+
+The door to the root cellar is now visible to the south.
+
+The dumbwaiter hangs well above Watson’s head, with a tape recorder and your
+torch in it.
+
+“...he had been completely under his wife’s ascendancy, so much so that, on
+dying, he left the place to her for her lifetime...”
+
+Exits: (south) southwest
+
+> s
+(first attempting to open the root cellar door to the south)
+Watson noses the root cellar door open.
+
+“...as well as the larger part of his income; an arrangement that was distinctly
+unfair to his two sons...”
+
+Watson saunters through the root cellar door, and you drift along behind.
+
+Root cellar (in the dark)
+It’s pitch dark, and you can barely see a thing. You can make out light to the
+north.
+
+The door to the root cellar swings closed again.
+
+Your score has gone up by one point.
+
+Exits: (north) south east west northeast northwest southwest southeast
+
+> * *** In Cellar ***
+> smell
+Watson splashes through the water as he snuffles around, before stopping a few
+feet off to the northwest.
+
+Exits: (north) south east west northeast northwest southwest southeast
+
+> xyzzy
+As you speak the word, you feel a strange sensation pulling you northwest...
+Watson splashes away to the northwest, and you try your best to follow...until
+his paw hits something with a soft thump. He must have found the carrots!
+
+Depths of the root cellar (in the dark)
+It’s pitch dark, and you can barely see a thing. You can’t even make out any
+exits.
+
+From the sound of Watson’s snuffling, there’s something at your feet.
+
+Exits: north south east west northeast northwest southwest southeast
+
+> carrots
+A one-peck bundle of carrots, fresh from the farmer’s market. Lottie picked them
+up as part of a good deal on onions, but she can’t stand the smell, so she
+brought them over for you and Watson to enjoy. They should be good, even if
+they’re mildly soggy now.
+
+Exits: north south east west northeast northwest southwest southeast
+
+> get it
+Watson opens his mouth and carefully scoops up the bundle of carrots.
+
+Your score has gone up by one point.
+
+Exits: north south east west northeast northwest southwest southeast
+
+> listen
+Watson is silent for a moment, listening intently, before you hear him move to
+the west. There seems to be some source of noise that way!
+
+Exits: north south east west northeast northwest southwest southeast
+
+> xyzzy
+As you speak the word, you feel a strange sensation pulling you west... Watson
+splashes away to the west, and you try your best to follow...until suddenly a
+hint of light is visible in the darkness.
+
+Root cellar (in the dark)
+It’s pitch dark, and you can barely see a thing. You can make out light to the
+north.
+
+Exits: (north) south east west northeast northwest southwest southeast
+
+> north
+(first attempting to open the root cellar door to the north)
+Watson noses the root cellar door open.
+
+Watson noses his way out the root cellar door, and you drift along behind.
+
+Pantry
+In the torchlight, your fears are confirmed: Watson is standing in at least
+three inches of water. Oh, what a mess...
+
+The door to the root cellar is now visible to the south.
+
+The dumbwaiter hangs well above Watson’s head, with a tape recorder and your
+torch in it.
+
+The door to the root cellar swings closed again.
+
+“...their step-mother, however, had always been most generous to them...”
+
+Exits: (south) southwest
+
+> go to dining room
+(attempting to go southwest)
+Watson saunters southwest, and you drift along behind.
+
+Landing
+The stairs turn around sharply here at a little wooden landing, just a foot or
+so above the ground. The pump here is supposed to keep your cellar from
+flooding, but with the electricity out, you now know it’s thoroughly failed at
+that. The cellar proper is down to the northeast, in near-total darkness without
+the light from the hall windows, or you can go back up to the east.
+
+That photo album Lottie brought has been set in the corner for when she comes
+back.
+
+(attempting to go east)
+Watson saunters up the cellar stairs, and you drift along behind.
+
+Hall
+This narrow hallway is right at the centre of the house, linking the sitting
+room to the south to the kitchen to the north. To the west, dark stairs lead
+down to the cellar, and to the east used to be a closet until you had it turned
+into a tiny little lavatory.
+
+(attempting to go north)
+Watson saunters north, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+(attempting to go west)
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis runs her hands through her hair with a sigh.
+
+Exits: south east
+
+> xyzzy
+That’s that “magic word” Nigel was on about, from some new game he found? You
+don’t understand any of it, really, but he seems to enjoy it at least.
+
+Davis flips one of the sheets over, tapping her pen against the table.
+
+Exits: south east
+
+> give carrots to davis
+Davis looks down at Watson, and winces at the sight of water being dripped all
+over your rug. (Well, it can’t be helped.) It takes her a moment more to realise
+what exactly it’s dripping from.
+
+“The carrots!” Watson lets go obligingly as she heaves the bundle up onto the
+table, trying to keep it from soaking her paperwork. “Don’t know how you knew we
+needed these, but I’ll get them to the lab right away. Thanks, boy.”
+
+Watson sits back with a proud smile as Davis makes the arrangements, though he
+seems a bit sad not to be given a carrot himself for his efforts. The lab tests
+will take a while, but you’re confident they’ll come back clean. Lottie is
+innocent.
+
+Your score has gone up by one point.
+
+Exits: south east
+
+> * *** Access Attic ***
+> s
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+Your body lies at the bottom of the stairs.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+Davis makes her way from the reception room to the kitchen.
+
+Exits: north south east (west)
+
+> up
+Watson saunters up the stairs, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+From the sound of it, Phillips is hard at work in the suite to the south.
+
+Davis makes her way from the kitchen to the dining room.
+
+Exits: (north) (south) west northwest
+
+> nw
+Watson saunters northwest, and you drift along behind.
+
+Upstairs hall
+The hall runs alongside the staircase here before bending sharply at the end,
+with a little balcony to the south overlooking the first floor. The top of the
+stairs is back to the southeast, and the guest room will be to the north—once
+it’s been properly repainted and made livable, at least.
+
+A dangling cord marks the location of the trapdoor to the attic.
+
+A mattress is propped up against one wall, for lack of anywhere better to put
+it.
+
+Davis settles back into her chair and returns to work.
+
+Exits: south southeast (up)
+
+> cord
+The cord hangs down just above Watson’s head, easily within reach.
+
+Exits: south southeast (up)
+
+> pull it
+Watson leaps upward and catches the cord in his teeth, trying to hold onto it
+with all his strength. For a moment it doesn’t seem like his weight will be
+enough...but with a steady groan the trapdoor opens and the stairs swing
+downward. His momentum carries him off to the south, depositing him with a
+gentle thump on the balcony.
+
+Balcony
+The hallway ends with a narrow balcony, connecting your bedroom to the south
+with everything else to the north. The railing to the east protects you from a
+dizzying drop to the bottom of the stairs. Evidence from another of your past
+cases is displayed proudly on the wall.
+
+The trapdoor to the attic is open, blocking off the passage to the north.
+Unfortunately, the stairs are on the other side.
+
+Exits: (south)
+
+> n
+The stairs to the attic block off that hallway completely.
+
+Exits: (south)
+
+> jump
+Watson peers over the edge, then look up at you with a scared whimper. He’s
+always been a good jumper, but after what happened last night, you can’t really
+blame him.
+
+Exits: (south)
+
+> push stairs
+Watson shoves his face and paws under the bottom step, rolling over onto his
+back and pushing with all his might. It only moves a little, but that’s enough
+for the mechanism to take over, and it snaps up into the ceiling.
+
+Exits: north (south)
+
+> n
+Watson saunters north, and you drift along behind.
+
+Upstairs hall
+The hall runs alongside the staircase here before bending sharply at the end,
+with a little balcony to the south overlooking the first floor. The top of the
+stairs is back to the southeast, and the guest room will be to the north—once
+it’s been properly repainted and made livable, at least.
+
+A dangling cord marks the location of the trapdoor to the attic.
+
+A mattress is propped up against one wall, for lack of anywhere better to put
+it.
+
+Exits: south southeast (up)
+
+> push mattress south
+Watson maneuvers the mattress carefully south, with you following behind.
+
+Balcony
+The hallway ends with a narrow balcony, connecting your bedroom to the south
+with everything else to the north. The railing to the east protects you from a
+dizzying drop to the bottom of the stairs. Evidence from another of your past
+cases is displayed proudly on the wall.
+
+A dangling cord marks the location of the trapdoor to the attic.
+
+A mattress is propped up against one wall, for lack of anywhere better to put
+it.
+
+Exits: north (south)
+
+> push mattress east
+With a mighty heave, Watson shoves the mattress over the edge! It tumbles end-
+over-end in a rush of air, the corners of the fabric fluttering wildly, until it
+lands with a mighty whomp at the foot of the stairs.
+
+Well, at least you won’t have to look at your own corpse any more.
+
+Exits: north (south)
+
+> pull cord
+Watson leaps upward and catches the cord in his teeth, trying to hold onto it
+with all his strength. For a moment it doesn’t seem like his weight will be
+enough...but with a steady groan the trapdoor opens and the stairs swing
+downward, carrying Watson with them and depositing him with a gentle thump on
+the balcony.
+
+Balcony
+The hallway ends with a narrow balcony, connecting your bedroom to the south
+with everything else to the north. The railing to the east protects you from a
+dizzying drop to the bottom of the stairs. Evidence from another of your past
+cases is displayed proudly on the wall.
+
+The trapdoor to the attic is open, blocking off the passage to the north.
+Unfortunately, the stairs are on the other side.
+
+Exits: (south)
+
+> jump
+Watson braces himself on the edge for a moment, steeling his nerves. Then with a
+mighty leap, he launches himself up and over the balcony! You find yourself
+drifting down with him as he plummets down the stairs and lands with a whump on
+the mattress below.
+
+Bottom of the stairs (on the mattress)
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+Exits: north south east (west)
+
+> up
+(first attempting to get off the mattress)
+Watson leaps off the mattress.
+
+Watson saunters up the stairs, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+From the sound of it, Phillips is hard at work in the suite to the south.
+
+Exits: (north) (south) west northwest
+
+> nw
+Watson saunters northwest, and you drift along behind.
+
+Upstairs hall
+The hall runs alongside the staircase here before bending sharply at the end,
+with a little balcony to the south overlooking the first floor. The top of the
+stairs is back to the southeast, and the guest room will be to the north—once
+it’s been properly repainted and made livable, at least.
+
+The trapdoor to the attic is open, the collapsible steps leading up to the
+south.
+
+Exits: southeast up
+
+> s
+The stairs to the attic block off that hallway completely.
+
+Exits: southeast up
+
+> u
+Watson clambers up the attic stairs, and you drift along behind.
+
+Attic, west (in the dark)
+It’s pitch dark, and you can barely see a thing. You can make out light below.
+
+The collapsible stairs lead down through the trapdoor to the rest of the house.
+
+A faint hint of light outlines the heavy shutters blocking the window.
+
+Off to the northeast, you can almost make out a victrola.
+
+Off to the southeast, you can almost make out a grandfather clock.
+
+Your score has gone up by one point.
+
+Exits: northeast southeast down
+
+> * *** In Attic ***
+> go to kitchen
+(attempting to go down)
+Watson clambers down the attic stairs, and you drift along behind.
+
+Upstairs hall
+The hall runs alongside the staircase here before bending sharply at the end,
+with a little balcony to the south overlooking the first floor. The top of the
+stairs is back to the southeast, and the guest room will be to the north—once
+it’s been properly repainted and made livable, at least.
+
+The trapdoor to the attic is open, the collapsible steps leading up to the
+south.
+
+(attempting to go southeast)
+Watson saunters southeast, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+From the sound of it, Phillips is hard at work in the suite to the south.
+
+(attempting to go west)
+Watson saunters down the stairs, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+(attempting to go north)
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis runs her hands through her hair with a sigh.
+
+(attempting to go east)
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+Exits: south west southeast
+
+> push wheel
+The dumbwaiter rises into sight, bringing you a tape recorder and your torch.
+
+“...indeed, they were so young at the time of their father’s remarriage that
+they always thought of her as their own mother...”
+
+Exits: south west southeast
+
+> off
+The recorder clicks off.
+
+Exits: south west southeast
+
+> push wheel
+The dumbwaiter rises out of sight.
+
+Exits: south west southeast
+
+> push wheel
+The cables glide along their tracks, sending the dumbwaiter to the attic.
+
+Exits: south west southeast
+
+> go to attic west
+(attempting to go west)
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis pulls out another page, cross-checking it against the last.
+
+(attempting to go south)
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+(attempting to go east)
+Watson saunters up the stairs, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+From the sound of it, Phillips is hard at work in the suite to the south.
+
+(attempting to go northwest)
+Watson saunters northwest, and you drift along behind.
+
+Upstairs hall
+The hall runs alongside the staircase here before bending sharply at the end,
+with a little balcony to the south overlooking the first floor. The top of the
+stairs is back to the southeast, and the guest room will be to the north—once
+it’s been properly repainted and made livable, at least.
+
+The trapdoor to the attic is open, the collapsible steps leading up to the
+south.
+
+(attempting to go up)
+Watson clambers up the attic stairs, and you drift along behind.
+
+Attic, west (in the dark)
+It’s pitch dark, and you can barely see a thing. You can make out light to the
+northeast and below.
+
+The collapsible stairs lead down through the trapdoor to the rest of the house.
+
+A faint hint of light outlines the heavy shutters blocking the window.
+
+Off to the northeast, you can clearly see a victrola. Watson might be able to
+leap to it, from the right starting point.
+
+Off to the southeast, you can almost make out a grandfather clock.
+
+Exits: northeast southeast down
+
+> n
+Watson noses his way northeast, and you drift along behind.
+
+Attic, north
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the north side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+Outside your little circle of torchlight, who knows what might be hidden in the
+darkness?
+
+A faint hint of light outlines the heavy shutters blocking the window.
+
+The dumbwaiter is here, with a tape recorder and your torch in it.
+
+Your old victrola rests under the dumbwaiter.
+
+Off to the southeast, you can almost make out an organ.
+
+Exits: southwest southeast
+
+> clutter
+Too many things to even list—not that that’s stopped Nigel from trying. He wants
+to make a proper inventory of it at some point, and that sort of fastidiousness
+is what he lives for.
+
+Exits: southwest southeast
+
+> nigel
+Your nephew Nigel is such a dear. He worries about everything, and at your age,
+you have to admit it’s not entirely without cause. You wouldn’t put it past him
+to contemplate murder, perhaps, but he’d immediately talk himself out of it.
+
+Unfortunately, he isn’t anywhere near your house at the moment.
+
+Exits: southwest southeast
+
+> get torch
+Watson opens his mouth and carefully plucks your torch out of the dumbwaiter.
+
+Exits: southwest southeast
+
+> vents
+There are vents set into the floor under the carpet, to keep your laboratory
+well-ventilated, but the torchlight isn’t bright enough to pick them out.
+
+Exits: southwest southeast
+
+> jump on victrola
+Watson leaps up onto the victrola.
+
+Exits: southwest southeast
+
+> jump on organ
+Watson peers toward the organ in the east side of the attic, then whimpers
+nervously. He’s a great leaper and could probably cross the distance, but he
+can’t see it well enough in the dark to be sure of his landing.
+
+Exits: southwest southeast
+
+> e
+(first attempting to get off the victrola)
+Watson leaps off the victrola.
+
+Watson saunters southeast, and you drift along behind.
+
+Attic, east
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the east side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+Outside your little circle of torchlight, who knows what might be hidden in the
+darkness?
+
+The door to your laboratory stands to the west.
+
+A faint hint of light outlines the heavy shutters blocking the window.
+
+A reed organ is positioned against the inner wall.
+
+Off to the northwest, you can almost make out a victrola.
+
+Off to the southwest, you can almost make out a grandfather clock.
+
+Exits: (west) northwest southwest
+
+> open windows
+Watson looks up at the chains, and flops down forlornly. They’re a good eight
+feet above the ground, far too high for him to jump.
+
+Exits: (west) northwest southwest
+
+> get on organ
+Watson can just barely get his paws up on top, but it’s a bit too tall to jump
+to from the ground.
+
+Exits: (west) northwest southwest
+
+> put torch on organ
+Watson sets your torch carefully on the organ.
+
+Exits: (west) northwest southwest
+
+> n
+Watson saunters northwest, and you drift along behind.
+
+Attic, north (in the dark)
+It’s pitch dark, and you can barely see a thing. You can make out light to the
+southeast.
+
+A faint hint of light outlines the heavy shutters blocking the window.
+
+You can dimly make out the shape of your old victrola, pushed back against the
+wall.
+
+Off to the southeast, you can clearly see an organ. Watson might be able to leap
+to it, from the right starting point.
+
+Exits: southwest southeast
+
+> get on victrola
+Watson leaps up onto the victrola.
+
+Exits: southwest southeast
+
+> jump on organ
+Watson focuses intently on the organ, gauging the distance for a moment. Then
+with a mighty leap, he launches himself across the gap!
+
+Attic, east (on the organ)
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the east side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+Outside your little circle of torchlight, who knows what might be hidden in the
+darkness?
+
+The door to your laboratory stands to the west.
+
+A faint hint of light outlines the heavy shutters blocking the window.
+
+A reed organ is positioned against the inner wall.
+
+Your torch is on the organ.
+
+Off to the northwest, you can almost make out a victrola.
+
+Off to the southwest, you can almost make out a grandfather clock.
+
+Exits: (west) northwest southwest
+
+> jump on clock
+Watson peers toward the grandfather clock in the south side of the attic, then
+whimpers nervously. He’s a great leaper and could probably cross the distance,
+but he can’t see it well enough in the dark to be sure of his landing.
+
+Exits: (west) northwest southwest
+
+> throw torch
+(first attempting to take your torch)
+Watson opens his mouth and carefully scoops up your torch.
+
+In which direction?
+
+Exits: (west) northwest southwest
+
+> southwest
+With a sharp flick of his head, Watson flings your torch southwestward, sending
+it sailing to the south side of the attic.
+
+Exits: northwest southwest
+
+> jump on clock
+Watson focuses intently on the grandfather clock, gauging the distance for a
+moment. Then with a mighty leap, he launches himself across the gap!
+
+Attic, south (on the grandfather clock)
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the south side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+Outside your little circle of torchlight, who knows what might be hidden in the
+darkness?
+
+A faint hint of light outlines the heavy shutters blocking the window.
+
+You see your torch here.
+
+The grandfather clock looms just under the windows.
+
+Off to the northeast, you can almost make out an organ.
+
+Exits: northeast northwest
+
+> get torch
+Watson stretches his body, trying to reach your torch, then settles back with a
+sad whimper.
+
+Exits: northeast northwest
+
+> open windows
+From his perch atop the clock, Watson stretches up and catches the chain in his
+mouth. With a sharp tug the shutters all around the attic snap open, and the
+afternoon sunlight streams in.
+
+Attic, south (on the grandfather clock)
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the south side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+In the afternoon sunlight, you can just barely trace the outline of the vents
+under the carpet.
+
+You see your torch here.
+
+The grandfather clock looms just under the windows.
+
+Off to the northeast, you can clearly see an organ. Watson could probably make
+that leap.
+
+Your score has gone up by one point.
+
+Exits: northeast northwest
+
+> get in vent
+Watson stretches his body, trying to reach the floor vents, then settles back
+with a sad whimper.
+
+Exits: northeast northwest
+
+> down
+Watson leaps off the grandfather clock.
+
+Exits: northeast northwest
+
+> get in vent
+Watson tries, but there’s a layer of carpet in the way. He’ll have to get
+through that first.
+
+Exits: northeast northwest
+
+> open vent
+Watson paws at the carpet for a moment, but can’t find a way to open it without
+just chewing through. And surely that’s not what you want.
+
+Exits: northeast northwest
+
+> chew carpet
+You kneel down and guide Watson’s nose to the right place, and he starts
+scratching at the carpet with furious intensity. He doesn’t get the opportunity
+to dig very often, and he’s determined to make the most of this moment. Soon a
+corner tears free, revealing the vent hidden underneath.
+
+Exits: northeast northwest
+
+> get in vent
+Watson launches himself into the floor vents, and you follow along behind.
+
+Exits: north northeast northwest
+
+> north
+You can’t see Watson moving, but as he scrabbles through the vents, you find
+yourself pulled along to the north.
+
+Laboratory (in the floor vents)
+At the very center of the attic is the laboratory, where you spend your spare
+time tinkering with chemicals. Nigel jokes that you’re a fairy-tale witch
+updated to the twentieth century, but it’s been plenty of help with cases in the
+past—and besides, everyone needs a hobby.
+
+The door leads out to the east, thankfully easier to open from this side.
+
+In the afternoon sunlight, you can just barely trace the outline of the vents
+under the carpet.
+
+Your box of poisons lies in the midst of the equipment, clearly labelled for
+safety.
+
+Exits: north south east west
+
+> equipment
+It’s probably a bit antiquated, by modern standards, but you’ve found it very
+serviceable.
+
+Exits: north south east west
+
+> out
+Watson tries, but there’s a layer of carpet in the way. He’ll have to get
+through that first.
+
+Exits: north south east west
+
+> chew carpet
+There’s a scratching, scrabbling noise as Watson struggles to get his teeth and
+claws into the carpet—followed by a loud, satisfying rip. His head emerges from
+the floor, tongue lolling out happily.
+
+Exits: north south east west
+
+> push carpet
+Watson nudges the carpet, and it flops loosely, not posing much of an obstacle
+now.
+
+Exits: north south east west
+
+> out
+Watson leaps out of the floor vents.
+
+Exits: (east)
+
+> get poisons
+Watson opens his mouth and carefully scoops up the box of poisons.
+
+Exits: (east)
+
+> open door
+Watson noses the laboratory door open.
+
+Exits: east
+
+> out
+Watson saunters out the laboratory door, and you drift along behind.
+
+Attic, east
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the east side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+The door to your laboratory stands open to the west.
+
+In the afternoon sunlight, you can just barely trace the outline of the vents
+under the carpet.
+
+A reed organ is positioned against the inner wall.
+
+Off to the northwest, you can clearly see a victrola. Watson might be able to
+leap to it, from the right starting point.
+
+Off to the southwest, you can clearly see a grandfather clock. Watson might be
+able to leap to it, from the right starting point.
+
+Exits: west northwest southwest
+
+> go to dining room
+(attempting to go southwest)
+Watson saunters southwest, and you drift along behind.
+
+Attic, south
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the south side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+The carpet has been torn up to reveal the vent underneath.
+
+You see your torch here.
+
+The grandfather clock looms just under the windows.
+
+Off to the northeast, you can clearly see an organ. Watson might be able to leap
+to it, from the right starting point.
+
+(attempting to go northwest)
+Watson saunters northwest, and you drift along behind.
+
+Attic, west
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the west side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+The collapsible stairs lead down through the trapdoor to the rest of the house.
+
+In the afternoon sunlight, you can just barely trace the outline of the vents
+under the carpet.
+
+Off to the northeast, you can clearly see a victrola. Watson might be able to
+leap to it, from the right starting point.
+
+Off to the southeast, you can clearly see a grandfather clock. Watson might be
+able to leap to it, from the right starting point.
+
+(attempting to go down)
+Watson clambers down the attic stairs, and you drift along behind.
+
+Upstairs hall
+The hall runs alongside the staircase here before bending sharply at the end,
+with a little balcony to the south overlooking the first floor. The top of the
+stairs is back to the southeast, and the guest room will be to the north—once
+it’s been properly repainted and made livable, at least.
+
+The trapdoor to the attic is open, the collapsible steps leading up to the
+south.
+
+(attempting to go southeast)
+Watson saunters southeast, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+From the sound of it, Phillips is hard at work in the suite to the south.
+
+(attempting to go west)
+Watson saunters down the stairs, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+(attempting to go north)
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis runs her hands through her hair with a sigh.
+
+Exits: south east
+
+> give poisons to davis
+“What’s this now?” Watson pushes the box insistently into Davis’s hands, and she
+has to turn it around to read it. “Poisons? Now where on earth did you get
+this?” She extricates it carefully from his mouth, and opens it to see the
+assortment of carefully-labelled vials inside. “This would be from her
+laboratory, then? The nephew could have tampered with them—you,” she looks
+severely at Watson, “need to be more careful! It could have poisoned you too.”
+
+She seals the box again. “The fingerprints will tell us one way or another.” But
+you already know the answer; Nigel isn’t the sort to do a thing like that. The
+tests will prove him innocent.
+
+Your score has gone up by one point.
+
+Exits: south east
+
+> * *** Access Upstairs ***
+> e
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+Davis makes her way from the reception room to the kitchen (where you are).
+
+Exits: south west southeast
+
+> se
+Watson saunters southeast, and you drift along behind.
+
+Reception room
+You designed this room specifically for uninvited guests. Back when the front
+door was at the west end of the house, they’d have to wait awkwardly outside
+until you had the sitting room or dining room in order. Now, there’s a place to
+sit and take tea with them at a moment’s notice—and admire the framed case
+reports on the wall—and that can make witnesses ever so much more willing to
+open up. What used to be the back door of the house leads northwest to the
+kitchen, and the new front door leads out to the south.
+
+Today’s mail is scattered across the floor.
+
+Davis makes her way from the kitchen to the dining room.
+
+Exits: south northwest
+
+> get mail
+Watson opens his mouth and carefully scoops up the mail.
+
+Davis settles back into her chair and returns to work.
+
+Exits: south northwest
+
+> nw
+Watson saunters northwest, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side.
+
+Exits: south west southeast
+
+> put mail on stove
+Watson sets the mail carefully on the stove.
+
+Exits: south west southeast
+
+> turn on stove
+The lighter makes a clicking sound as Watson paws at the dials, until finally he
+catches it just right, and the flame takes hold. It’s not long before the mail
+on top starts to fill the room with smoke. Really, you suppose, that’s the best
+you can expect from a dog’s cooking.
+
+Exits: south west southeast
+
+> w
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+A haze of smoke clouds the air.
+
+The smoke alarm begins to shriek. As the alarm starts to blare, Davis puts aside
+her work with a groan.
+
+Exits: south east
+
+> get alarm
+Watson stretches his body, trying to reach the smoke detector, then settles back
+with a sad whimper.
+
+Exits: south east
+
+> jump on table
+Watson leaps up onto the table.
+
+A haze of smoke clouds the air.
+
+The smoke alarm continues to shriek.
+
+“Down from there! Now!” Davis gives Watson a little shove, and he hops down with
+a whimper.
+
+Exits: south east
+
+> z
+Watson tries as hard as he can to demonstrate patience.
+
+A haze of smoke clouds the air.
+
+The smoke alarm continues to shriek.
+
+Davis gets up from her chair.
+
+Exits: south east
+
+> z
+Watson tries as hard as he can to demonstrate patience.
+
+A haze of smoke clouds the air.
+
+The smoke alarm continues to shriek.
+
+Davis makes her way from the dining room (where you are) to the kitchen.
+
+Exits: south east
+
+> jump on table
+Watson leaps up onto the table.
+
+A haze of smoke clouds the air.
+
+The smoke alarm continues to shriek.
+
+Following the smoke to the kitchen, Davis is confronted with the horrors of the
+smoldering mail, and immediately turns off the stove.
+
+Exits: south east
+
+> get alarm
+Balancing on his hind legs and stretching to his full length, Watson manages to
+knock the smoke detector down from its perch and scoop it into his mouth.
+
+A haze of smoke clouds the air.
+
+The smoke alarm continues to shriek.
+
+Exits: south east
+
+> s
+(first attempting to get off the table)
+Watson leaps off the table.
+
+A haze of smoke clouds the air.
+
+The smoke alarm continues to shriek.
+
+Davis makes her way from the kitchen to the dining room (where you are).
+
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+A haze of smoke clouds the air.
+
+The smoke alarm continues to shriek.
+
+Davis settles back into her chair and returns to work.
+
+Exits: north south east (west)
+
+> up
+Watson saunters up the stairs, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+From the sound of it, Phillips is hard at work in the suite to the south.
+
+The alarm falls silent, and Watson can finally relax again.
+
+Exits: (north) (south) west northwest
+
+> drop alarm
+Watson sets the smoke detector carefully on the ground.
+
+Exits: (north) (south) west northwest
+
+> down
+Watson saunters down the stairs, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+Exits: north south east (west)
+
+> n
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis sets the last sheet aside, turning to the next.
+
+Exits: south east
+
+> e
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side. On the stove is some mail.
+
+Exits: south west southeast
+
+> turn on stove
+The lighter makes a clicking sound as Watson paws at the dials, until finally he
+catches it just right, and the flame takes hold. It’s not long before the mail
+on top starts to fill the room with smoke. Really, you suppose, that’s the best
+you can expect from a dog’s cooking.
+
+Exits: south west southeast
+
+> w
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+A haze of smoke clouds the air.
+
+At the telltale smell of smoke, Davis puts aside her work with a groan.
+
+Exits: south east
+
+> s
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+A haze of smoke clouds the air.
+
+Davis gets up from her chair.
+
+Exits: north south east (west)
+
+> up
+Watson saunters up the stairs, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+From the sound of it, Phillips is hard at work in the suite to the south.
+
+You see a smoke detector here.
+
+A haze of smoke clouds the air.
+
+The smoke alarm begins to shriek.
+
+The sound of an emergency alarm is finally enough to pull Constable Phillips
+away from his work. He throws open the door to the suite and launches himself
+down the stairs.
+
+Davis makes her way from the dining room to the kitchen.
+
+Your score has gone up by one point.
+
+Exits: (north) south west northwest
+
+> s
+Watson saunters through the suite door, and you drift along behind.
+
+Master suite
+Such a grand name for what amounts to five feet of hallway-slash-closet,
+connecting your bedroom to the west to your bathroom to the northeast. The door
+to the north leads out to the rest of the house.
+
+Your racks of clothes stand in disarray, methodically ransacked by the
+constables.
+
+A haze of smoke clouds the air.
+
+In the top of the stairs, the smoke alarm continues to shriek. Phillips hurries
+through the dining room to the kitchen.
+
+Following the smoke to the kitchen, Davis is confronted with the horrors of the
+smoldering mail, and immediately turns off the stove.
+
+Exits: north west northeast
+
+> phillips
+“Fastidious” is perhaps the best word to describe the young constable, so
+insistent on doing everything by the book. You always appreciate his
+thoroughness in searching for clues, now that you’re in no state to be bending
+down and dusting for fingerprints under automobiles and such, but he’ll never be
+promoted if he can’t learn to put the pieces together himself. When he’s set
+himself to a task, nothing short of an absolute emergency will sway him from his
+course.
+
+Currently, he should be in the kitchen.
+
+In the top of the stairs, the smoke alarm continues to shriek. Phillips sprints
+out to the veranda, finally pausing to see if the alarm continues.
+
+Exits: north west northeast
+
+> * *** In Upstairs ***
+> clothes
+What could the constables have been searching for in here? You keep your
+medicines locked in the bathroom, and the keys on the nightstand in your
+bedroom.
+
+The alarm falls silent, and Watson can finally relax again. Phillips heads off
+to investigate this false alarm.
+
+Davis makes her way from the kitchen to the dining room.
+
+Exits: north west northeast
+
+> search them
+Watson noses through the racks, but finds nothing except more clothes.
+
+Davis settles back into her chair and returns to work.
+
+Exits: north west northeast
+
+> w
+Watson saunters west, and you drift along behind.
+
+Bedroom
+As your age advances, the little luxuries of your bedroom have suffered for it.
+Even with Emily’s help, you’ve had to recognise the difficulties in day-to-day
+life, and the room is now designed around being cared for rather than
+comfortable. The suite opens out to the east, and a door to the north leads out
+to the rest of the house.
+
+Your bed stands in equal disarray. You’d given no thought to tidying it up.
+
+The nightstand is placed next to the head of the bed, entirely devoid of keys.
+
+Exits: (north) east
+
+> bed
+Not quite as soft as you would like it, sadly; at your age, getting into and out
+of it easily has become more of a priority. Now the mattress is too firm and
+there’s an unattractively large gap underneath.
+
+Exits: (north) east
+
+> look under bed
+Watson snuffles around under your bed and turns up a truncheon. He looks up at
+you proudly.
+
+Exits: (north) east
+
+> truncheon
+You got this from the constables, at Emily’s insistence; she maintains that
+someone you exposed will eventually want revenge, and having a weapon on hand
+will make them think twice about coming into your house. She means well, but
+she’s never quite understood how these things actually happen—you have no idea
+how to use something like this effectively, and a person bent on murder won’t be
+dissuaded by it.
+
+Exits: (north) east
+
+> emily
+You used to feel a bit ashamed to admit it, but a companion really is a
+necessity at your age. She checks in on you periodically, arranges your
+medicines, and handles any problems before they come up; not the brightest girl,
+perhaps, but a very good heart. She’d be horrified by the very idea of murder,
+and probably end up in tears for even thinking about it.
+
+Unfortunately, she isn’t anywhere near your house at the moment.
+
+Exits: (north) east
+
+> get truncheon
+Watson opens his mouth and carefully plucks the truncheon out from under your
+bed.
+
+Exits: (north) east
+
+> e
+Watson saunters east, and you drift along behind.
+
+Master suite
+Such a grand name for what amounts to five feet of hallway-slash-closet,
+connecting your bedroom to the west to your bathroom to the northeast. The door
+to the north leads out to the rest of the house.
+
+Your racks of clothes stand in disarray, methodically ransacked by the
+constables.
+
+Exits: north west northeast
+
+> ne
+Watson saunters northeast, and you drift along behind.
+
+Bathroom
+Watson is far more excited about this room than you are—it’s normally off-limits
+to him, and the sink, bath, and toilet are all mysterious and new. The only exit
+leads back southwest.
+
+You keep your medicines in a mirrored cabinet to one side.
+
+Exits: southwest
+
+> turn on sink
+Watson paws at the sink, and it switches on!
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> turn on bath
+Watson paws at the bath, and it switches on!
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> flush toilet
+Watson noses at the handle, and the toilet does its best to flush. But something
+seems to be clogging it. These old pipes jam up so easily.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> drink bath
+Watson laps happily at the bath.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> mirror
+More a functional piece of furniture than a beautiful one, it works as both a
+full-length mirror and a place to keep your medicines and toiletries. You don’t
+normally lock it, though; what would be the point, in your own bathroom?
+
+You only wish it could be set into the wall, instead of free-standing. The
+baseboards keep it from standing quite flush, leaving an inch or so of space
+behind it, and you can see a glint of something caught back there.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> look behind mirror
+Watson snuffles around behind the standing mirror and turns up an earring. He
+looks up at you proudly.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> put truncheon behind mirror
+Watson manages to work the handle end into the little gap behind the cabinet,
+leaving it sticking out at an odd angle.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> push truncheon
+Watson gives the truncheon a vigorous tug, and for a moment, it seems like
+nothing will happen. But he tugs again, and the cabinet wavers—and slowly begins
+to topple forward! He darts out of the way as the whole cabinet comes crashing
+down, the mirror shattering into hundreds of pieces on the tiles.
+
+Your medicine box now lies amid the wreckage.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Your score has gone up by one point.
+
+Exits: southwest
+
+> push mirror
+That seems a bit gratuitous at this point, doesn’t it?
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> mirror
+More a functional piece of furniture than a beautiful one, it works as both a
+full-length mirror and a place to keep your medicines and toiletries. Or at
+least, it used to.
+
+Your medicine chest is buried in the shards.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> get chest
+Watson opens his mouth and carefully plucks the medicine chest out of the
+shattered mirror.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> sw
+Watson saunters southwest, and you drift along behind.
+
+Master suite
+Such a grand name for what amounts to five feet of hallway-slash-closet,
+connecting your bedroom to the west to your bathroom to the northeast. The door
+to the north leads out to the rest of the house.
+
+Your racks of clothes stand in disarray, methodically ransacked by the
+constables.
+
+Exits: north west northeast
+
+> n
+Watson saunters out the suite door, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+You see a smoke detector here.
+
+Exits: (north) south west northwest
+
+> throw chest down
+Bracing his paws on the banister, Watson flings the medicine chest over the
+edge! The box tumbles downward, landing with a soft flump on the mattress.
+
+Exits: (north) south west northwest
+
+> down
+Watson saunters down the stairs, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell. On the mattress is
+a medicine chest.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+Exits: north south east (west)
+
+> get chest
+Watson opens his mouth and carefully plucks the medicine chest off the mattress.
+
+Exits: north south east (west)
+
+> up
+Watson saunters up the stairs, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+You see a smoke detector here.
+
+Exits: (north) south west northwest
+
+> nw
+Watson saunters northwest, and you drift along behind.
+
+Upstairs hall
+The hall runs alongside the staircase here before bending sharply at the end,
+with a little balcony to the south overlooking the first floor. The top of the
+stairs is back to the southeast, and the guest room will be to the north—once
+it’s been properly repainted and made livable, at least.
+
+The trapdoor to the attic is open, the collapsible steps leading up to the
+south.
+
+Exits: southeast up
+
+> up
+Watson clambers up the attic stairs, and you drift along behind.
+
+Attic, west
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the west side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+The collapsible stairs lead down through the trapdoor to the rest of the house.
+
+In the afternoon sunlight, you can just barely trace the outline of the vents
+under the carpet.
+
+Off to the northeast, you can clearly see a victrola. Watson might be able to
+leap to it, from the right starting point.
+
+Off to the southeast, you can clearly see a grandfather clock. Watson might be
+able to leap to it, from the right starting point.
+
+Exits: northeast southeast down
+
+> ne
+Watson saunters northeast, and you drift along behind.
+
+Attic, north
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the north side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+In the afternoon sunlight, you can just barely trace the outline of the vents
+under the carpet.
+
+The dumbwaiter is here, with a tape recorder in it.
+
+Your old victrola rests under the dumbwaiter.
+
+Off to the southeast, you can clearly see an organ. Watson might be able to leap
+to it, from the right starting point.
+
+Exits: southwest southeast
+
+> push wheel
+The dumbwaiter sinks out of sight.
+
+Exits: southwest southeast
+
+> push wheel
+The cables glide along their tracks, sending the dumbwaiter to the ground floor.
+
+Exits: southwest southeast
+
+> put chest in shaft
+Watson drops the medicine chest into the shaft, and it falls away into the
+darkness. A moment later, you hear a clang from below. With, perhaps, a hint of
+cracking glass as well?
+
+Exits: southwest southeast
+
+> go to kitchen
+(attempting to go southwest)
+Watson saunters southwest, and you drift along behind.
+
+Attic, west
+There are only two real rooms in the attic: the laboratory, in the center, and
+everything else, forming a huge ring around it. This is the west side of that
+ring, packed to the gills with the clutter of a life well lived.
+
+The collapsible stairs lead down through the trapdoor to the rest of the house.
+
+In the afternoon sunlight, you can just barely trace the outline of the vents
+under the carpet.
+
+Off to the northeast, you can clearly see a victrola. Watson might be able to
+leap to it, from the right starting point.
+
+Off to the southeast, you can clearly see a grandfather clock. Watson might be
+able to leap to it, from the right starting point.
+
+(attempting to go down)
+Watson clambers down the attic stairs, and you drift along behind.
+
+Upstairs hall
+The hall runs alongside the staircase here before bending sharply at the end,
+with a little balcony to the south overlooking the first floor. The top of the
+stairs is back to the southeast, and the guest room will be to the north—once
+it’s been properly repainted and made livable, at least.
+
+The trapdoor to the attic is open, the collapsible steps leading up to the
+south.
+
+(attempting to go southeast)
+Watson saunters southeast, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+You see a smoke detector here.
+
+(attempting to go west)
+Watson saunters down the stairs, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+(attempting to go north)
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis runs her hands through her hair with a sigh.
+
+(attempting to go east)
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter is here, with a broken medicine chest and a tape recorder in it.
+
+The stove is tucked away to one side. On the stove is some mail.
+
+Exits: south west southeast
+
+> chest
+You keep your various medicines locked in a little frosted-glass box, just in
+case anyone tries to tamper with them—you’ve seen the effects of that sort of
+thing far too often in your work. After that fall, it’s not securing anything
+any more.
+
+Your pill box is hidden inside.
+
+Exits: south west southeast
+
+> get pills
+Watson opens his mouth and carefully plucks the pill box out of the broken
+medicine chest.
+
+Exits: south west southeast
+
+> w
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis flips one of the sheets over, tapping her pen against the table.
+
+Exits: south east
+
+> give pills to davis
+Watson has to nudge Davis’s hand a few times with the pill box before she hears
+it rattling. “What’s this? Is this—are these the pills Phillips was turning the
+bedroom upside down for?” She actually laughs as he drops it in her hand. “How
+did you find these before he did? Such a good dog!” She opens the box and counts
+out the remaining pills. “I’ll get these down to the lab, and they’ll know if
+anyone tampered with them.” They didn’t, of course; Emily is the only one to
+have the opportunity, and she’s too diligent to make that mistake. But this will
+confirm it, and rule her out once and for all.
+
+* *** Finale ***
+Some time later, Davis is back in the dining room, going over the files. “This
+doesn’t make sense. There were only four people with a motive and an
+opportunity...but no evidence pointing toward any of them. How else could it
+’ave happened?”
+
+She looks down at Watson, as if he’s going to have an answer for her, then
+stands. “I’m getting the other two. We need a new direction.” Biddlecombe is
+promptly summoned down from the library, and Phillips from wherever he’s gotten
+off to; soon all three of them are huddled together around the table, comparing
+notes.
+
+Your score has gone up by one point.
+
+Exits: south east
+
+> look
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+All three constables have convened around the table.
+
+Biddlecombe and Davis are having a heated debate about the evidence. Phillips is
+off in the corner, running his hands through his hair.
+
+Exits: south east
+
+> s
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+Exits: north south east (west)
+
+> up
+Watson saunters up the stairs, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+You see a smoke detector here.
+
+Exits: north south west northwest
+
+> n
+Watson saunters through the library door, and you drift along behind.
+
+Library
+Nobody else ever likes this room. They say the carpets and the drapes clash
+horribly with the bookshelves, and they can never find what they’re looking for.
+But that really doesn’t matter; it’s a place for you to work, study, and read,
+and to your eyes, the colours are perfectly fine. The only door leads back to
+the south.
+
+The dumbwaiter used to run through here, but you covered over the shaft when you
+turned the room into a library. There was just too much risk of something
+spilling out.
+
+Exits: south
+
+> drapes
+Apparently they’re an odd mixture of purple, orange, and red that clashes
+horribly with the shelves, but to you, they go together very well.
+
+Exits: south
+
+> shelves
+The shelves line every wall, leaving no real place to work—your desk, after all,
+is hidden in the niche behind them. All you have to do now is open it.
+
+Exits: south
+
+> open them
+It’s very simple, if you know the trick. You direct Watson to pull one
+particular book off the shelf, then a second, then a third—and as the last one
+falls, the cases swing silently outward to reveal your desk in the niche behind
+them. It’s still covered with those ledgers and files from last week; you kept
+meaning to get back to that investigation...
+
+Exits: south
+
+> desk
+It is, perhaps, not truly necessary to hide your desk behind a bookcase. But
+when you came across a mechanism like this in one of your investigations, you
+simply couldn’t resist. Now your workspace is tucked away behind the shelves
+when it’s not being used.
+
+Exits: south
+
+> ledgers
+Dozens of records and ledgers from the constabulary are laid out here, carefully
+arranged so you can compare them side by side. This isn’t the sort of business
+you normally do, but the Inspector had remarked a few weeks back that their
+auditors couldn’t make heads nor tails of the discrepancies, and you thought it
+might be linked to something deeper. Really, you started to regret it by the
+third page, which is why you left it sitting here for a week and a half.
+
+But being murdered does tend to lend some urgency to things. You settle yourself
+over the desk and direct Watson how to push the papers around, letting you look
+for the patterns you need. It’s tedious work, but you don’t seem to grow tired
+the way you used to.
+
+None of these discrepancies make sense. Their bookkeeping isn’t just atrocious:
+it seems designed to be as confusing as possible. But the only person with the
+authority to cause that sort of snarl...
+
+...would be the Inspector himself.
+
+Your score has gone up by one point.
+
+Exits: south
+
+> bark
+Watson lets out a loud bark that echoes through the house, then looks up at you
+for approval, tail wagging happily.
+
+Off in the dining room, Davis steadfastly ignores the sound. She’s investigating
+a murder now, and can’t be distracted by barking dogs!
+
+Exits: south
+
+> close shelves
+Watson tugs as hard as he can, but it scarcely moves—it takes significantly more
+force to close than to open. But the counterweighting does make it swing open oh
+so beautifully.
+
+Exits: south
+
+> s
+Watson saunters through the library door, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+You see a smoke detector here.
+
+Exits: north south west northwest
+
+> down
+Watson saunters down the stairs, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+Exits: north south east (west)
+
+> n
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis is hurriedly gathering up the most important files. “I have to get this
+all in order—the Inspector is on his way!” She spares Watson a quick, apologetic
+glance, then hurries out of the room.
+
+So Hughes is coming. He’ll never let the other constables see the evidence now.
+But this isn’t time to panic; it’s time to act.
+
+You know exactly where he’s going to be: in the library, destroying the ledgers.
+You have a chance. Push him hard enough and he’ll slip—and give you the evidence
+you need for a conviction.
+
+Exits: south east
+
+> e
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter is here, with a broken medicine chest and a tape recorder in it.
+
+The stove is tucked away to one side. On the stove is some mail.
+
+Exits: south west southeast
+
+> record
+The recorder clicks on, and begins to record.
+
+Exits: south west southeast
+
+> w
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis’s seat stands conspicuously vacant.
+
+Exits: south east
+
+> s
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+Exits: north south east (west)
+
+> up
+Watson saunters up the stairs, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+You see a smoke detector here.
+
+Exits: north south west northwest
+
+> n
+Watson saunters through the library door, and you drift along behind.
+
+Library
+Nobody else ever likes this room. They say the carpets and the drapes clash
+horribly with the bookshelves, and they can never find what they’re looking for.
+But that really doesn’t matter; it’s a place for you to work, study, and read,
+and to your eyes, the colours are perfectly fine. The only door leads back to
+the south.
+
+Your desk is now visible behind the secret door, covered with various ledgers
+and files.
+
+The dumbwaiter used to run through here, but you covered over the shaft when you
+turned the room into a library. There was just too much risk of something
+spilling out.
+
+Exits: south
+
+> push wheel
+The cables glide along their tracks, sending the dumbwaiter to the cellar.
+
+Exits: south
+
+> push wheel
+The cables glide along their tracks, sending the dumbwaiter to the ground floor.
+
+Exits: south
+
+> push wheel
+The cables glide along their tracks, sending the dumbwaiter to the first floor.
+
+Barely a moment later the door slams open and Inspector Hughes strides in, his
+bulky frame wrapped in an enormous overcoat. “None of the suspects, she says.
+All four of the theories ruled out. Have to look deeper. And Biddlecombe doesn’t
+find a single bloody thing. It’s time to take care of this myself.”
+
+Your score has gone up by one point.
+
+Exits: south
+
+> hughes
+You have a long history with Basil Hughes, and it’s in no small part thanks to
+your investigations that he’s risen through the ranks from Constable to
+Inspector. He has his eye on Chief Inspector now, but really, well...the man is
+far too close-minded, far too quick to jump to the obvious conclusion. Large and
+stout, with an immaculate uniform and an impressive moustache, he tries to look
+every bit the image of the modern constabulary.
+
+“Now, what have we here?” Hughes sets his briefcase on the desk.
+
+Exits: south
+
+> bite hughes
+You’ve trained Watson well not to get aggressive with people, but he’s smart
+enough to understand the anger behind that command—he leaps at the Inspector
+with a growl, teeth bared to bite! Hughes does his best to fend him off, but his
+Inverness coat now has some dramatic new tears.
+
+“Shoo! Get out of here! Go!” With a hiss of displeasure, Hughes turns back to
+the desk.
+
+Exits: south
+
+> undo
+
+Undoing the last turn (bite hughes).
+
+Library
+
+Exits: south
+
+> kiss hughes
+Watson needs very little encouragement to throw himself upon the Inspector,
+lavishing him with distinctly unwanted canine affection. Hughes tries his
+hardest to push him away, but Watson is undeterred, and by the time the
+Inspector fights free his face and hands are thoroughly wet.
+
+“Shoo! Get out of here! Go!” With a hiss of displeasure, Hughes turns back to
+the desk.
+
+Exits: south
+
+> undo
+
+Undoing the last turn (kiss hughes).
+
+Library
+
+Exits: south
+
+> vomit
+You’ve trained Watson well not to do such things in the house, but you’ve also
+trained him to recognise an emergency—and this certainly qualifies. Hughes
+freezes in his work as he hears the telltale sound behind him.
+
+“Shoo! Get out of here! Go!” With a hiss of displeasure, Hughes turns back to
+the desk.
+
+Exits: south
+
+> undo
+
+Undoing the last turn (vomit).
+
+Library
+
+Exits: south
+
+> get briefcase
+The moment Hughes’s back is turned, Watson reaches up and gives his briefcase a
+mighty shove, sending it to the floor. The Inspector whirls around a moment too
+late to stop him from snatching it up, and he’s off on a merry chase!
+
+Watson manages to evade the constable for a good while before Hughes eventually
+manages to snag his case back, puffing and panting for breath.
+
+“Shoo! Get out of here! Go!” With a hiss of displeasure, Hughes turns back to
+the desk.
+
+Exits: south
+
+> get briefcase
+“Bad!” Hughes shoves Watson away before he can get hold of the case again.
+
+Hughes flips through another ledger, grumbling under his breath.
+
+Exits: south
+
+> jump on desk
+Watson’s tail wags for a moment, and the Inspector has only a moment of warning
+before he leaps up onto the desk, papers flying everywhere! Hughes shouts
+something incoherent and tries to push him aside, his work now scattered all
+over the room.
+
+“Wretched mutt! You’re as bad as she was!” Hughes visibly composes himself for a
+moment before going back to his task.
+
+Exits: south
+
+> bark
+Positioning himself right behind Hughes’s work, Watson waits for the perfect
+moment to let out a thunderous bark. The Inspector jumps, clenching his hand so
+hard on a pen that it snaps in half.
+
+“ENOUGH!” Hughes whirls on Watson, rage burning on his face. “You confounded
+beast! I had it all arranged! There was no evidence to be found! We’d file it as
+an accident and close the case, or send Davis and Phillips on a snipe hunt until
+the case went cold! But you, you had to get in my way at every single turn!”
+
+He snatches up a stack of papers and starts to shred them between his hands.
+“But it’s not enough. This was the last evidence of the motive, and without it,
+they’ll never even begin to investigate. This house is going up for auction, and
+you’re going to the pound!”
+
+He aims a petty kick at Watson as he flings the door open and storms out of the
+room.
+
+Your score has gone up by one point.
+
+Exits: south
+
+> look
+Library
+Nobody else ever likes this room. They say the carpets and the drapes clash
+horribly with the bookshelves, and they can never find what they’re looking for.
+But that really doesn’t matter; it’s a place for you to work, study, and read,
+and to your eyes, the colours are perfectly fine. The only door leads back to
+the south.
+
+Your desk is now visible behind the secret door, stripped clean of evidence.
+
+The dumbwaiter used to run through here, but you covered over the shaft when you
+turned the room into a library. There was just too much risk of something
+spilling out.
+
+You can hear the Inspector storming out, almost bowling over Constable Davis in
+the process. She tries in vain to apologise as he slams the front door behind
+him.
+
+Exits: south
+
+> s
+Watson saunters through the library door, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+You see a smoke detector here.
+
+Davis makes her way from the reception room to the kitchen.
+
+Exits: north south west northwest
+
+> down
+Watson saunters down the stairs, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+Davis makes her way from the kitchen to the dining room.
+
+Exits: north south east (west)
+
+> n
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis is here, looking rather frazzled.
+
+Davis settles back into her chair and returns to work.
+
+Exits: south east
+
+> e
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter shaft is set into the north wall.
+
+The stove is tucked away to one side. On the stove is some mail.
+
+Exits: south west southeast
+
+> push wheel
+The dumbwaiter sinks into sight, bringing you a broken medicine chest and a tape
+recorder.
+
+Exits: south west southeast
+
+> off
+The recorder clicks off.
+
+Exits: south west southeast
+
+> get recorder
+Watson opens his mouth and carefully plucks the tape recorder out of the
+dumbwaiter.
+
+Exits: south west southeast
+
+> w
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis sets the last sheet aside, turning to the next.
+
+Exits: south east
+
+> give recorder to davis
+“Hm? What’s’at?” Davis sounds exhausted as she looks down at the recorder. “Ah,
+you found this for us. Thanks, dog.” She checks the tape, then rewinds it and
+taps ‘play’.
+
+There’s a minute of muffled silence, the sounds of someone rifling around in the
+library, and Davis frowns. But then Hughes’s voice comes through loud and clear.
+I had it all arranged! There was no evidence to be found! We’d file it as an
+accident and close the case, or send Davis and Phillips on a snipe hunt until
+the case went cold!
+
+The recorder falls from the constable’s hand with a crash. “Inspector Hughes?
+He—why—”
+
+Watson sits back on his haunches, panting happily as Davis grabs the recorder
+and sprints off. Finally taking her own initiative, for once in her life; you
+wish you could tell her you were proud. She’s the sort who will dot all the i’s
+and cross all the t’s, and with a confession like that, Hughes has no way to
+wiggle out of it.
+
+The front door slams, and you’re left alone in the silence. Davis will get the
+credit, of course, but you don’t mind that; you’ve had plenty of glory in your
+time. Someone else can get the accolades for solving your own murder. And Nigel
+will take good care of Watson; your will is explicit on that point.
+
+The real question is—what comes next for you?
+
+     *** The End ***
+
+You scored 18 points out of 18.
+
+Would you like to:
+     UNDO the last move,
+     RESTORE a saved position,
+     see your SCORE,
+     QUIT the program,
+     or RESTART from the beginning?
+
+> score
+
+You currently have 18 points out of a maximum of 18, in 334 turns.
+
+You’ve earned points for:
+- Finding a way to interact with the world
+- Escaping the armchair
+- Proving it was murder
+- Gaining access to the gardens
+- Identifying the green roses
+- Exculpating your gardener Alfred
+- Gaining access to the attic
+- Opening the attic windows
+- Exculpating your nephew Nigel
+- Gaining access to the root cellar
+- Finding the carrots
+- Exculpating your friend Charlotte
+- Gaining access to your bedroom suite
+- Opening the medicine cabinet
+- Exculpating your companion Emily
+- Discovering the real identity of the murderer
+- Hiding a tape recorder
+- Recording Hughes’s confession
+
+Your work here is finished.
+
+Would you like to:
+     UNDO the last move,
+     RESTORE a saved position,
+     see your SCORE,
+     QUIT the program,
+     or RESTART from the beginning?
+
+> * *** Metapuzzle secrets ***
+> undo
+
+Undoing the last turn (give recorder to davis).
+
+Dining room
+
+Exits: south east
+
+> drop recorder
+Watson sets the tape recorder carefully on the ground.
+
+Davis pulls out another page, cross-checking it against the last.
+
+Exits: south east
+
+> find mail
+Watson leaps up and sprints off in hot pursuit of the mail, heading for the
+kitchen.
+
+(attempting to go east)
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter is here, with a broken medicine chest in it.
+
+The stove is tucked away to one side. On the stove is some mail.
+
+Exits: south west southeast
+
+> get mail
+Watson opens his mouth and carefully plucks the mail off the stove.
+
+Exits: south west southeast
+
+> find bath
+Watson leaps up and sprints off in hot pursuit of the bath, heading for the
+bathroom.
+
+(attempting to go west)
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+You see a tape recorder here.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis sets the last sheet aside, turning to the next.
+
+(attempting to go south)
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+(attempting to go east)
+Watson saunters up the stairs, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+You see a smoke detector here.
+
+(attempting to go south)
+Watson saunters through the suite door, and you drift along behind.
+
+Master suite
+Such a grand name for what amounts to five feet of hallway-slash-closet,
+connecting your bedroom to the west to your bathroom to the northeast. The door
+to the north leads out to the rest of the house.
+
+Your racks of clothes stand in disarray, methodically ransacked by the
+constables.
+
+(attempting to go northeast)
+Watson saunters northeast, and you drift along behind.
+
+Bathroom
+Watson is far more excited about this room than you are—it’s normally off-limits
+to him, and the sink, bath, and toilet are all mysterious and new. The only exit
+leads back southwest.
+
+You see an earring here.
+
+You see a truncheon here.
+
+The mirrored cabinet lies on the floor, shattered.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> turn on bath
+Watson paws at the bath, but it is already on.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> get in bath
+Watson launches himself into the bath, and you follow along behind.
+
+Water pours from the bathtub faucet, thoroughly soaking Watson’s fur.
+
+Water rushes through the sink.
+
+Exits: southwest
+
+> go to reception room
+(attempting to go southwest)
+(first attempting to get out of the bath)
+Watson leaps out of the bath.
+
+Water pours from the bathtub faucet, straight down the drain.
+
+Water rushes through the sink.
+
+Watson saunters southwest, and you drift along behind.
+
+Master suite
+Such a grand name for what amounts to five feet of hallway-slash-closet,
+connecting your bedroom to the west to your bathroom to the northeast. The door
+to the north leads out to the rest of the house.
+
+Your racks of clothes stand in disarray, methodically ransacked by the
+constables.
+
+(attempting to go north)
+Watson saunters out the suite door, and you drift along behind.
+
+Top of the stairs
+The afternoon light coming through the big windows makes the first floor look so
+cheerful and pleasant, and not at all like the place someone fell to her death
+just last night. It’s better that way; you’ve never wanted this house to look
+dreary by any stretch of the imagination. Identical doors lead north and south
+to your library and master suite, respectively; the hallway continues to the
+northwest, and the stairs lead back down to the west.
+
+You see a smoke detector here.
+
+(attempting to go west)
+Watson saunters down the stairs, and you drift along behind.
+
+Bottom of the stairs
+This was once the front room of your house, before you sealed off the door here
+and built the larger front room on the other side. Now it just serves as a
+little hallway connecting the evening room to the south to the dining room to
+the north. The stairs to the east lead up to the first floor.
+
+A mattress lies at the bottom of the stairs, where you fell.
+
+A big grate is set into the floor under the stairs.
+
+Your telephone hangs in its niche on the north wall.
+
+Various old newspapers are stacked in the corner.
+
+(attempting to go north)
+Watson saunters through the shredded police tape, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+You see a tape recorder here.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis looks for her biscuit, realises she’s run out, and sighs.
+
+(attempting to go east)
+Watson saunters east, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter is here, with a broken medicine chest in it.
+
+The stove is tucked away to one side.
+
+(attempting to go southeast)
+Watson saunters southeast, and you drift along behind.
+
+Reception room
+You designed this room specifically for uninvited guests. Back when the front
+door was at the west end of the house, they’d have to wait awkwardly outside
+until you had the sitting room or dining room in order. Now, there’s a place to
+sit and take tea with them at a moment’s notice—and admire the framed case
+reports on the wall—and that can make witnesses ever so much more willing to
+open up. What used to be the back door of the house leads northwest to the
+kitchen, and the new front door leads out to the south.
+
+Exits: (south) northwest
+
+> open door
+Watson noses the front door open.
+
+Exits: south northwest
+
+> find calendulas
+Watson leaps up and sprints off in hot pursuit of the calendula, heading for the
+northeast bed.
+
+(attempting to go south)
+Watson saunters out the front door, and you drift along behind.
+
+Veranda
+A little refuge from the weather, for when you want the fresh outdoor air
+without all the sun and the rain, between the front door to the north and the
+lawn to the south.
+
+(attempting to go south)
+Watson saunters south, and you drift along behind.
+
+Lawn
+It’s really not big enough to be called the grounds, but you’ve always been
+proud of your lawn and gardens, encircling the house on all sides. The most
+important one right now is your tea garden, down to the south; the veranda is
+back to the north.
+
+Today’s newspaper lies in front of the porch steps.
+
+(attempting to go south)
+Watson saunters south, and you drift along behind.
+
+Tea garden, centre
+Your tea garden is nestled deep in the foundation of the old ruins, the stone
+walls rising up on every side to give the plants just the perfect amount of
+sunlight and shade. Here at the centre is where you placed that lovely fountain,
+and a sturdy chair, to sit in while you contemplate your options.
+
+The garden beds themselves are arranged in a ring around you, and the path north
+leads back to the lawn. You have a lovely view of the whole thing from your
+sitting room.
+
+On the garden chair are a pair of gardening gloves.
+
+(attempting to go northeast)
+Watson saunters northeast, and you drift along behind.
+
+Tea garden, northeast
+The garden bed under the old walls is just as neat and tidy as ever, as it
+should be. The calendula is flourishing, ready for your next cup of tea.
+
+Exits: west southwest southeast
+
+> dig calendulas
+Normally, Watson would be too well-trained to obey an order like that. He knows
+perfectly well that your garden is not for digging. And yet...he knows that
+there’s something odd here, different from all the rest.
+
+He throws himself into the work with great enthusiasm, uprooting your poor
+calendulas left and right, until with an awful lurch the garden bed collapses in
+on itself and sinks down into something underneath! This must be where the old
+cistern was, long ago; you’d been told the house had one when you bought it, but
+you never saw it yourself.
+
+Exits: west southwest southeast down
+
+> down
+Watson clambers down the messy tunnel, and you drift along behind.
+
+Old cistern
+The old cistern isn’t especially large, and if you still had a body, you
+wouldn’t be able to stand up without hitting your head. Lichen covers the old
+stones, and in one corner they’ve crumbled away entirely into some sort of
+cavern beneath.
+
+A messy hole leads back to the garden above.
+
+Your score has gone up by one point.
+
+Exits: up down
+
+> down
+Watson clambers down, and you drift along behind.
+
+Ancient chamber
+This place cannot exist. It simply can’t. You can’t even stop your cellar from
+flooding, for goodness’ sake; how could a chamber like this possibly stay dry?
+For that matter, how can you even see Watson three feet in front of you, with no
+light coming down from the surface?
+
+And yet somehow it does, fifteen feet wide and round like a dome, the ancient
+walls crumbling with lichen. A roughly-hewn slab of stone stands right in the
+middle.
+
+Exits: up
+
+> get on altar
+Watson leaps up onto the stone slab.
+
+Exits: up
+
+> bite mail
+You’re not quite sure what to expect when Watson sinks his teeth into the mail.
+Some part of you remains convinced that it’s all nonsense. Another part is being
+steadily forced to accept the existence of ghosts, which you have steadfastly
+refused to accept as an explanation for murder for the past fifty-some years.
+
+Whatever you expected, it wasn’t this.
+
+It feels like your whole spirit is being forced through a funnel just over your
+heart, drawn out and twisted into a cord, needled through the mail like a thread
+through cloth. You become your name, and your name becomes you, and Watson—
+
+Nothing has changed, and at the same time, everything has changed. You feel no
+more solid than before. But in some strange way, you’re more real. More certain
+that your story isn’t quite yet reaching its end.
+
+Your score has gone up by one point.
+
+Exits: up
+
+> drop mail
+Watson sets the mail carefully on the stone slab.
+
+Exits: up
+
+> find davis
+Watson leaps up and sprints off in hot pursuit of Constable Davis, heading for
+the dining room.
+
+(attempting to go up)
+(first attempting to get off the stone slab)
+Watson leaps off the stone slab.
+
+Watson clambers up, and you drift along behind.
+
+Old cistern
+The old cistern isn’t especially large, and if you still had a body, you
+wouldn’t be able to stand up without hitting your head. Lichen covers the old
+stones, and in one corner they’ve crumbled away entirely into some sort of
+cavern beneath.
+
+A messy hole leads back to the garden above.
+
+(attempting to go up)
+Watson clambers up the messy tunnel, and you drift along behind.
+
+Tea garden, northeast
+The garden bed under the old walls is just as neat and tidy as ever, as it
+should be. The calendula is flourishing, ready for your next cup of tea.
+
+A large sinkhole in the middle of the garden bed thoroughly disrupts the
+aesthetic.
+
+(attempting to go southwest)
+Watson saunters southwest, and you drift along behind.
+
+Tea garden, centre
+Your tea garden is nestled deep in the foundation of the old ruins, the stone
+walls rising up on every side to give the plants just the perfect amount of
+sunlight and shade. Here at the centre is where you placed that lovely fountain,
+and a sturdy chair, to sit in while you contemplate your options.
+
+The garden beds themselves are arranged in a ring around you, and the path north
+leads back to the lawn. You have a lovely view of the whole thing from your
+sitting room.
+
+On the garden chair are a pair of gardening gloves.
+
+(attempting to go north)
+Watson saunters north, and you drift along behind.
+
+Lawn
+It’s really not big enough to be called the grounds, but you’ve always been
+proud of your lawn and gardens, encircling the house on all sides. The most
+important one right now is your tea garden, down to the south; the veranda is
+back to the north.
+
+Today’s newspaper lies in front of the porch steps.
+
+(attempting to go north)
+Watson saunters north, and you drift along behind.
+
+Veranda
+A little refuge from the weather, for when you want the fresh outdoor air
+without all the sun and the rain, between the front door to the north and the
+lawn to the south.
+
+(attempting to go north)
+Watson saunters through the front door, and you drift along behind.
+
+Reception room
+You designed this room specifically for uninvited guests. Back when the front
+door was at the west end of the house, they’d have to wait awkwardly outside
+until you had the sitting room or dining room in order. Now, there’s a place to
+sit and take tea with them at a moment’s notice—and admire the framed case
+reports on the wall—and that can make witnesses ever so much more willing to
+open up. What used to be the back door of the house leads northwest to the
+kitchen, and the new front door leads out to the south.
+
+(attempting to go northwest)
+Watson saunters northwest, and you drift along behind.
+
+Kitchen
+Your kitchen isn’t spacious by any stretch of the imagination, but you’ve always
+found it cozy rather than cramped. A big door leads west to the dining room, and
+a smaller one leads southeast to your new reception room; the rest of the house
+is back to the south.
+
+The dumbwaiter is here, with a broken medicine chest in it.
+
+The stove is tucked away to one side.
+
+(attempting to go west)
+Watson saunters west, and you drift along behind.
+
+Dining room
+This is the proper place to share a meal with someone, with plenty of windows, a
+big table, and a lovely chandelier. Display cabinets along the walls show off
+some of your favourite curiosities from your long career; doors lead east to the
+kitchen and south to the rest of the house.
+
+You see a tape recorder here.
+
+Constable Davis herself sits in one of your chairs, hard at work. Her paperwork
+covers the table.
+
+Davis pulls out another page, cross-checking it against the last.
+
+Exits: south east
+
+> get recorder
+Watson opens his mouth and carefully scoops up the tape recorder.
+
+Davis looks for her biscuit, realises she’s run out, and sighs.
+
+Exits: south east
+
+> give recorder to davis
+“Hm? What’s’at?” Davis sounds exhausted as she looks down at the recorder. “Ah,
+you found this for us. Thanks, dog.” She checks the tape, then rewinds it and
+taps ‘play’.
+
+There’s a minute of muffled silence, the sounds of someone rifling around in the
+library, and Davis frowns. But then Hughes’s voice comes through loud and clear.
+I had it all arranged! There was no evidence to be found! We’d file it as an
+accident and close the case, or send Davis and Phillips on a snipe hunt until
+the case went cold!
+
+The recorder falls from the constable’s hand with a crash. “Inspector Hughes?
+He—why—”
+
+Watson sits back on his haunches, panting happily as Davis grabs the recorder
+and sprints off. Finally taking her own initiative, for once in her life; you
+wish you could tell her you were proud. She’s the sort who will dot all the i’s
+and cross all the t’s, and with a confession like that, Hughes has no way to
+wiggle out of it.
+
+The front door slams, and you’re left alone in the silence. Davis will get the
+credit, of course, but you don’t mind that; you’ve had plenty of glory in your
+time. Someone else can get the accolades for solving your own murder.
+
+The real question is—what comes next for you? That odd ritual seems to have
+bound your soul to Watson, and that binding shows no signs of fading. You look
+down at Watson, who’s sitting back on his haunches, panting happily. You might
+not know what the next chapter in your story will bring, but it certainly won’t
+be the last.
+
+Congratulations on solving the metapuzzle and reaching the true ending! This
+puzzle was run as a competition during IFComp 2024, with the prize won by S. V.
+Linwood.
+
+- Daniel Stelzer, N. Cormier, Emery Joyce, Ben Jackson, and Phil Riley
+
+     *** The End ***
+
+You scored 20 points out of 20.
+
+Would you like to:
+     UNDO the last move,
+     RESTORE a saved position,
+     see your SCORE,
+     QUIT the program,
+     or RESTART from the beginning?
+
+> score
+
+You currently have 20 points out of a maximum of 20, in 372 turns.
+
+You’ve earned points for:
+- Finding a way to interact with the world
+- Escaping the armchair
+- Proving it was murder
+- Gaining access to the gardens
+- Identifying the green roses
+- Exculpating your gardener Alfred
+- Gaining access to the attic
+- Opening the attic windows
+- Exculpating your nephew Nigel
+- Gaining access to the root cellar
+- Finding the carrots
+- Exculpating your friend Charlotte
+- Gaining access to your bedroom suite
+- Opening the medicine cabinet
+- Exculpating your companion Emily
+- Discovering the real identity of the murderer
+- Hiding a tape recorder
+- Recording Hughes’s confession
+- Discovering the secrets buried under your garden (?)
+- Performing a Druidic ritual (?!)
+
+Your work here is finished.
+
+Would you like to:
+     UNDO the last move,
+     RESTORE a saved position,
+     see your SCORE,
+     QUIT the program,
+     or RESTART from the beginning?
+
+> 

--- a/test/impossible/Makefile
+++ b/test/impossible/Makefile
@@ -13,7 +13,7 @@ $(FRONTEND):
 
 all: test
 
-test: test.js test.6502
+test: test.js test.6502 test.lua test.go
 
 test.js: impossible.js.out
 	$(DIFF) impossible.js.out impossible.js.gold
@@ -27,7 +27,19 @@ test.6502: impossible.6502.out
 impossible.6502.out: impossible.aastory $(AAMBOX) $(FRONTEND)
 	$(AAMBOX) -s 1234 $(FRONTEND) impossible.aastory <impossible.in >impossible.6502.out
 
+test.lua: impossible.lua.out
+	$(DIFF) impossible.lua.out impossible.lua.gold
+
+impossible.lua.out: impossible.aastory
+	luajit ../../src/lua/frontend.lua -s 1234 impossible.aastory <impossible.in >impossible.lua.out
+
+test.go: impossible.go.out
+	$(DIFF) impossible.go.out impossible.go.gold
+
+impossible.go.out: impossible.aastory
+	../../src/go/aamrun -s 1234 impossible.aastory <impossible.in >impossible.go.out
+
 clean:
 	rm -f *.out
 
-.PHONY: all test test.js test.6502 clean
+.PHONY: all test test.js test.6502 test.lua test.go clean

--- a/test/impossible/impossible.go.gold
+++ b/test/impossible/impossible.go.gold
@@ -1,0 +1,3807 @@
+
+
+The Impossible Stairs
+An interactive fiction by Mathbrush.
+Written in Dialog. Authorized sequel to The Impossible Bottle by Linus Åkesson.
+Release 3. Serial number <SERIAL>.
+<COMPILER>. <LIBRARY>
+
+What a mess! The hurricane did a real number on the old family home, and to
+think it would happen the week that your dad is moving out!
+
+You notice some movement from an upstairs window. A woman that looks somewhat
+familiar leans out and throws out a paper airplane that floats down and lands by
+you.
+
+"There you go, CJ! See you at dinner!" she shouts, then slams the window shut.
+
+"Huh. Who the heck was that?" you say to yourself.
+
+[Tutorial: You can LOOK to check out your surroundings. You can type TUTORIAL
+OFF to turn off this brief tutorial at any time.]
+
+> *** From David Welbourn's walkthrough
+> look
+Front Lawn
+You are standing in front of your family home, which you recently purchased from
+your father. The front door is to the east.
+
+The paper airplane is lying on the ground next to you.
+
+[Tutorial: You can TAKE AIRPLANE to pick up the paper airplane.]
+
+> take airplane
+You scoop up the airplane and un-fold it. It's a... chores list?
+
+[Tutorial: You can now type I or INVENTORY to check your inventory.]
+
+> i
+You have a chores list.
+
+[Tutorial: You can EXAMINE LIST or X LIST or READ LIST to see what it says.]
+
+> x list
+The list says "BEFORE THE GUESTS ARRIVE:" in all caps at the top. At the bottom
+it says,
+
+-Give the good serving dish to Uncle Joe
+
+-Put the plates on the table
+
+-Find Mom's baklava recipe and make it
+
+-Help Ada finish up in the garage (could take a while)
+
+-Remind Uncle Rob about dinner
+
+Huh. Strange.
+
+[Tutorial: You can now go EAST or E to enter the house. This is the end of the
+tutorial. For more help, you can type HELP or HINT at any time. Thanks!]
+
+> x me
+You're still feeling a bit frazzled from the hurricane and helping your dad pack
+for his big move, but otherwise you're doing fine.
+
+> x house
+You moved into this place pretty soon after your mother passed away, although
+she helped design it. It's not very big, but it has a lot of great memories in
+it.
+
+It's too bad that the hurricane damaged it quite a bit. You can't see it from
+here, but it's even worse in the kitchen.
+
+> e
+(first attempting to open the front door to the east)
+You open the front door.
+
+You walk into the house (your house, now) and close the door behind you.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> x center
+This massive entertainment center is designed to hold your TV and all of its
+attachments. You haven't moved in your TV yet. You'll do that after dad moves
+out.
+
+> x carpeting
+You bought this carpet to be unique, but it turns out all the homeowners in the
+neighborhood had the same idea.
+
+> x calendar
+This calendar is a little warped from the water, but it still works. It's a
+calendar with pictures of wolves. You got it at Borders. It's August 20th, 2001.
+
+> n
+You start to head out before you remember: The garage was crushed by the tree in
+your backyard when the hurricane blew it over a few days ago. There's no way out
+there right now.
+
+Your cousin Ada was so sad about losing her projects, she hasn't been back
+since.
+
+> s
+You walk south.
+
+Office
+This is your art studio. Or, at least, it will be. Right now, it's mostly empty,
+except for a single easel in the middle and a pedestal. Your family's memory
+board is here, the only thing you kept from your dad's old office. The shelves
+and most of the books had to be thrown out.
+
+The family room is back to the north.
+
+On the pedestal, you can see a dish towel, artfully arranged.
+
+Your dad is puttering around, making sure that your new studio is ready for you
+to move into.
+
+"Oh hey, CJ," he says, looking up for a second.
+
+> x easel
+It cost a little more than you budgeted for, but you hope it will suffice for
+the next few years, at least.
+
+> x pedestal
+This hefty pedestal is where you intend to put your current inspiration. Your
+choice may shape your future career, so you've been a bit nervous about it.
+
+> x towel
+A colorful dish towel which struck your fancy at the store. It is artfully
+arranged on the pedestal, serving as your current object of inspiration.
+
+> x board
+The memory board has portraits of all your loved ones who have passed on. Right
+now, that includes your grandfather, grandmother and mom.
+
+> x grandfather
+Grandpa died before you were born. It shows him standing outside a coal mine,
+pick in hand. That was his first job, after he immigrated.
+
+> x grandmother
+This is your grandmother's graduation picture from nursing school. She's wearing
+a crisp white uniform and cap, and standing by two nuns. She passed away shortly
+after her 84th birthday.
+
+> x mom
+You only have vague memories of your mother, including the day this was taken.
+The photo shows her at a picnic, feeding you a tiny slice of baklava.
+
+The corner of a recipe card is sticking out from behind the portrait.
+
+> take card
+You snatch up the card. It's your mom's old baklava recipe!
+
+> read it
+This is your mom's recipe for baklava.
+
+The card looks pretty old, and has food stains. At the bottom, it says, 'Dad's
+recipe'. Huh, you never thought about it, but she must have got it from Grandpa.
+
+It says you need cinnamon, phyllo dough, butter, nuts, and honey. Hopefully,
+Uncle Joe isn't hogging all the butter again.
+
+[To make the baklava, you can type MAKE RECIPE in the kitchen once you have all
+the ingredients.]
+
+> x dad
+Dad has mellowed out a lot since you were younger. He has a full head of white
+hair that he finally gave up on dyeing. He changed out of his "nice suit"
+earlier so he could wear his old suit, just in case things got messy.
+
+> talk to dad
+Your dad looks up. "Hey, CJ!" he says, smiling. "What's up?"
+
+1. "Hey, I saw a strange woman standing in the upstairs window. Any idea who it
+was?"
+2. "Have you seen the serving dish?"
+3. "Do you know where the plates are?"
+4. "Oh, just wanted to say hi."
+> 1
+"Hey, I saw a strange woman standing in the upstairs window. Any idea who it
+was?"
+
+Your dad looks startled. "Huh. Strange woman. What did she look like?"
+
+"I don't know, but she looked familiar. She threw a paper airplane at me," you
+say.
+
+"Did she seem dangerous?" asks Dad.
+
+"No, it's just weird having strangers in the house," you answer.
+
+"Well, it wouldn't be the weirdest thing that's happened here. Let me know if
+you see her again, okay?" says dad.
+
+1. "Have you seen the serving dish?"
+2. "Do you know where the plates are?"
+3. "Oh, just wanted to say hi."
+> 1
+"Have you seen the serving dish?"
+
+"I think it's downstairs somewhere."
+
+1. "Have you seen the serving dish?"
+2. "Do you know where the plates are?"
+3. "Oh, just wanted to say hi."
+> 2
+"Do you know where the plates are?"
+
+"Oh, those. Last I saw them, they were in the treehouse."
+
+1. "Have you seen the serving dish?"
+2. "Do you know where the plates are?"
+3. "Oh, just wanted to say hi."
+> 3
+"Oh, just wanted to say hi."
+
+"Hi to you, too, kid. Sorry I've been so busy lately!" he says. It hasn't just
+been lately, of course, but that's just Dad.
+
+> n
+You walk north.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> e
+You walk east.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Plastic tarps are covering parts of the walls and ceilings. Light rain begins to
+drum on them.
+
+Uncle Joe is slicing and dicing potatoes like an expert chef. Which, of course,
+he is.
+
+"Hey, there you are," he says, as you walk in the room. "Hope you're hungry for
+later!"
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> x Joe
+Uncle Joe is only ten years older than you. He's a grizzled, mostly-bald man.
+He's tall and bulky, but leaner than he was a few years ago.
+
+He looks happy to see you. He's also sweating profusely in the kitchen heat.
+
+> undo
+Undoing the last turn (x joe).
+Kitchen
+
+> x Joe
+Uncle Joe is only ten years older than you. He's a grizzled, mostly-bald man.
+He's tall and bulky, but leaner than he was a few years ago.
+
+He looks happy to see you. He's also sweating profusely in the kitchen heat.
+
+> talk to Joe
+"Hey, Uncle Joe, do you have a second?"
+
+"Sure, CJ, what's up?"
+
+1. "Did you see a strange woman upstairs today?"
+2. "How's work been recently?"
+3. "Did you see what happened to the garage?"
+4. "Do you know where Uncle Rob went?"
+5. "Do you have any butter, Uncle Joe?"
+6. "Can I help you with the potatoes?"
+7. "Never mind, Uncle Joe."
+> 1
+"Did you see a strange woman upstairs today?"
+
+Uncle Joe wipes his prodigious brow. "CJ, I haven't left this kitchen at all.
+Did she look hungry? Because I think I made way too many potatoes."
+
+"No, she didn't look hungry, but she did seem familiar. She left me a chores
+list for a party," you answer.
+
+"Oh, well that's great, actually. I thought I was the only one getting ready.
+Maybe she's a guest who came early?"
+
+1. "How's work been recently?"
+2. "Did you see what happened to the garage?"
+3. "Do you know where Uncle Rob went?"
+4. "Do you have any butter, Uncle Joe?"
+5. "Can I help you with the potatoes?"
+6. "Never mind, Uncle Joe."
+> 1
+"How's work been recently?"
+
+"We opened three new franchises this month," says Uncle Joe. "We're even
+expanding into Canada!"
+
+1. "How's work been recently?"
+2. "Did you see what happened to the garage?"
+3. "Do you know where Uncle Rob went?"
+4. "Do you have any butter, Uncle Joe?"
+5. "Can I help you with the potatoes?"
+6. "Never mind, Uncle Joe."
+> 2
+"Did you see what happened to the garage?"
+
+He stops chopping for a minute.
+
+"Yeah, what a mess. Can't believe the old maple fell on it. Should never have
+planted it that close to the house."
+
+1. "How's work been recently?"
+2. "Do you know where Uncle Rob went?"
+3. "Do you have any butter, Uncle Joe?"
+4. "Can I help you with the potatoes?"
+5. "Never mind, Uncle Joe."
+> 2
+"Do you know where Uncle Rob went?"
+
+"I'm just glad he's not here snacking. That guy's an eating machine! But, you
+know, he's like you," he says, pointing at you. "He kind of 'wanders', if you
+get my drift. But I think you'll find him."
+
+1. "How's work been recently?"
+2. "Do you have any butter, Uncle Joe?"
+3. "Can I help you with the potatoes?"
+4. "Never mind, Uncle Joe."
+> 2
+"Do you have any butter, Uncle Joe?"
+
+"No, I stopped using that years ago. It's margarine for me, now."
+
+1. "How's work been recently?"
+2. "Do you have any butter, Uncle Joe?"
+3. "Can I help you with the potatoes?"
+4. "Never mind, Uncle Joe."
+> 3
+"Can I help you with the potatoes?"
+
+"Sounds great!" says Joe. He hands you a pile of potatoes and you scrub them. He
+shows you some interesting cooking techniques while you're working. He can talk
+about potatoes for hours, if you let him. He starts: "Potatoes are the fruit of
+the earth. You can roast them, boil them, fry them, mash them."
+
+He goes on: "There's baked potatoes, mashed potatoes. Fried potatoes: pan fried,
+deep fried, stir-fried. There's potato tacos, twice-baked potatoes, tater-tots,
+potatoes au gratin, chips, potato soup, potato stew, potato salad, shrimp and
+potatoes, hashbrowns, steak fries. That's about it."
+
+By now, you've washed a ton of potatoes. Uncle Joe says, "Thanks, CJ. That
+helps!"
+
+> x tarps
+You put these up on the ceiling to temporarily handle the damage from the
+hurricane.
+
+> x counter
+This long granite counter is destined to outlast you, the house, and everyone in
+it. It was installed a little crooked when it was first put in, leaving a gap.
+
+> x gap
+Stuff keeps falling in here for some reason. It's a narrow gap. Right now,
+there's a serving dish stuck in there.
+
+> x dish
+This is the family's antique serving platter. Grandpa got it from the old
+country.
+
+It looks pretty dirty right now.
+
+> take dish
+The gap is too small for an adult's arm to fit.
+
+> x oven
+This is your dad's old stove, still. Your new one won't come in until later in
+the week.
+
+> e
+You walk east.
+
+Outdoors
+A small row of houses is lined up behind yours. Most of them are clearly still
+recovering from the storm.
+
+From out here you can see the damage to your own house.
+
+The rain is drizzling.
+
+The kitchen is back to the west.
+
+The old maple tree has fallen on the garage, and the brand new treehouse is
+smashed on top of it.
+
+> x tree
+Your family's majestic maple tree has fallen onto the garage, crushing it
+completely.
+
+> x treehouse
+The hurricane knocked over the new treehouse. Now it's shattered, and so is
+everything in it!
+
+> x houses
+Most of your neighbours grew up and moved away, with newer families taking their
+place.
+
+> w
+You walk west.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Plastic tarps are covering parts of the walls and ceilings. Light rain drums on
+them.
+
+Uncle Joe is slicing and dicing potatoes like an expert chef. Which, of course,
+he is.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> s
+You walk south.
+
+Pantry
+This is your family's pantry, just a glorified closet with shelves.
+
+The shelves have some crushed walnuts and a can of yellow wax beans on them.
+
+> x shelves
+Plain white shelves, completely utilitarian. And very sturdy.
+
+> x walnuts
+Looks like this bag of crushed walnuts was the only thing left in the pantry,
+what with all the supply chain problems. You've already eaten through most of
+your supplies.
+
+> x beans
+Nobody in the house likes yellow wax beans. But this can is so old now it's part
+of your heritage, like the rest of the house.
+
+> take walnuts
+You take the crushed walnuts off the shelves.
+
+> n
+You walk north.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Plastic tarps are covering parts of the walls and ceilings. Light rain drums on
+them.
+
+Uncle Joe is slicing and dicing potatoes like an expert chef. Which, of course,
+he is.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> w
+You walk west.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again. She's holding her usual bottle of Sprite.
+
+She gives you a little wave as you walk come down the stairs.
+
+> x calendar
+This is a linen calendar towel with decorative flowers all around it. It's May
+17th, 1981, and it's Grandma's birthday!
+
+> x rug
+Sensible, practical, and easy to vacuum.
+
+> x paneling
+Your dad just recently bought this. It was fun helping him put it up.
+
+> x boombox
+This is the JVC RC-M90, the cutting edge of sound technology. Uncle Joe got it
+for Grandma for her birthday. It's blasting out "Bette Davis Eyes" at maximum
+loudness. The boombox is closed.
+
+> open it
+You open the boombox, revealing a battery.
+
+> x battery
+A single Z-cell battery. This thing is honestly huge! Ada made it herself, years
+ago.
+
+> x grandma
+Grandma looks pretty tired. Then again, she has been for weeks. She's
+comfortable on the couch in her house dress and slippers. She notices you
+looking and waves at you cheerfully.
+
+> talk to grandma
+"What is it, dear?" asks your grandmother.
+
+1. "Hey Grandma, some woman threw this list at me."
+2. "Happy Birthday!"
+3. "Grandma, do you know where the plates are?"
+4. "I can't find Uncle Rob anywhere."
+5. "Grandma, have you seen the good serving dish?"
+6. "That's all I wanted to say, Grandma."
+> 1
+"Hey Grandma, some woman threw this list at me."
+
+"Oh, that sounds pretty unusual. I've had a clipboard thrown at my face, if that
+makes you feel any better," she answers, still watching TV.
+
+"No, that doesn't...actually, yeah, that does kind of make me feel better," you
+answer.
+
+"Did she seem nice?" says Grandma.
+
+"She seemed familiar, somehow. She was leaning out the upstairs window," you
+say.
+
+"Ah, I see the problem. Don't worry dear, that kind of thing will sort itself
+out," says Grandma.
+
+1. "Happy Birthday!"
+2. "Grandma, do you know where the plates are?"
+3. "I can't find Uncle Rob anywhere."
+4. "Grandma, have you seen the good serving dish?"
+5. "That's all I wanted to say, Grandma."
+> 1
+"Happy Birthday!"
+
+"Oh thank you, Katrina," says Grandma.
+
+You try not to react at her calling you your mom's name. Grandma notices your
+unease and thinks for a moment.
+
+"I mean CJ, of course. It's not every day you turn eighty-four years old! I
+appreciate you taking care of the party!" she says, putting a kind hand on yours
+for a moment.
+
+1. "Grandma, do you know where the plates are?"
+2. "I can't find Uncle Rob anywhere."
+3. "Grandma, have you seen the good serving dish?"
+4. "That's all I wanted to say, Grandma."
+> 1
+"Grandma, do you know where the plates are?"
+
+You said plates? I'm not sure what plates you're talking about, dear, but I
+think your father would know."
+
+1. "Grandma, do you know where the plates are?"
+2. "I can't find Uncle Rob anywhere."
+3. "Grandma, have you seen the good serving dish?"
+4. "That's all I wanted to say, Grandma."
+> 2
+"I can't find Uncle Rob anywhere."
+
+"Oh, I'm not sure. He walks around like it was his purpose in life. Have you
+checked with Ada? The two of them think alike."
+
+1. "Grandma, do you know where the plates are?"
+2. "I can't find Uncle Rob anywhere."
+3. "Grandma, have you seen the good serving dish?"
+4. "That's all I wanted to say, Grandma."
+> 3
+"Grandma, have you seen the good serving dish?"
+
+"I lost that darned thing years ago. I was finishing washing up and putting away
+some of the plates when I heard the loudest clatter of my life. All the pots and
+pans had fallen over and rolled all over the room. I found them all eventually,
+but not the dish," says Grandma.
+
+1. "Grandma, do you know where the plates are?"
+2. "I can't find Uncle Rob anywhere."
+3. "Grandma, have you seen the good serving dish?"
+4. "That's all I wanted to say, Grandma."
+> 4
+"That's all I wanted to say, Grandma."
+
+She nods at you politely before going back to watching the TV.
+
+> x tv
+Dallas is playing on the television. It's a rerun, so you already know who shot
+JR. Grandma may have forgotten. The doctors like keeping things simple for her,
+these days.
+
+> x recliner
+Grandma's recliner is well past its glory years, but she refuses to replace it.
+
+> x sprite
+Grandma's been into Sprite ever since she first saw it advertised, years ago.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+Your cousin Ada is working diligently on her latest theorem in applied
+homological algebra. She seems withdrawn and focused.
+
+She notices you walk in.
+
+"Hi, CJ," she says absent-mindedly, and keeps walking around.
+
+> x whiteboard
+The whiteboard is covered in equations.
+
+> x equations
+Looks like she's studying finite subdivision rules. This is a series calculating
+the growth rate of a Gromov hyperbolic group.
+
+> x Ada
+Ada is a tall, young woman, about your age. Her wavy hair is dyed bright red,
+and she's wearing a black sweater that hangs loosely on her.
+
+She's your closest cousin, and a genius.
+
+> x sweater
+Ada has always preferred black sweaters.
+
+> talk to Ada
+Ada says, "Sorry, CJ, I'm busy. The life of a mathematician never slows down!
+Well, maybe never. But at least not until I've proven that there are no zeros
+off the critical line using annealing methods in numerical partial differential
+equations. But enough about me. What's up?"
+
+1. "Ada, did you see a strange woman upstairs?"
+2. "Make sure you're ready for dinner soon!"
+3. "So why do you like math so much anyway?"
+4. "Hey, do you know where Uncle Rob is?"
+5. "Ada, I seem to be traveling through time. Do you know anything about that?"
+6. "Hey, I know this is weird, but do you remember much about my mom?"
+7. "Nevermind, Ada!"
+> 1
+"Ada, did you see a strange woman upstairs?"
+
+"Besides you and me? Not really. Actually, have you ever even been upstairs?
+What with your... problem?"
+
+"It's not a problem, Ada!" you exclaim.
+
+"Oh, okay. That's actually a nice attitude. Anyway, no I haven't seen anyone. If
+you find her, let me know and I'll go say hi," she says.
+
+1. "Make sure you're ready for dinner soon!"
+2. "So why do you like math so much anyway?"
+3. "Hey, do you know where Uncle Rob is?"
+4. "Ada, I seem to be traveling through time. Do you know anything about that?"
+5. "Hey, I know this is weird, but do you remember much about my mom?"
+6. "Nevermind, Ada!"
+> 1
+"Make sure you're ready for dinner soon!"
+
+"Not now, CJ," says Ada. "Sorry if it sounds rude, but I feel like I'm on a real
+mission, like I can do something great here! As soon as I can figure out a
+couple problems."
+
+1. "So why do you like math so much anyway?"
+2. "Hey, do you know where Uncle Rob is?"
+3. "Ada, I seem to be traveling through time. Do you know anything about that?"
+4. "Hey, I know this is weird, but do you remember much about my mom?"
+5. "Nevermind, Ada!"
+> 1
+"So why do you like math so much anyway?"
+
+"Well, CJ, who wouldn't like math? In all the other sciences, you can doubt what
+your senses tell you. For all we know, nothing is real and we're just in a
+simulation or something. But math is a way of organizing human thought in
+consistent patterns, and it can be a source of truth even if you question
+everything else," she says.
+
+"Wow, I guess that makes sense," you say.
+
+"Also I tried biology but it was kind of boring," she says.
+
+1. "Hey, do you know where Uncle Rob is?"
+2. "Ada, I seem to be traveling through time. Do you know anything about that?"
+3. "Hey, I know this is weird, but do you remember much about my mom?"
+4. "Nevermind, Ada!"
+> 1
+"Hey, do you know where Uncle Rob is?"
+
+"Man, why do people keep asking me that?" says Ada. "Rob is kind of...you
+know..." she makes a weird gesture with her finger, like an infinity sign, and
+leans forward to whisper, "non-spatio-temporally anchored. You know. Like you.
+And our other cousin."
+
+She gives you a knowing nod and goes back to work.
+
+1. "Hey, do you know where Uncle Rob is?"
+2. "Ada, I seem to be traveling through time. Do you know anything about that?"
+3. "Hey, I know this is weird, but do you remember much about my mom?"
+4. "Nevermind, Ada!"
+> 2
+"Ada, I seem to be traveling through time. Do you know anything about that?"
+
+"Haha! Oh, CJ, you're such a kidder!" she says. "You know that you're one of the
+few members of the family with spatio-temporal disjunction. I've explained it to
+you many times before! And I specifically recall how disappointed you were when
+your beautiful and wondrous ability could be reduced to a simple and mundane 4-
+dimensional explanation! Oh, how the joy of mystery breaks down in the face of
+pure reason," she says, shaking her head.
+
+"Oh, yeah," you say. "I completely forgot about my spatio-temporal disjunction.
+Thanks for reminding me!"
+
+1. "Hey, do you know where Uncle Rob is?"
+2. "Hey, I know this is weird, but do you remember much about my mom?"
+3. "Nevermind, Ada!"
+> 2
+"Hey, I know this is weird, but do you remember much about my mom?"
+
+"I only met her when I was very little. It might be better to ask your dad or
+Joe or someone," she says a little uncomfortably.
+
+"That's why I wanted to talk to you; they knew her more and I feel like they
+would just get sad if I asked. What do you remember about her?" you say.
+
+"Oh, gosh. Well, I remember that she used to tell me stories when I was bored,
+like from Greek mythology. Cyclops and stuff. That was pretty cool. And she
+liked the color blue, and I swear I saw her take a pan out of the oven with her
+bare hands once. Although that doesn't really make sense given the laws of
+thermodynamics. Does that help?" she asks.
+
+"Yeah, that's great. Thanks Ada!" you say.
+
+1. "Hey, do you know where Uncle Rob is?"
+2. "Nevermind, Ada!"
+> 2
+"Nevermind, Ada!"
+
+"OK, CJ, see you later!" she says.
+
+> s
+You walk south.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again. She's holding her usual bottle of Sprite.
+
+> s
+You walk south.
+
+Office
+This is your father's office. It's covered in shelves filled with old classics
+and weathered issues of National Geographic, with a memory board on one wall.
+His old wooden desk is here, with his new computer.
+
+The family room is back to the north.
+
+Your dad is staring thoughtfully into space.
+
+> x desk
+Your father's desk is old and well-worn. It's been here so long it's probably
+fused with the house. You shudder to imagine someone trying to move this thing
+someday.
+
+Oh, what's this? There's a subscription form for ordering puzzles. It looks
+fairly old.
+
+> x form
+This looks fairly faded. It's a form for ordering a year's worth of crossword
+puzzle books. It's dated 1961.
+
+> x computer
+Your dad's computer is turned on, running Visicalc. You'll have to wait until
+later to play Zork II.
+
+> x dad
+Dad looks a little softer and more gentle than when you were a kid in this
+house, but he still looks tough. He has grey in his mustache, but always dyes
+his hair. He's still wearing his suit, like you remember.
+
+> x national
+These have really piled up over the years. Your dad move some of the old books
+into storage to make room for these.
+
+> take form
+You take the subscription form.
+
+> n
+You walk north.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again. She's holding her usual bottle of Sprite.
+
+> e
+You walk east.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+A whole-roasted chicken is sitting out on the counter to cool.
+
+Uncle Joe is slicing potatoes expertly. He's gotten pretty good at this since he
+started his restaurant.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> x chicken
+A tender and juicy roasted chicken. Uncle Joe sure is getting better at cooking.
+One drumstick is sticking out.
+
+> x drumstick. take it.
+This tender hunk of meat is the entire leg of a chicken.
+
+You take the drumstick.
+
+> talk to joe
+"Hey, Uncle Joe, do you have a second?"
+
+"Sure, CJ, what's up?"
+
+1. "How's work been recently?"
+2. "Do you have any butter, Uncle Joe?"
+3. "Can I help you with the potatoes?"
+4. "Never mind, Uncle Joe."
+> 2
+"Do you have any butter, Uncle Joe?"
+
+"No, I stopped using that years ago. It's margarine for me, now."
+
+1. "How's work been recently?"
+2. "Do you have any butter, Uncle Joe?"
+3. "Can I help you with the potatoes?"
+4. "Never mind, Uncle Joe."
+> 3
+"Can I help you with the potatoes?"
+
+"I think I'm good for now, but feel free to hang out!" he answers cheerfully.
+You spend a bit chatting with him about dinner and the party.
+
+> s
+You walk south.
+
+Pantry
+This is your family's pantry, just a glorified closet with shelves.
+
+The shelves have a box of Count Chocula cereal, a box of oatmeal, and a can of
+yellow wax beans on them.
+
+> x cereal
+This must be left over from Halloween.
+
+> x oatmeal
+Oh, sweet, it's your favorite: maple and brown sugar.
+
+> x
+(I only understood you as far as wanting to examine something.)
+
+> beans
+Nobody in the house likes yellow wax beans, but, on the other hand, no one wants
+to throw this out. Who knows how old this is now.
+
+> n
+You walk north.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+A whole-roasted chicken is sitting out on the counter to cool.
+
+Uncle Joe is slicing potatoes expertly. He's gotten pretty good at this since he
+started his restaurant.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> e
+You walk east.
+
+Outdoors
+Rolling grass stretches all the way to your neighbor's distant fence.
+
+The kitchen is back to the west.
+
+Your maple tree is beautiful in the summer light.
+
+> x maple
+A beautiful maple tree that has been growing for a few years. It's pretty large,
+but it will grow even bigger over time.
+
+> w
+You walk west.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+A whole-roasted chicken is sitting out on the counter to cool.
+
+Uncle Joe is slicing potatoes expertly. He's gotten pretty good at this since he
+started his restaurant.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> w
+You walk west.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again. She's holding her usual bottle of Sprite.
+
+> d
+The stairs seem to get bigger the further down you get. Or have you gotten
+smaller?
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on ABC right now,
+playing an ad for Sprite, the new drink.
+
+> x calendar
+The calendar is paper; they were handing them out at the drugstore. It's March
+5th, 1961.
+
+> x wallpaper
+Your mom bought this just a couple of weeks ago. It was fun helping her put it
+up, and is one of your last memories of her.
+
+> x carpeting
+Now this is the wave of the future! Soft and luxurious.
+
+> x grandma
+Grandma has tight curls of grey hair that bounce when she moves her head. She's
+wearing a green house dress and slippers. She gives you a little wink and goes
+back to watching TV.
+
+> x recliner
+This shiny and new recliner has been Grandma's favorite ever since her surgery.
+
+> x tv
+The TV is currently on ABC. An ad for a new softdrink is playing: Sprite! It
+seems very refreshing, and Grandma looks interested.
+
+Of course, she always lets you change the channel if you want. Too bad there are
+only 3 channels on the dial.
+
+> talk to grandma
+"What is it, dear?" asks your grandmother.
+
+1. "What do you think of the new house?"
+2. "Hey Grandma, what are you watching?"
+3. "Grandma, do you know where the plates are?"
+4. "I can't find Uncle Rob anywhere."
+5. "Grandma, have you seen the good serving dish?"
+6. "That's all I wanted to say, Grandma."
+> 1
+"What do you think of the new house?"
+
+"Oh, I adore it. The central air conditioning is just lovely!"
+
+1. "Hey Grandma, what are you watching?"
+2. "Grandma, do you know where the plates are?"
+3. "I can't find Uncle Rob anywhere."
+4. "Grandma, have you seen the good serving dish?"
+5. "That's all I wanted to say, Grandma."
+> 1
+"Hey Grandma, what are you watching?"
+
+"Coca-Cola made a new drink, it seems. It's called Sprite; isn't that the name
+of a fairy? It looks very interesting, though. I might have to try it," she
+says.
+
+1. "Can I watch with you for a bit?"
+2. "Can I change the channel, Grandma?"
+3. "That's interesting, Grandma."
+> 1
+"Can I watch with you for a bit?"
+
+"I'd love that, CJ," she says. You squeeze in next to her and she puts her arm
+around you.
+
+The kitchen on the show is a lot bigger than your own. And the lady is making
+some very strange food. You'd never thought of cinnamon gelatin before. After
+you watch for a bit, you get up again.
+
+> change channel
+You turn the tv to the next channel, CBS. It's Perry Mason! You like this show,
+but grandma is usually watching Bonanza. Good thing it changed time slots.
+Grandma takes your channel-changing in stride, and settles in to watch the new
+show.
+
+Your Grandma's future has slightly changed.
+
+> u
+You climb up the stairs. They seem to get smaller as you get higher. Or have you
+gotten taller?
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma's autographed poster of Raymond Burr is hanging on the wall.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> x poster
+Grandma is a big Perry Mason fan now, so she paid for this autographed poster of
+Raymond Burr a few years back.
+
+> d
+The stairs seem to get bigger the further down you get. Or have you gotten
+smaller?
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on CBS right now,
+playing Perry Mason..
+
+> change channel
+You turn the tv to the next channel, NBC. It's a cooking show that seems to be
+focusing on all the ways you can use cinnamon. Grandma takes your channel-
+changing in stride, and settles in to watch the new show.
+
+Your Grandma's future has slightly changed.
+
+> u. e. s
+You climb up the stairs. They seem to get smaller as you get higher. Or have you
+gotten taller?
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+You walk east.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+A whole-roasted chicken is sitting out on the counter to cool.
+
+Uncle Joe is slicing potatoes expertly. He's gotten pretty good at this since he
+started his restaurant.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+You walk south.
+
+Pantry
+This is your family's pantry, just a glorified closet with shelves.
+
+The shelves have a can of ground cinnamon, a box of Count Chocula cereal, a box
+of oatmeal, and a can of yellow wax beans on them.
+
+> x cinnamon
+This is a can of French's ground cinnamon.
+
+> take it
+You grab the cinnamon. It seems to resist you a bit. Once you take it, you feel
+your timeline partially stabilize.
+
+> n
+You walk north.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+A whole-roasted chicken is sitting out on the counter to cool.
+
+Uncle Joe is slicing potatoes expertly. He's gotten pretty good at this since he
+started his restaurant.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> w
+You walk west.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> d
+The stairs seem to get bigger the further down you get. Or have you gotten
+smaller?
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+> e
+You walk east.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Uncle Joe is slicing potatoes. He's going pretty slow, and not doing that great
+of a job.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> x gap
+Stuff keeps falling in here for some reason. It's a narrow gap. Right now,
+there's a serving dish stuck in there.
+
+> take dish
+You take the serving dish out of the gap.
+
+> give dish to Joe
+"What happened to this?" he asks incredulously. "Actually, I'd rather not know.
+Is there any way you could clean it up a little for me? I'm not putting food on
+it but it could bear a good wiping."
+
+> talk to Joe
+"Hey, Uncle Joe, do you have a second?"
+
+"Sure, CJ, what's up?"
+
+1. "How's work been recently?"
+2. "Do you have any butter, Uncle Joe?"
+3. "Can I help you with the potatoes?"
+4. "Never mind, Uncle Joe."
+> 2
+"Do you have any butter, Uncle Joe?"
+
+"Yeah, I think I have a stick laying around here somewhere," he says, then grabs
+and tosses you a stick of stick of butter. "There you go!" He stops talking and
+turns back to cooking.
+
+> x butter
+This stuff sure makes food taste good.
+
+> talk to Joe
+"Hey, Uncle Joe, do you have a second?"
+
+"Sure, CJ, what's up?"
+
+1. "How's work been recently?"
+2. "Can I help you with the potatoes?"
+3. "Never mind, Uncle Joe."
+> 1
+"How's work been recently?"
+
+"Gee, I've just been helping out Mr. Holladay in the back, but he's teaching me
+a lot about the grill," says Uncle Joe.
+
+1. "How's work been recently?"
+2. "Can I help you with the potatoes?"
+3. "Never mind, Uncle Joe."
+> 3
+"Never mind, Uncle Joe."
+
+"No problem, kid. See you around!"
+
+> s
+You walk south.
+
+Pantry
+This is your family's pantry, just a glorified closet with shelves.
+
+The shelves have a honey bear, some Cheerios, a jar of peanut butter, some cans
+of peach preserves, and a can of yellow wax beans on them.
+
+> x honey
+One of those new plastic honey bottles shaped like a bear.
+
+> take it
+You take the honey bear off the shelves.
+
+> x cheerios, peanut butter, peach and beans
+The Cheerios: A yellow box of cereal with Rocky and Bullwinkle on it.
+
+The jar of peanut butter: A short glass jar of Skippy brand peanut butter.
+
+The cans of peach preserves: A lot of cans of peach preserves. Grandma sure
+likes to be prepared.
+
+The can of yellow wax beans: Nobody in the house likes yellow wax beans. But you
+saw this in the store and put it in the cart. No one will ever know.
+
+> n and e
+North: You walk north.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Uncle Joe is slicing potatoes. He's going pretty slow, and not doing that great
+of a job.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+East: You walk east.
+
+Outdoors
+Rolling grass stretches out as far as you can see.
+
+The kitchen is back to the west.
+
+A sapling is buried out here.
+
+> x sapling
+This is a small sapling, its roots forming a sphere, more or less.
+
+> take sapling
+You aren't strong enough to pull out the sapling yourself. Someone bigger could
+do it, if you could persuade them.
+
+> w
+You walk west.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Uncle Joe is slicing potatoes. He's going pretty slow, and not doing that great
+of a job.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> talk to Joe
+"Hey, Uncle Joe, do you have a second?"
+
+"Sure, CJ, what's up?"
+
+1. "Hey Uncle Joe, could you help me move that sapling out back?"
+2. "How's work been recently?"
+3. "Can I help you with the potatoes?"
+4. "Never mind, Uncle Joe."
+> 1
+"Hey Uncle Joe, could you help me move that sapling out back?"
+
+He stops chopping for a minute.
+
+"I don't know CJ, I just planted it back there."
+
+1. "I just think it's ugly, that's all."
+2. "I think it's dangerous for the tree to be so close to the house."
+> 2
+"I think it's dangerous for the tree to be so close to the house."
+
+"Hey, thanks for the heads up. Let's go grab it!"
+
+Uncle Joe walks out to the back.
+
+> e
+You walk east.
+
+Outdoors
+Rolling grass stretches out as far as you can see.
+
+The kitchen is back to the west.
+
+Uncle Joe is eyeing the tree critically.
+
+A sapling is buried out here.
+
+> pull sapling
+Together, the two of you yank out the tree, tugging it until it pops out. Uncle
+Joe shakes off some of the dirt, fixes the roots, and says, "Smart thinking,
+kiddo. This could have done some real damage!" He tousles your hair and walks
+back inside.
+
+Outdoors
+Rolling grass stretches out as far as you can see.
+
+The kitchen is back to the west.
+
+You are now carrying a sapling. Something important has changed in the house's
+future.
+
+> w.w.s.
+You walk west.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Uncle Joe is slicing potatoes. He's going pretty slow, and not doing that great
+of a job.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+You walk west.
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+You walk south.
+
+Office
+This is your father's office. It's lined in shelves filled with old classics and
+many back issues of National Geographic, with a memory board on one wall. His
+tall oak desk takes up the most space.
+
+The family room is back to the north.
+
+Your dad curses faintly to himself, then shakes his head at the paper he is
+reading.
+
+> give form to dad
+"Huh," he says, "that actually looks kind of cool. You know, I think I'll sign
+up," he says. "But only if you help me with them."
+
+"Definitely," you say.
+
+He grabs the form from you and tucks it away.
+
+Something has changed in your father's future.
+
+> talk to dad
+Your dad looks up. "Hey, CJ!" he says, smiling. "What's up?"
+
+1. "I've been thinking about our family recently. It's pretty cool."
+2. "Do you know where the plates are?"
+3. "Oh, just wanted to say hi."
+> 1
+"I've been thinking about our family recently. It's pretty cool."
+
+Your dad pauses for a bit. "Yeah, you come from a great group. We're lucky to
+have everybody in the house together." He looks over at the memory board. "Well,
+most people. Your mom was really tough, you know. That's why we were all so
+shocked when she got breast cancer. But before she went, she was the strongest
+one in the house. Had a temper, too. She never hit you or me, but oh, would she
+shout when she was mad."
+
+He looks at the memory board, and adds, "Your grandfather was pretty much the
+same, like two peas in a pod. I heard they had some legendary arguments. But I
+only barely knew him, and by then he had mellowed out a ton. He had cancer, too,
+but it was lung cancer. You should probably get that checked out some day for
+all that stuff," he says. "But you can worry about that when you're older."
+
+The two of you chat for a little bit longer about the rest of your family before
+he gets back to work.
+
+1. "Do you know where the plates are?"
+2. "Oh, just wanted to say hi."
+> 2
+"Oh, just wanted to say hi."
+
+"Hi to you, too, kid. Sorry I've been so busy lately!" he says. It hasn't just
+been lately, of course, but that's just Dad.
+
+> n
+You walk north.
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+> u
+You climb up the stairs. They seem to get smaller as you get higher. Or have you
+gotten taller?
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> s
+You walk south.
+
+Office
+This is your father's office. It's covered in shelves filled with old classics
+and weathered issues of National Geographic, with a memory board on one wall.
+His old wooden desk is here, with his new computer.
+
+The family room is back to the north.
+
+A crossword puzzle book is lying here.
+
+Your dad is sitting at his desk, looking through papers.
+
+> x puzzle book
+This is one of your dad's favorite crossword puzzle books. It looks like he's
+solved every puzzle.
+
+> take it
+You take the crossword puzzle book.
+
+Your dad looks up, and says, "Hey, sorry kid, I already finished that one!"
+
+"It's okay, dad," you say. "I think I can find a use for it."
+
+> n
+You walk north.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> d
+The stairs seem to get bigger the further down you get. Or have you gotten
+smaller?
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+Your cousin Ada is skipping around the garage, chatting to herself and
+occasionally drawing on the whiteboard.
+
+> talk to Ada
+Ada says, "I'm trying to figure out what I want to do next. Some kind of big
+project. I'll let you know if I come up with anything! Anyway, what's up?"
+
+1. "Hey, do you know where Uncle Rob is?"
+2. "Nevermind, Ada!"
+> 2
+"Nevermind, Ada!"
+
+"OK, CJ, see you later!" she says.
+
+> s
+You walk south.
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+> d
+You look the stairs down with trepidation. What would happen? You imagine
+yourself shrinking, becoming younger and younger, scrunching into yourself until
+you become two little cells. Scary!
+
+You will not go any lower.
+
+> u
+You climb up the stairs. They seem to get smaller as you get higher. Or have you
+gotten taller?
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> e
+You walk east.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Plastic tarps are covering parts of the walls and ceilings. Light rain drums on
+them.
+
+Uncle Joe is slicing and dicing potatoes like an expert chef. Which, of course,
+he is.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> e
+You walk east.
+
+Outdoors
+A small row of houses is lined up behind yours. Most of them are clearly still
+recovering from the storm.
+
+From out here you can see the damage to your own house. The lawn has a pretty
+big hole in it, a couple feet across and fairly deep, but otherwise the damage
+is minimal.
+
+The rain is drizzling.
+
+The kitchen is back to the west.
+
+> put sapling in hole
+It fits in quite nicely. You pat the dirt around it and it seems settled in.
+
+You can feel your future change.
+
+> w
+You walk west.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Plastic tarps are covering parts of the walls and ceilings. Light rain drums on
+them.
+
+Uncle Joe is slicing and dicing potatoes like an expert chef. Which, of course,
+he is.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> w
+You walk west.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> x calendar
+This is a digital calendar. It's currently displaying the date December 23,
+2021.
+
+> x tree
+You bought your own tree a few years ago. It's smaller than your family's old
+ones, since it's just you and Joe and Ada now, but it's still beautiful. It's
+glowing in a rainbow of colors.
+
+> x rug
+Apparently this is 'boho-style'.
+
+> s
+You walk south.
+
+Office
+This is your art studio, a spacious room with a single easel in the middle. The
+family memory board takes up a lot of space on one side. You usually use the
+rest of the space to store art.
+
+The family room is back to the north.
+
+A few paintings of a dish towel line the side of the room.
+
+> x board
+The memory board has portraits of all your loved ones who have passed on. Right
+now, that includes your grandparents and your parents.
+
+> x dad
+In this photo, your father is sitting in his room late at night, reading law. He
+looks just as you remember him.
+
+> x paintings
+These are the paintings you haven't sold recently. Most of the paintings are of
+a dish towel since that was the inspiration for your first paintings twenty
+years ago.
+
+> n
+You walk north.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> e
+You walk east.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Uncle Joe is slowly and reflectively slicing potatoes. He has excellent
+technique, but less energy than he once did.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> s
+You walk south.
+
+Pantry
+This is your family's pantry, just a glorified closet with shelves.
+
+The shelves have some phyllo dough, a jar of granola, and a can of yellow wax
+beans on them.
+
+> x dough
+You set it out to warm earlier. Now it's perfect!
+
+> take it
+You take the phyllo dough off the shelves.
+
+> x granola
+You've switched over to organic granola, recently.
+
+> x beans
+Nobody in the house likes yellow wax beans. But the can has lasted longer than
+almost everything else in the house. It'd be a shame to move it now.
+
+> n
+You walk north.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Uncle Joe is slowly and reflectively slicing potatoes. He has excellent
+technique, but less energy than he once did.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> make recipe
+You preheat the oven, unroll the dough, melt the butter, and begin layering. It
+takes a while and leaves you worn out, but it's in the oven. It should be done
+after dinner, when you can let it cool while everybody talks.
+
+> e
+You walk east.
+
+Outdoors
+This plot of land is one of the biggest remaining backyards in the area. A
+pleasant stone fence sections it off.
+
+The kitchen is back to the west.
+
+A tall maple tree provides shade.
+
+> x fence
+This ended up costing more than you budgeted for, but it feels comforting. Kind
+of an earthy, settled feeling.
+
+> x tree
+This is a tall and lovely maple tree, twenty years old.
+
+> w
+You walk west.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Uncle Joe is slowly and reflectively slicing potatoes. He has excellent
+technique, but less energy than he once did.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> w
+You walk west.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+The family room has a bare hardwood floor and white, dusty walls.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> x calendar
+This is less of a calendar and more of a note to yourself. It says: "MOVE OUT:
+April 4th, 2041".
+
+> s
+You walk south.
+
+Office
+This is your former studio, but now the room is empty. It echoes in here. Your
+family's memory board is on the ground. You're not packing it, because it'll go
+in the car with you.
+
+The family room is back to the north.
+
+> x board
+The memory board has portraits of all your loved ones who have passed on. Right
+now, that includes your grandparents, your parents and Uncle Joe.
+
+> x Joe
+This picture of your Uncle Joe was taken at the opening of his first franchise,
+back when he had more hair. He's standing tall, arms crossed, grinning at the
+camera.
+
+> n
+You walk north.
+
+Family Room
+The family room has a bare hardwood floor and white, dusty walls.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> e
+You walk east.
+
+Kitchen
+The kitchen is quiet. A long granite counter runs down one side. A small oven is
+next to it. The backyard is to the east, the pantry is to the south, and the
+family room is to the west.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> s
+You walk south.
+
+Pantry
+This is your family's pantry, just a glorified closet with shelves.
+
+The shelves have a can of yellow wax beans on them.
+
+> x beans
+This can has born witness to over eighty years of history. It may well outlast
+mankind. Certainly you'll never eat it.
+
+> n
+You walk north.
+
+Kitchen
+The kitchen is quiet. A long granite counter runs down one side. A small oven is
+next to it. The backyard is to the east, the pantry is to the south, and the
+family room is to the west.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> e
+You walk east.
+
+Outdoors
+The stone fence around this plot is covered with moss, but the grass is recently
+trimmed.
+
+The kitchen is back to the west.
+
+An old maple tree provides shade here. The treehouse you built for the neighbor
+kids sits in it, with a ladder leading up.
+
+> x tree
+This is a towering, lovely maple tree, forty years old.
+
+> x ladder
+This ladder leads up into the treehouse. It's new, like the rest of the
+treehouse, and has wide steps to help you get up more easily.
+
+> x treehouse
+You wanted to leave a memento for the neighbors, when you realized that you had
+no one left to leave the house to. They've enjoyed it for the last few years.
+
+A ladder leads up into it.
+
+> u
+It's hard going, but you carefully make your way up the ladder.
+
+Treehouse
+This is a small and homey little treehouse. It's not furnished; the kids will
+take care of that, eventually. The back yard is down below.
+
+A pile of plates lies here.
+
+> x plates
+There are just enough plates for everyone to eat dinner together.
+
+> take plates
+You take the plates.
+
+> d
+You carefully negotiate your way down the ladder.
+
+Outdoors
+The stone fence around this plot is covered with moss, but the grass is recently
+trimmed.
+
+The kitchen is back to the west.
+
+An old maple tree provides shade here. The treehouse you built for the neighbor
+kids sits in it, with a ladder leading up.
+
+> w
+You walk west.
+
+Kitchen
+The kitchen is quiet. A long granite counter runs down one side. A small oven is
+next to it. The backyard is to the east, the pantry is to the south, and the
+family room is to the west.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> put plates on table
+You put the plates on the table. Your whole timeline feels a bit more settled
+now.
+
+> w
+You walk west.
+
+Family Room
+The family room has a bare hardwood floor and white, dusty walls.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+Your elderly cousin Ada is pacing around the room somewhat wistfully. She still
+hasn't packed.
+
+> talk to Ada
+Ada says, "You know, CJ, I regret never living my passion...making robots! It's
+too late for me to really get into it now, but it inspired me to write about
+them! Here, take this. I only wish my younger self could have seen it."
+
+She hands you a small book.
+
+> x small book
+It says "Robot Empire", by Ada S. It's a children's book
+
+> read it
+It's about a space society of sentient robot ships that battle across an entire
+galaxy, trying to find a mysterious, black-hole orbiting planet said to contain
+the strongest metal in the universe. The main character is constantly upgrading
+itself throughout the story.
+
+> s
+You walk south.
+
+Family Room
+The family room has a bare hardwood floor and white, dusty walls.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> u
+You start going up, but it seems different up there, dark and uncertain. You'll
+take that path one day, but not today.
+
+You will not go any higher.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> d
+The stairs seem to get bigger the further down you get. Or have you gotten
+smaller?
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+Your cousin Ada is skipping around the garage, chatting to herself and
+occasionally drawing on the whiteboard.
+
+> talk to Ada
+Ada says, "I'm trying to figure out what I want to do next. Some kind of big
+project. I'll let you know if I come up with anything! Anyway, what's up?"
+
+1. "Hey, do you want to check out this book on robots?"
+2. "Hey, do you know where Uncle Rob is?"
+3. "Nevermind, Ada!"
+> 1
+"Hey, do you want to check out this book on robots?"
+
+You give young Ada the book.
+
+"Whoa! This story is awesome! I wonder if someone could make a robot in real
+life...you know what, I'm going to try it!"
+
+She immediately starts tinkering around, assembling parts. This looks like it
+might take a while.
+
+Ada's future has changed.
+
+> s
+You walk south.
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+> u
+You climb up the stairs. They seem to get smaller as you get higher. Or have you
+gotten taller?
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The robot prototype Ada's always working on is in the corner.
+
+Your cousin Ada is sketching schematics on the whiteboard.
+
+> x robot prototype
+The original toaster design remains, but there are multiple attachments now.
+
+> talk to Ada
+Ada says, "Sorry, CJ, I'm working on an idea for a robot! I've been kind of
+busy. What do you need?"
+
+1. "So why do you like robots so much anyway?"
+2. "Hey, do you know where Uncle Rob is?"
+3. "Nevermind, Ada!"
+> 1
+"So why do you like robots so much anyway?"
+
+"Robots are cool. You have to know math to make them, and they're kind of like
+biological organisms but if you don't understand how part of the body works you
+can just put whatever you want there instead. Like something that shoots sparks,
+or makes a quacking sound," she says. "Also it helps ease my mind, because if
+we're in a simulation, and I make a simulated human, it's like a double
+simulation and I'm continuing on the chain of existence," she says, and cackles
+madly.
+
+"Oh. I guess that's pretty cool," you say.
+
+"You're darn right it is!" says Ada.
+
+1. "Hey, do you know where Uncle Rob is?"
+2. "Nevermind, Ada!"
+> 2
+"Nevermind, Ada!"
+
+"OK, CJ, see you later!" she says.
+
+> s
+You walk south.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The robot prototype Ada's always working on is in the corner.
+
+Your cousin Ada is pacing around the room, tinkering with spare parts.
+
+> x robot prototype
+The original casing has been stripped off and replaced with shiny steel. It has
+a screen, too.
+
+> x screen
+The screen is inert, for now.
+
+> s
+You walk south.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The robot prototype Ada's always working on is in the corner.
+
+Your cousin Ada is frantically looking through the boxes. "Where is it?" she
+mutters.
+
+> x robot prototype
+The robot shaped like a toaster has been pried open. Wires reach out of it in
+many directions. It is silent.
+
+> x wires
+The robot shaped like a toaster has been pried open. Wires reach out of it in
+many directions. It is silent.
+
+> talk to Ada
+"Sorry, CJ, I've got a major problem right now. What's up?"
+
+1. "Hey, what's wrong? You look upset."
+2. "Hey, do you know where Uncle Rob is?"
+3. "Nevermind, Ada!"
+> 1
+"Hey, what's wrong? You look upset."
+
+Ada says, "Have you seen a battery anywhere? I made a really big battery years
+ago, large enough to power some hefty electronics. I was saving it to power my
+final creation. But I can't find it anywhere! I know I used it for something,
+but I have no idea where it's gone, or when. It's so frustrating!"
+
+"I'll see if I can find anything like that," you say.
+
+She gives you a wan smile. "Thanks!"
+
+1. "Hey, what's wrong? You look upset."
+2. "Hey, do you know where Uncle Rob is?"
+3. "Nevermind, Ada!"
+> 3
+"Nevermind, Ada!"
+
+"OK, CJ, see you later!" she says.
+
+> s
+You walk south.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> take battery
+You take the battery out of the boombox.
+
+The boombox is now silent.
+
+Grandma looks a bit put out. "I was listening to Kim Carnes!" she says. "Oh
+well. At least now I can hear Dallas better."
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The robot prototype Ada's always working on is in the corner.
+
+Your cousin Ada is frantically looking through the boxes. "Where is it?" she
+mutters.
+
+> give battery to Ada
+You hand over the Z-cell battery to Ada.
+
+"You found it!" says Ada, pumping her fist with excitement. "Perfect! You're
+gonna love what I come up with after this. Check in with me later...a lot
+later!"
+
+Ada's future has changed.
+
+> s
+You walk south.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+The family room has a bare hardwood floor and white, dusty walls.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The robot prototype Ada's always working on is in the corner.
+
+Your cousin Ada is finishing up her last bits of work. She still hasn't packed.
+
+> x robot
+The prototype looks finished! Ada must so be so excited!
+
+> talk to Ada
+Ada looks at you and beams. She says, "It's finally finished! My greatest work!
+It's Toaster Bot! Even though it...doesn't really toast anything. But it is
+vaguely toaster-shaped."
+
+She hands you the little toaster robot, then smiles.
+
+"It's not much, but it's the best I could do with the time I have..." she says.
+
+Toaster Bot beeps mysteriously.
+
+> x bot
+This is a cute little robot shaped like a toaster, although all toaster
+functionality was stripped out of it years ago. It doesn't have a lot of
+capabilities, apparently, but it's an honest-to-goodness robot with a screen and
+attachments, and that's pretty impressive.
+
+Ada probably could have improved it, given enough time.
+
+Toaster Bot shakes violently for a second before stopping.
+
+> x screen
+The screen mostly flashes, making different kinds of eyes, like UwU or OwO.
+
+Toaster Bot beeps mysteriously.
+
+> talk to Ada
+She beams at you, and says, "Hey, what's up?"
+
+1. "What should I do with this robot?"
+2. "Hey, do you know where Uncle Rob is?"
+3. "Nevermind, Ada!"
+> 1
+"What should I do with this robot?"
+
+"I dunno, I just remember how you inspired me with that robot story, years ago.
+I always wanted to inspire someone else in the same way," says Ada.
+
+1. "Hey, do you know where Uncle Rob is?"
+2. "Nevermind, Ada!"
+> 2
+"Nevermind, Ada!"
+
+"OK, CJ, see you later!" she says.
+
+> s
+You walk south.
+
+Family Room
+The family room has a bare hardwood floor and white, dusty walls.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Toaster Bot shakes violently for a second before stopping.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Toaster Bot beeps mysteriously.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+Toaster Bot shoots off a tiny shower of sparks.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Toaster Bot beeps mysteriously.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Toaster Bot gurgles and coos in your arms.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Toaster Bot shakes violently for a second before stopping.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+The boombox is silent now.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+Toaster Bot gurgles and coos in your arms.
+
+> d
+The stairs seem to get bigger the further down you get. Or have you gotten
+smaller?
+
+Toaster Bot shakes violently for a second before stopping.
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+Toaster Bot shoots off a tiny shower of sparks.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The robot prototype Ada's always working on is in the corner.
+
+Your cousin Ada is skipping around the garage, chatting to herself and
+occasionally drawing on the whiteboard.
+
+Toaster Bot beeps mysteriously.
+
+> talk to Ada
+Ada says, "I love robots! I'm going to make one. It's kind of hard for me to
+know what to do, though, but I do have a cool idea!"
+
+She messes around with the prototype for a bit, then realizes you're still
+there. "Oh, did you need anything?"
+
+1. "Hey, check out this cool Toaster Robot!"
+2. "Hey, do you know where Uncle Rob is?"
+3. "Nevermind, Ada!"
+> 1
+"Hey, check out this cool Toaster Robot!"
+
+You give young Ada the robot.
+
+"Holy Cow! What is this? I...hey, I think I know how this works! But it doesn't
+really...do much. Hmmm I think I have some ideas!"
+
+She gets to work, grabbing parts and working on a new prototype.
+
+Ada's future has changed.
+
+> s
+You walk south.
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+> u
+You climb up the stairs. They seem to get smaller as you get higher. Or have you
+gotten taller?
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+The boombox is silent now.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The walking robot prototype Ada's always working on in the corner.
+
+Your cousin Ada is staring at the whiteboard, frustrated.
+
+> x walking robot
+The old toaster shape has been replaced with a small humanoid torso. It looks
+like there should be legs at the bottom, but they're missing.
+
+> talk to Ada
+"Oh. Hey CJ. What's up?" she says.
+
+1. "Hey, what's wrong? You seem frustrated."
+2. "Hey, do you know where Uncle Rob is?"
+3. "Nevermind, Ada!"
+> 1
+"Hey, what's wrong? You seem frustrated."
+
+"I wish I had inspiration for the joints," she says. "What I really need is a
+way to study a leg in detail." She sighs. "You got any legs?"
+
+"Uh, I have two, I guess," you say, looking down at yours. "Same as you."
+
+"Well, unless I can borrow them permanently, it's not going to help. If you see
+any other legs, let me know!" she says.
+
+1. "Hey, could you use this drumstick?"
+2. "Hey, what's wrong? You seem frustrated."
+3. "Hey, do you know where Uncle Rob is?"
+4. "Nevermind, Ada!"
+> 1
+"Hey, could you use this drumstick?"
+
+"Oh!" exclaims Ada. "Yes, I could learn a lot about legs from this!"
+
+But then she looks concerned. "But this is only one leg, and it will go bad
+soon. I wish I could have more info on legs, especially in a way that won't
+decay with time. Like a photo or something."
+
+1. "Hey, could you use this drumstick?"
+2. "Hey, what's wrong? You seem frustrated."
+3. "Hey, do you know where Uncle Rob is?"
+4. "Nevermind, Ada!"
+> 4
+"Nevermind, Ada!"
+
+"OK, CJ, see you later!" she says.
+
+> s
+You walk south.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+The boombox is silent now.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> s
+You walk south.
+
+Office
+This is your art studio. Or, at least, it will be. Right now, it's mostly empty,
+except for a single easel in the middle and a pedestal. Your family's memory
+board is here, the only thing you kept from your dad's old office. The shelves
+and most of the books had to be thrown out.
+
+The family room is back to the north.
+
+On the pedestal, you can see a dish towel, artfully arranged.
+
+Your dad is hustling back and forth, finishing the last few tasks before you can
+move in completely.
+
+He looks up and smiles as you walk in before going back to his work.
+
+> take towel
+You take the dish towel off the pedestal.
+
+You feel your future career slightly change.
+
+> wipe dish
+You wipe off most of the dirt with the towel. It looks much better now!
+
+> x dish
+This is the family's antique serving platter. Grandpa got it from the old
+country.
+
+It's bright and clean.
+
+> put drumstick on pedestal
+You put the drumstick on the pedestal.
+
+You feel your future career slightly change.
+
+> n
+You walk north.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> s
+You walk south.
+
+Office
+This is your art studio, a spacious room with a single easel in the middle. The
+family memory board takes up a lot of space on one side. You usually use the
+rest of the space to store art.
+
+The family room is back to the north.
+
+A few paintings of a drumstick line the side of the room.
+
+> x paintings
+These are the paintings you haven't sold recently. Most of the paintings are of
+a drumstick since that was the inspiration for your first paintings twenty years
+ago.
+
+> take paintings
+You take the paintings of a drumstick.
+
+> n
+You walk north.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+The boombox is silent now.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The walking robot prototype Ada's always working on in the corner.
+
+Your cousin Ada is staring at the whiteboard, frustrated.
+
+> talk to Ada
+"Oh. Hey CJ. What's up?" she says.
+
+1. "Hey, are these paintings helpful at all?"
+2. "Hey, what's wrong? You seem frustrated."
+3. "Hey, do you know where Uncle Rob is?"
+4. "Nevermind, Ada!"
+> 1
+"Hey, are these paintings helpful at all?"
+
+You hand over the paintings to Ada.
+
+"This is perfect!" says Ada. "I love it! Let me go throw these in the car to get
+them framed later," she says, running into the house. You hear the front door
+open and then close a couple seconds later.
+
+She rushes back in. "Done! And thanks again! Now I can really get to work."
+
+Ada's future has changed.
+
+> s
+You walk south.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+The boombox is silent now.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+The family room has a bare hardwood floor and white, dusty walls.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The walking robot prototype Ada's always working on in the corner.
+
+Your cousin Ada is finishing up her last bits of work. She still hasn't packed.
+
+> x robot
+The prototype looks finished! Ada must so be so excited!
+
+> talk to Ada
+Ada looks at you and beams. She says, "It's finally finished! My greatest work!
+It's Walkbot!"
+
+She places the walking robot on the ground and nudges it towards you. It
+troddles forward and cuddles your leg before walking to your side. Ada smiles,
+then sighs.
+
+"There's so much more I could have done, given the time," she says.
+
+Walkbot trips a bit but catches itself as you walk.
+
+> talk to Ada
+"Hey, thanks for your help earlier. What do you need?" asks Ada.
+
+1. "What should I do with this robot?"
+2. "Hey, do you know where Uncle Rob is?"
+3. "Nevermind, Ada!"
+> 1
+"What should I do with this robot?"
+
+"Hey, I think people deserve to see this bad boy. Show it around!" says Ada
+proudly.
+
+1. "Hey, do you know where Uncle Rob is?"
+2. "Nevermind, Ada!"
+> 2
+"Nevermind, Ada!"
+
+"OK, CJ, see you later!" she says.
+
+> s
+You walk south.
+
+Family Room
+The family room has a bare hardwood floor and white, dusty walls.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Walkbot follows close behind you as you walk.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+Walkbot walks around in a little circle.
+
+> e
+You walk east.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Uncle Joe is slowly and reflectively slicing potatoes. He has excellent
+technique, but less energy than he once did.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has some plates on it.
+
+Walkbot runs headlong into a wall, then recalibrates and follows you.
+
+> show walkbot to Joe
+"Whoa!" says Joe. "What's this?"
+
+"Ada made a walking robot," you answer.
+
+"Neat! I don't suppose it knows how to chop potatoes, does it?" he asks,
+teasingly.
+
+"I don't think so, Uncle Joe," you answer.
+
+> w
+You walk west.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+Walkbot follows close behind you as you walk.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Walkbot walks around in a little circle.
+
+> s
+You walk south.
+
+Office
+This is your art studio. Or, at least, it will be. Right now, it's mostly empty,
+except for a single easel in the middle and a pedestal. Your family's memory
+board is here, the only thing you kept from your dad's old office. The shelves
+and most of the books had to be thrown out.
+
+The family room is back to the north.
+
+On the pedestal, you can see a drumstick, artfully arranged.
+
+Your dad is puttering around, making sure that your new studio is ready for you
+to move into.
+
+Walkbot trips a bit but catches itself as you walk.
+
+> show walkbot to dad
+"Is that something Ada made?" asks Dad.
+
+"Yeah, how'd you know?" you ask.
+
+"She's always talking about robotics these days. I'm proud of her," says Dad.
+
+> n
+You walk north.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Walkbot follows close behind you as you walk.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+The boombox is silent now.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+Walkbot walks around in a little circle.
+
+> show walkbot to grandma
+"What a funny little thing!" says Grandma. "Did you buy that?"
+
+"No, Ada made it," you say.
+
+"Well that's marvelous," she says. "I'll have to tell her how proud I am."
+
+> d
+The stairs seem to get bigger the further down you get. Or have you gotten
+smaller?
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+Walkbot walks around in a little circle.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The walking robot prototype Ada's always working on in the corner.
+
+Your cousin Ada is skipping around the garage, chatting to herself and
+occasionally drawing on the whiteboard.
+
+Walkbot trips a bit but catches itself as you walk. Ada sees the walking robot
+following you and gasps.
+
+"Oh my goodness! What an adorable robot! Hello, my name is Ada. What's yours?"
+
+When the robot doesn't respond, she strokes her chin and says, "Huh. Doesn't
+talk. I wonder if I can fix that. Give me some space, I'm gonna get to work!"
+
+She immediately starts tinkering with the robot, pulling some parts out and
+replacing them with others.
+
+Ada's future has changed.
+
+> s
+You walk south.
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+> u
+You climb up the stairs. They seem to get smaller as you get higher. Or have you
+gotten taller?
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+The boombox is silent now.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The android prototype Ada's always working on is here.
+
+Ada is taking a break, looking kind of upset.
+
+> x android
+The prototype's outward appearance looks complete, but it's turned off and has
+wires going into its head.
+
+> talk to Ada
+"Hey, CJ, what's up?" says Ada.
+
+1. "Hey, what's wrong?"
+2. "Hey, do you know where Uncle Rob is?"
+3. "Nevermind, Ada!"
+> 1
+"Hey, what's wrong?"
+
+Ada says, "I'm kind of stuck. I need a source of concentrated knowledge to train
+my robot with. And it can't be digital, I've had enough of that. I'm looking for
+something imperfect, like someone's journals or a finished book of puzzles."
+
+"Hmmm," you say, "sounds like something my dad would have."
+
+"Really? Well, let me know if you find it!" says Ada.
+
+1. "Hey, my dad finished this crossword puzzle book. Could you use it?"
+2. "Hey, what's wrong?"
+3. "Hey, do you know where Uncle Rob is?"
+4. "Nevermind, Ada!"
+> 1
+"Hey, my dad finished this crossword puzzle book. Could you use it?"
+
+You hand over the puzzle book to Ada.
+
+"Wow," says Ada. "This is perfect! And I like that your dad worked on this. The
+data will influence the robot's personality, so he might end up similar to your
+dad. Kind of like brothers!"
+
+Ada's future has changed.
+
+> s
+You walk south.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+The family room has a bare hardwood floor and white, dusty walls.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The android prototype Ada's always working on is here.
+
+Your cousin Ada is finishing up her last bits of work. She still hasn't packed.
+
+> x android
+The prototype looks finished! Ada must so be so excited!
+
+> talk to Ada
+Ada looks at you and beams. She says, "It's finally finished! My greatest work!
+It's Uncle Rob!"
+
+She presses a button, and Rob lights up.
+
+"Hello, CJ. It's a pleasure to see you. Do you have any food? I am quite
+hungry," says Rob.
+
+Ada smacks her forehead. "Of course! I forgot about dinner. Here, take Rob and
+let me know when everyone else gets here! I'm going to go wash up," she says,
+and walks into the house.
+
+> x Rob
+This is a big, walking, talking robot. It's engraved with the words "Uncle Rob!"
+on it. He has a thick copper mustache.
+
+> x mustache
+This metallic mustache looks quite a bit like your dad's mustache.
+
+> talk to Rob
+Uncle Rob looks at you attentively. "What do you need, CJ?" he asks.
+
+1. "What's it like being sentient?"
+2. "How do you eat food?"
+3. "Do you know any good songs?"
+4. "Nevermind."
+> 1
+"What's it like being sentient?"
+
+"Thanks, CJ! Great question! I've been wondering the same thing. In fact, I'm
+trying to determine my organizing principles in life. I can't decide if Rule 1
+should be 'I must not injure humans' or 'Live, laugh, love.'"
+
+1. "How do you eat food?"
+2. "Do you know any good songs?"
+3. "Nevermind."
+> 1
+"How do you eat food?"
+
+"You know, I honestly don't know. Probably some kind of slow-burn, inefficient
+mass-to-energy converter that requires a massive amount of infrastructure to
+deal with both constant consumption of input and constant excretion of output.
+You know, like you!"
+
+1. "Do you know any good songs?"
+2. "Nevermind."
+> 1
+"Do you know any good songs?"
+
+"Of course! This one's my favorite, from a personal hero of mine: They ruled the
+solar system
+Near ten thousand years before
+In their single starcrossed scout ships
+Mining ast'roids, spinning lore.
+
+Then one true courageous miner
+Spied a spaceship from the stars
+Boarded he that alien liner
+Out beyond the orb of Mars.
+
+Yes, that ship was filled with danger
+Mighty monsters barred his way
+Yet he solved the alien myst'ries
+Mining quite a lode that day.
+
+O, they ruled the solar system
+Near ten thousand years before
+'Til one brave advent'rous spirit
+Brought that mighty ship to shore."
+
+1. "Nevermind."
+> 1
+"Nevermind."
+
+"Never...mind? I always use my mind," he says, brow furrowing.
+
+> s
+You walk south.
+
+Family Room
+The family room has a bare hardwood floor and white, dusty walls.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Uncle Rob follows you.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+Uncle Rob hums a little ditty to himself.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Uncle Rob is making notes to himself about human culture.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+The boombox is silent now.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+Uncle Rob is glancing around the room amiably.
+
+> e
+You walk east.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+A whole-roasted chicken is sitting out on the counter to cool.
+
+Uncle Joe is slicing potatoes expertly. He's gotten pretty good at this since he
+started his restaurant.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has some plates on it.
+
+Uncle Rob follows you.
+
+> give dish to Joe
+You hand the serving platter to Uncle Joe.
+
+"This looks perfect," he says. "Thanks so much for getting this ready!"
+
+You hear someone knocking at the front door.
+
+> w
+You walk west.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+The boombox is silent now.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+You hear someone knocking at the front door.
+
+Uncle Rob follows you.
+
+> open door
+Look who it is! It's your young cousin Emma!
+
+"We finally made it! I brought a gift for Grandma, and a toy for later," she
+says. She holds up a wrapped present and a dollhouse. She looks at everyone else
+in the room behind you: "Hey grandma! Hey Uncle Rob!" she says.
+
+"Hi, Emma!" says Grandma from her chair. "Come on in! We're just heading in to
+dinner."
+
+Emma walks past you while Uncle Rob helps Grandma up and into the kitchen.
+
+Your dad pokes his head out of the office. "Everyone's here already? Great! I
+can smell the baklava." He walks into the kitchen, and you hear Ada in there,
+too.
+
+> e
+You walk east. Everyone's in the kitchen, seated at the table: Grandma, Dad,
+Emma, Uncle Rob, Uncle Joe, and Ada. They're cheerfully talking and saying hi to
+each other. Uncle Rob in particular seems excited to say hi to everyone.
+
+You take your place at the table while Uncle Joe slices everything up.
+
+Ada stands and says, "Here's to Grandma!"
+
+"To grandma!" you all shout, and sit down to eat.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has a wrapped present, some gravy, some mashed
+potatoes, some french fries, some au gratin potatoes, some baklava, some roast
+chicken, and some plates on it.
+
+Everyone looks happy to talk, with Grandma and Emma looking especially
+interested in chatting to you. Ada, Dad, Uncle Joe, and Uncle Rob are cheerfully
+eating and talking to each other.
+
+> talk to grandma
+"Hey, grandma," you say.
+
+"Yes, dear?" she answers.
+
+1. "Are you going to open your present from Emma, Grandma?"
+2. "Nevermind, Grandma."
+> 1
+"Are you going to open your present from Emma, Grandma?"
+
+"Oh, as long as it doesn't bother anyone," says Grandma.
+
+"Yeah, go for it!" says Uncle Joe. "It's your party, have some fun!"
+
+Grandma unwraps the present, revealing a very strangely-shaped bottle. It
+intersects itself in a bizarre fashion. It's labelled 'Klein'.
+
+"I love it!" says Grandma. Emma grins.
+
+> x bottle
+This is a bottle that intersects itself in bizarre ways.
+
+> x emma
+Emma is your cousin that lives in the next town over, so you only see her on
+holidays and parties. She's around six years old, and is, honestly, a model
+child.
+
+> talk to emma
+"What's up?" asks Emma.
+
+1. "You wouldn't believe the crazy day I had!"
+2. "Where's the rest of your family, Emma?"
+3. "Just wanted to say thanks for coming!"
+> 1
+"You wouldn't believe the crazy day I had!"
+
+"Yeah? What happened?" asks Emma.
+
+"Some random woman I don't know threw me a note card from upstairs. She looked
+familiar, but I couldn't place her," you say.
+
+"Really? What did the note card say?" asks Emma.
+
+You show her the card.
+
+"That gives me an idea," says Emma. She pulls out a card of her own and takes
+notes.
+
+Ada looks over, and says, "Hey, are you guys resolving a spatio-temporal
+paradox?"
+
+"I guess?" says Emma. She runs out of the room. You hear feet on the stairs and
+floorboards creaking above you. You hear a window opening, and a woman shouting,
+"There you go, CJ! See you at dinner!" Then there are footsteps coming down the
+stairs.
+
+Emma comes back in, looking decidedly out of sorts. "You've got to get those
+stairs fixed. Whew!"
+
+> take mashed
+You scoop up a big lump of potatoes and add gravy to it.
+
+> take fries
+You snag a couple of fries. They're still pretty hot!
+
+> take au gratin
+You scoop up a healthy ladle of potatoes and lay it on your plate. The cheese is
+truly delightful.
+
+> take baklava
+Your baklava came out perfect. You pick up a slice that's dripping with honey
+and eat it.
+
+> take chicken
+You grab yourself a couple slices of chicken to eat. It's delicious!
+
+> talk to dad
+"Hey, Dad," you say.
+
+"Yeah, sweetie?"
+
+1. "Are you enjoying the party, Dad?"
+2. "Just wanted to say hi."
+> 1
+"Are you enjoying the party, Dad?"
+
+He smiles. "Yeah, I really am. When was the last time we were together like
+this? It reminds me of the parties we used to have before your grandfather
+passed away. Although the food is a lot better, thanks to Joe. Your baklava is
+pretty great, too!"
+
+1. "Just wanted to say hi."
+> 1
+"Just wanted to say hi."
+
+"Hi to you, too," he says with a smile.
+
+> talk to Rob
+"Hi, Uncle Rob!" you say.
+
+"Greetings, young CJ," he says.
+
+1. "So, have you met everyone yet?"
+2. "Just wanted to say that I hope you're enjoying your first party!"
+> 1
+"So, have you met everyone yet?"
+
+Uncle Rob scratches his copper mustache. "Well, my existence seems to be feeding
+into some kind of ontological loop where I simultaneously have both always
+existed and never existed. So yes, and no, and maybe. But I'm glad to be here!"
+he says as he downs another few bites of au gratin potatoes.
+
+1. "Just wanted to say that I hope you're enjoying your first party!"
+> 1
+"Just wanted to say that I hope you're enjoying your first party!"
+
+"It's been amazing" says Uncle Rob. "And I've been using my puzzle-solving
+skills to the max, like: what's the optimal order to try new food in? It's
+excellent!"
+
+> talk to Ada
+"Hey, Ada," you say.
+
+Ada looks up from consuming a large variety of potatoes. "What's up?" she asks.
+
+1. "By the way, Ada, congratulations on solving the problem of sentient AI."
+2. "Just glad that you're here, that's all."
+> 1
+"By the way, Ada, congratulations on solving the problem of sentient AI."
+
+"Hey, people need hobbies," says Ada. "Besides, I definitely had some help. I
+think. The timeline is pretty confusing, to be honest."
+
+1. "Just glad that you're here, that's all."
+> 1
+"Just glad that you're here, that's all."
+
+"Well I'm definitely glad to be here, too," she says with a smile.
+
+> talk to Emma
+"What's up?" asks Emma.
+
+1. "Where's the rest of your family, Emma?"
+2. "You look a little bored, Emma. Want to go do something fun?"
+3. "Just wanted to say thanks for coming!"
+> 1
+"Where's the rest of your family, Emma?"
+
+She smiles and pats the dollhouse. "Don't worry, CJ, they're in good hands!"
+
+1. "You look a little bored, Emma. Want to go do something fun?"
+2. "Just wanted to say thanks for coming!"
+> 1
+"You look a little bored, Emma. Want to go do something fun?"
+
+She nods. "Yeah, I finished dinner a while ago. Wanna play with this?" She pulls
+out her dollhouse.
+
+"Well," you say, "I'm a little old for that." She looks crestfallen, so you grab
+the dollhouse and add, "But don't worry. Let me just run this downstairs."
+     *** You have won! ***     
+
+Would you like to:
+     UNDO the last move,
+     RESTORE a saved position,
+     see a list of AMUSING things to do,
+     QUIT the program,
+     or RESTART from the beginning?
+> amusing
+Have you tried...
+
+...xyzzy?
+
+...ripping the list?
+
+...pushing the easel repeatedly?
+
+...turning off the robots?
+
+...singing in different time periods?
+
+Would you like to:
+     UNDO the last move,
+     RESTORE a saved position,
+     see a list of AMUSING things to do,
+     QUIT the program,
+     or RESTART from the beginning?
+> quit
+Thanks for playing!

--- a/test/impossible/impossible.lua.gold
+++ b/test/impossible/impossible.lua.gold
@@ -1,0 +1,3808 @@
+
+
+The Impossible Stairs
+An interactive fiction by Mathbrush.
+Written in Dialog. Authorized sequel to The Impossible Bottle by Linus Åkesson.
+Release 3. Serial number <SERIAL>.
+<COMPILER>. <LIBRARY>
+
+What a mess! The hurricane did a real number on the old family home, and to
+think it would happen the week that your dad is moving out!
+
+You notice some movement from an upstairs window. A woman that looks somewhat
+familiar leans out and throws out a paper airplane that floats down and lands by
+you.
+
+"There you go, CJ! See you at dinner!" she shouts, then slams the window shut.
+
+"Huh. Who the heck was that?" you say to yourself.
+
+[Tutorial: You can LOOK to check out your surroundings. You can type TUTORIAL
+OFF to turn off this brief tutorial at any time.]
+
+> *** From David Welbourn's walkthrough
+> look
+Front Lawn
+You are standing in front of your family home, which you recently purchased from
+your father. The front door is to the east.
+
+The paper airplane is lying on the ground next to you.
+
+[Tutorial: You can TAKE AIRPLANE to pick up the paper airplane.]
+
+> take airplane
+You scoop up the airplane and un-fold it. It's a... chores list?
+
+[Tutorial: You can now type I or INVENTORY to check your inventory.]
+
+> i
+You have a chores list.
+
+[Tutorial: You can EXAMINE LIST or X LIST or READ LIST to see what it says.]
+
+> x list
+The list says "BEFORE THE GUESTS ARRIVE:" in all caps at the top. At the bottom
+it says,
+
+-Give the good serving dish to Uncle Joe
+
+-Put the plates on the table
+
+-Find Mom's baklava recipe and make it
+
+-Help Ada finish up in the garage (could take a while)
+
+-Remind Uncle Rob about dinner
+
+Huh. Strange.
+
+[Tutorial: You can now go EAST or E to enter the house. This is the end of the
+tutorial. For more help, you can type HELP or HINT at any time. Thanks!]
+
+> x me
+You're still feeling a bit frazzled from the hurricane and helping your dad pack
+for his big move, but otherwise you're doing fine.
+
+> x house
+You moved into this place pretty soon after your mother passed away, although
+she helped design it. It's not very big, but it has a lot of great memories in
+it.
+
+It's too bad that the hurricane damaged it quite a bit. You can't see it from
+here, but it's even worse in the kitchen.
+
+> e
+(first attempting to open the front door to the east)
+You open the front door.
+
+You walk into the house (your house, now) and close the door behind you.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> x center
+This massive entertainment center is designed to hold your TV and all of its
+attachments. You haven't moved in your TV yet. You'll do that after dad moves
+out.
+
+> x carpeting
+You bought this carpet to be unique, but it turns out all the homeowners in the
+neighborhood had the same idea.
+
+> x calendar
+This calendar is a little warped from the water, but it still works. It's a
+calendar with pictures of wolves. You got it at Borders. It's August 20th, 2001.
+
+> n
+You start to head out before you remember: The garage was crushed by the tree in
+your backyard when the hurricane blew it over a few days ago. There's no way out
+there right now.
+
+Your cousin Ada was so sad about losing her projects, she hasn't been back
+since.
+
+> s
+You walk south.
+
+Office
+This is your art studio. Or, at least, it will be. Right now, it's mostly empty,
+except for a single easel in the middle and a pedestal. Your family's memory
+board is here, the only thing you kept from your dad's old office. The shelves
+and most of the books had to be thrown out.
+
+The family room is back to the north.
+
+On the pedestal, you can see a dish towel, artfully arranged.
+
+Your dad is puttering around, making sure that your new studio is ready for you
+to move into.
+
+"Oh hey, CJ," he says, looking up for a second.
+
+> x easel
+It cost a little more than you budgeted for, but you hope it will suffice for
+the next few years, at least.
+
+> x pedestal
+This hefty pedestal is where you intend to put your current inspiration. Your
+choice may shape your future career, so you've been a bit nervous about it.
+
+> x towel
+A colorful dish towel which struck your fancy at the store. It is artfully
+arranged on the pedestal, serving as your current object of inspiration.
+
+> x board
+The memory board has portraits of all your loved ones who have passed on. Right
+now, that includes your grandfather, grandmother and mom.
+
+> x grandfather
+Grandpa died before you were born. It shows him standing outside a coal mine,
+pick in hand. That was his first job, after he immigrated.
+
+> x grandmother
+This is your grandmother's graduation picture from nursing school. She's wearing
+a crisp white uniform and cap, and standing by two nuns. She passed away shortly
+after her 84th birthday.
+
+> x mom
+You only have vague memories of your mother, including the day this was taken.
+The photo shows her at a picnic, feeding you a tiny slice of baklava.
+
+The corner of a recipe card is sticking out from behind the portrait.
+
+> take card
+You snatch up the card. It's your mom's old baklava recipe!
+
+> read it
+This is your mom's recipe for baklava.
+
+The card looks pretty old, and has food stains. At the bottom, it says, 'Dad's
+recipe'. Huh, you never thought about it, but she must have got it from Grandpa.
+
+It says you need cinnamon, phyllo dough, butter, nuts, and honey. Hopefully,
+Uncle Joe isn't hogging all the butter again.
+
+[To make the baklava, you can type MAKE RECIPE in the kitchen once you have all
+the ingredients.]
+
+> x dad
+Dad has mellowed out a lot since you were younger. He has a full head of white
+hair that he finally gave up on dyeing. He changed out of his "nice suit"
+earlier so he could wear his old suit, just in case things got messy.
+
+> talk to dad
+Your dad looks up. "Hey, CJ!" he says, smiling. "What's up?"
+
+1. "Hey, I saw a strange woman standing in the upstairs window. Any idea who it
+was?"
+2. "Have you seen the serving dish?"
+3. "Do you know where the plates are?"
+4. "Oh, just wanted to say hi."
+> 1
+"Hey, I saw a strange woman standing in the upstairs window. Any idea who it
+was?"
+
+Your dad looks startled. "Huh. Strange woman. What did she look like?"
+
+"I don't know, but she looked familiar. She threw a paper airplane at me," you
+say.
+
+"Did she seem dangerous?" asks Dad.
+
+"No, it's just weird having strangers in the house," you answer.
+
+"Well, it wouldn't be the weirdest thing that's happened here. Let me know if
+you see her again, okay?" says dad.
+
+1. "Have you seen the serving dish?"
+2. "Do you know where the plates are?"
+3. "Oh, just wanted to say hi."
+> 1
+"Have you seen the serving dish?"
+
+"I think it's downstairs somewhere."
+
+1. "Have you seen the serving dish?"
+2. "Do you know where the plates are?"
+3. "Oh, just wanted to say hi."
+> 2
+"Do you know where the plates are?"
+
+"Oh, those. Last I saw them, they were in the treehouse."
+
+1. "Have you seen the serving dish?"
+2. "Do you know where the plates are?"
+3. "Oh, just wanted to say hi."
+> 3
+"Oh, just wanted to say hi."
+
+"Hi to you, too, kid. Sorry I've been so busy lately!" he says. It hasn't just
+been lately, of course, but that's just Dad.
+
+> n
+You walk north.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> e
+You walk east.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Plastic tarps are covering parts of the walls and ceilings. Light rain begins to
+drum on them.
+
+Uncle Joe is slicing and dicing potatoes like an expert chef. Which, of course,
+he is.
+
+"Hey, there you are," he says, as you walk in the room. "Hope you're hungry for
+later!"
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> x Joe
+Uncle Joe is only ten years older than you. He's a grizzled, mostly-bald man.
+He's tall and bulky, but leaner than he was a few years ago.
+
+He looks happy to see you. He's also sweating profusely in the kitchen heat.
+
+> undo
+Undoing the last turn (x joe).
+Kitchen
+
+> x Joe
+Uncle Joe is only ten years older than you. He's a grizzled, mostly-bald man.
+He's tall and bulky, but leaner than he was a few years ago.
+
+He looks happy to see you. He's also sweating profusely in the kitchen heat.
+
+> talk to Joe
+"Hey, Uncle Joe, do you have a second?"
+
+"Sure, CJ, what's up?"
+
+1. "Did you see a strange woman upstairs today?"
+2. "How's work been recently?"
+3. "Did you see what happened to the garage?"
+4. "Do you know where Uncle Rob went?"
+5. "Do you have any butter, Uncle Joe?"
+6. "Can I help you with the potatoes?"
+7. "Never mind, Uncle Joe."
+> 1
+"Did you see a strange woman upstairs today?"
+
+Uncle Joe wipes his prodigious brow. "CJ, I haven't left this kitchen at all.
+Did she look hungry? Because I think I made way too many potatoes."
+
+"No, she didn't look hungry, but she did seem familiar. She left me a chores
+list for a party," you answer.
+
+"Oh, well that's great, actually. I thought I was the only one getting ready.
+Maybe she's a guest who came early?"
+
+1. "How's work been recently?"
+2. "Did you see what happened to the garage?"
+3. "Do you know where Uncle Rob went?"
+4. "Do you have any butter, Uncle Joe?"
+5. "Can I help you with the potatoes?"
+6. "Never mind, Uncle Joe."
+> 1
+"How's work been recently?"
+
+"We opened three new franchises this month," says Uncle Joe. "We're even
+expanding into Canada!"
+
+1. "How's work been recently?"
+2. "Did you see what happened to the garage?"
+3. "Do you know where Uncle Rob went?"
+4. "Do you have any butter, Uncle Joe?"
+5. "Can I help you with the potatoes?"
+6. "Never mind, Uncle Joe."
+> 2
+"Did you see what happened to the garage?"
+
+He stops chopping for a minute.
+
+"Yeah, what a mess. Can't believe the old maple fell on it. Should never have
+planted it that close to the house."
+
+1. "How's work been recently?"
+2. "Do you know where Uncle Rob went?"
+3. "Do you have any butter, Uncle Joe?"
+4. "Can I help you with the potatoes?"
+5. "Never mind, Uncle Joe."
+> 2
+"Do you know where Uncle Rob went?"
+
+"I'm just glad he's not here snacking. That guy's an eating machine! But, you
+know, he's like you," he says, pointing at you. "He kind of 'wanders', if you
+get my drift. But I think you'll find him."
+
+1. "How's work been recently?"
+2. "Do you have any butter, Uncle Joe?"
+3. "Can I help you with the potatoes?"
+4. "Never mind, Uncle Joe."
+> 2
+"Do you have any butter, Uncle Joe?"
+
+"No, I stopped using that years ago. It's margarine for me, now."
+
+1. "How's work been recently?"
+2. "Do you have any butter, Uncle Joe?"
+3. "Can I help you with the potatoes?"
+4. "Never mind, Uncle Joe."
+> 3
+"Can I help you with the potatoes?"
+
+"Sounds great!" says Joe. He hands you a pile of potatoes and you scrub them. He
+shows you some interesting cooking techniques while you're working. He can talk
+about potatoes for hours, if you let him. He starts: "Potatoes are the fruit of
+the earth. You can roast them, boil them, fry them, mash them."
+
+He goes on: "There's baked potatoes, mashed potatoes. Fried potatoes: pan fried,
+deep fried, stir-fried. There's potato tacos, twice-baked potatoes, tater-tots,
+potatoes au gratin, chips, potato soup, potato stew, potato salad, shrimp and
+potatoes, hashbrowns, steak fries. That's about it."
+
+By now, you've washed a ton of potatoes. Uncle Joe says, "Thanks, CJ. That
+helps!"
+
+> x tarps
+You put these up on the ceiling to temporarily handle the damage from the
+hurricane.
+
+> x counter
+This long granite counter is destined to outlast you, the house, and everyone in
+it. It was installed a little crooked when it was first put in, leaving a gap.
+
+> x gap
+Stuff keeps falling in here for some reason. It's a narrow gap. Right now,
+there's a serving dish stuck in there.
+
+> x dish
+This is the family's antique serving platter. Grandpa got it from the old
+country.
+
+It looks pretty dirty right now.
+
+> take dish
+The gap is too small for an adult's arm to fit.
+
+> x oven
+This is your dad's old stove, still. Your new one won't come in until later in
+the week.
+
+> e
+You walk east.
+
+Outdoors
+A small row of houses is lined up behind yours. Most of them are clearly still
+recovering from the storm.
+
+From out here you can see the damage to your own house.
+
+The rain is drizzling.
+
+The kitchen is back to the west.
+
+The old maple tree has fallen on the garage, and the brand new treehouse is
+smashed on top of it.
+
+> x tree
+Your family's majestic maple tree has fallen onto the garage, crushing it
+completely.
+
+> x treehouse
+The hurricane knocked over the new treehouse. Now it's shattered, and so is
+everything in it!
+
+> x houses
+Most of your neighbours grew up and moved away, with newer families taking their
+place.
+
+> w
+You walk west.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Plastic tarps are covering parts of the walls and ceilings. Light rain drums on
+them.
+
+Uncle Joe is slicing and dicing potatoes like an expert chef. Which, of course,
+he is.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> s
+You walk south.
+
+Pantry
+This is your family's pantry, just a glorified closet with shelves.
+
+The shelves have some crushed walnuts and a can of yellow wax beans on them.
+
+> x shelves
+Plain white shelves, completely utilitarian. And very sturdy.
+
+> x walnuts
+Looks like this bag of crushed walnuts was the only thing left in the pantry,
+what with all the supply chain problems. You've already eaten through most of
+your supplies.
+
+> x beans
+Nobody in the house likes yellow wax beans. But this can is so old now it's part
+of your heritage, like the rest of the house.
+
+> take walnuts
+You take the crushed walnuts off the shelves.
+
+> n
+You walk north.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Plastic tarps are covering parts of the walls and ceilings. Light rain drums on
+them.
+
+Uncle Joe is slicing and dicing potatoes like an expert chef. Which, of course,
+he is.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> w
+You walk west.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again. She's holding her usual bottle of Sprite.
+
+She gives you a little wave as you walk come down the stairs.
+
+> x calendar
+This is a linen calendar towel with decorative flowers all around it. It's May
+17th, 1981, and it's Grandma's birthday!
+
+> x rug
+Sensible, practical, and easy to vacuum.
+
+> x paneling
+Your dad just recently bought this. It was fun helping him put it up.
+
+> x boombox
+This is the JVC RC-M90, the cutting edge of sound technology. Uncle Joe got it
+for Grandma for her birthday. It's blasting out "Bette Davis Eyes" at maximum
+loudness. The boombox is closed.
+
+> open it
+You open the boombox, revealing a battery.
+
+> x battery
+A single Z-cell battery. This thing is honestly huge! Ada made it herself, years
+ago.
+
+> x grandma
+Grandma looks pretty tired. Then again, she has been for weeks. She's
+comfortable on the couch in her house dress and slippers. She notices you
+looking and waves at you cheerfully.
+
+> talk to grandma
+"What is it, dear?" asks your grandmother.
+
+1. "Hey Grandma, some woman threw this list at me."
+2. "Happy Birthday!"
+3. "Grandma, do you know where the plates are?"
+4. "I can't find Uncle Rob anywhere."
+5. "Grandma, have you seen the good serving dish?"
+6. "That's all I wanted to say, Grandma."
+> 1
+"Hey Grandma, some woman threw this list at me."
+
+"Oh, that sounds pretty unusual. I've had a clipboard thrown at my face, if that
+makes you feel any better," she answers, still watching TV.
+
+"No, that doesn't...actually, yeah, that does kind of make me feel better," you
+answer.
+
+"Did she seem nice?" says Grandma.
+
+"She seemed familiar, somehow. She was leaning out the upstairs window," you
+say.
+
+"Ah, I see the problem. Don't worry dear, that kind of thing will sort itself
+out," says Grandma.
+
+1. "Happy Birthday!"
+2. "Grandma, do you know where the plates are?"
+3. "I can't find Uncle Rob anywhere."
+4. "Grandma, have you seen the good serving dish?"
+5. "That's all I wanted to say, Grandma."
+> 1
+"Happy Birthday!"
+
+"Oh thank you, Katrina," says Grandma.
+
+You try not to react at her calling you your mom's name. Grandma notices your
+unease and thinks for a moment.
+
+"I mean CJ, of course. It's not every day you turn eighty-four years old! I
+appreciate you taking care of the party!" she says, putting a kind hand on yours
+for a moment.
+
+1. "Grandma, do you know where the plates are?"
+2. "I can't find Uncle Rob anywhere."
+3. "Grandma, have you seen the good serving dish?"
+4. "That's all I wanted to say, Grandma."
+> 1
+"Grandma, do you know where the plates are?"
+
+You said plates? I'm not sure what plates you're talking about, dear, but I
+think your father would know."
+
+1. "Grandma, do you know where the plates are?"
+2. "I can't find Uncle Rob anywhere."
+3. "Grandma, have you seen the good serving dish?"
+4. "That's all I wanted to say, Grandma."
+> 2
+"I can't find Uncle Rob anywhere."
+
+"Oh, I'm not sure. He walks around like it was his purpose in life. Have you
+checked with Ada? The two of them think alike."
+
+1. "Grandma, do you know where the plates are?"
+2. "I can't find Uncle Rob anywhere."
+3. "Grandma, have you seen the good serving dish?"
+4. "That's all I wanted to say, Grandma."
+> 3
+"Grandma, have you seen the good serving dish?"
+
+"I lost that darned thing years ago. I was finishing washing up and putting away
+some of the plates when I heard the loudest clatter of my life. All the pots and
+pans had fallen over and rolled all over the room. I found them all eventually,
+but not the dish," says Grandma.
+
+1. "Grandma, do you know where the plates are?"
+2. "I can't find Uncle Rob anywhere."
+3. "Grandma, have you seen the good serving dish?"
+4. "That's all I wanted to say, Grandma."
+> 4
+"That's all I wanted to say, Grandma."
+
+She nods at you politely before going back to watching the TV.
+
+> x tv
+Dallas is playing on the television. It's a rerun, so you already know who shot
+JR. Grandma may have forgotten. The doctors like keeping things simple for her,
+these days.
+
+> x recliner
+Grandma's recliner is well past its glory years, but she refuses to replace it.
+
+> x sprite
+Grandma's been into Sprite ever since she first saw it advertised, years ago.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+Your cousin Ada is working diligently on her latest theorem in applied
+homological algebra. She seems withdrawn and focused.
+
+She notices you walk in.
+
+"Hi, CJ," she says absent-mindedly, and keeps walking around.
+
+> x whiteboard
+The whiteboard is covered in equations.
+
+> x equations
+Looks like she's studying finite subdivision rules. This is a series calculating
+the growth rate of a Gromov hyperbolic group.
+
+> x Ada
+Ada is a tall, young woman, about your age. Her wavy hair is dyed bright red,
+and she's wearing a black sweater that hangs loosely on her.
+
+She's your closest cousin, and a genius.
+
+> x sweater
+Ada has always preferred black sweaters.
+
+> talk to Ada
+Ada says, "Sorry, CJ, I'm busy. The life of a mathematician never slows down!
+Well, maybe never. But at least not until I've proven that there are no zeros
+off the critical line using annealing methods in numerical partial differential
+equations. But enough about me. What's up?"
+
+1. "Ada, did you see a strange woman upstairs?"
+2. "Make sure you're ready for dinner soon!"
+3. "So why do you like math so much anyway?"
+4. "Hey, do you know where Uncle Rob is?"
+5. "Ada, I seem to be traveling through time. Do you know anything about that?"
+6. "Hey, I know this is weird, but do you remember much about my mom?"
+7. "Nevermind, Ada!"
+> 1
+"Ada, did you see a strange woman upstairs?"
+
+"Besides you and me? Not really. Actually, have you ever even been upstairs?
+What with your... problem?"
+
+"It's not a problem, Ada!" you exclaim.
+
+"Oh, okay. That's actually a nice attitude. Anyway, no I haven't seen anyone. If
+you find her, let me know and I'll go say hi," she says.
+
+1. "Make sure you're ready for dinner soon!"
+2. "So why do you like math so much anyway?"
+3. "Hey, do you know where Uncle Rob is?"
+4. "Ada, I seem to be traveling through time. Do you know anything about that?"
+5. "Hey, I know this is weird, but do you remember much about my mom?"
+6. "Nevermind, Ada!"
+> 1
+"Make sure you're ready for dinner soon!"
+
+"Not now, CJ," says Ada. "Sorry if it sounds rude, but I feel like I'm on a real
+mission, like I can do something great here! As soon as I can figure out a
+couple problems."
+
+1. "So why do you like math so much anyway?"
+2. "Hey, do you know where Uncle Rob is?"
+3. "Ada, I seem to be traveling through time. Do you know anything about that?"
+4. "Hey, I know this is weird, but do you remember much about my mom?"
+5. "Nevermind, Ada!"
+> 1
+"So why do you like math so much anyway?"
+
+"Well, CJ, who wouldn't like math? In all the other sciences, you can doubt what
+your senses tell you. For all we know, nothing is real and we're just in a
+simulation or something. But math is a way of organizing human thought in
+consistent patterns, and it can be a source of truth even if you question
+everything else," she says.
+
+"Wow, I guess that makes sense," you say.
+
+"Also I tried biology but it was kind of boring," she says.
+
+1. "Hey, do you know where Uncle Rob is?"
+2. "Ada, I seem to be traveling through time. Do you know anything about that?"
+3. "Hey, I know this is weird, but do you remember much about my mom?"
+4. "Nevermind, Ada!"
+> 1
+"Hey, do you know where Uncle Rob is?"
+
+"Man, why do people keep asking me that?" says Ada. "Rob is kind of...you
+know..." she makes a weird gesture with her finger, like an infinity sign, and
+leans forward to whisper, "non-spatio-temporally anchored. You know. Like you.
+And our other cousin."
+
+She gives you a knowing nod and goes back to work.
+
+1. "Hey, do you know where Uncle Rob is?"
+2. "Ada, I seem to be traveling through time. Do you know anything about that?"
+3. "Hey, I know this is weird, but do you remember much about my mom?"
+4. "Nevermind, Ada!"
+> 2
+"Ada, I seem to be traveling through time. Do you know anything about that?"
+
+"Haha! Oh, CJ, you're such a kidder!" she says. "You know that you're one of the
+few members of the family with spatio-temporal disjunction. I've explained it to
+you many times before! And I specifically recall how disappointed you were when
+your beautiful and wondrous ability could be reduced to a simple and mundane 4-
+dimensional explanation! Oh, how the joy of mystery breaks down in the face of
+pure reason," she says, shaking her head.
+
+"Oh, yeah," you say. "I completely forgot about my spatio-temporal disjunction.
+Thanks for reminding me!"
+
+1. "Hey, do you know where Uncle Rob is?"
+2. "Hey, I know this is weird, but do you remember much about my mom?"
+3. "Nevermind, Ada!"
+> 2
+"Hey, I know this is weird, but do you remember much about my mom?"
+
+"I only met her when I was very little. It might be better to ask your dad or
+Joe or someone," she says a little uncomfortably.
+
+"That's why I wanted to talk to you; they knew her more and I feel like they
+would just get sad if I asked. What do you remember about her?" you say.
+
+"Oh, gosh. Well, I remember that she used to tell me stories when I was bored,
+like from Greek mythology. Cyclops and stuff. That was pretty cool. And she
+liked the color blue, and I swear I saw her take a pan out of the oven with her
+bare hands once. Although that doesn't really make sense given the laws of
+thermodynamics. Does that help?" she asks.
+
+"Yeah, that's great. Thanks Ada!" you say.
+
+1. "Hey, do you know where Uncle Rob is?"
+2. "Nevermind, Ada!"
+> 2
+"Nevermind, Ada!"
+
+"OK, CJ, see you later!" she says.
+
+> s
+You walk south.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again. She's holding her usual bottle of Sprite.
+
+> s
+You walk south.
+
+Office
+This is your father's office. It's covered in shelves filled with old classics
+and weathered issues of National Geographic, with a memory board on one wall.
+His old wooden desk is here, with his new computer.
+
+The family room is back to the north.
+
+Your dad is staring thoughtfully into space.
+
+> x desk
+Your father's desk is old and well-worn. It's been here so long it's probably
+fused with the house. You shudder to imagine someone trying to move this thing
+someday.
+
+Oh, what's this? There's a subscription form for ordering puzzles. It looks
+fairly old.
+
+> x form
+This looks fairly faded. It's a form for ordering a year's worth of crossword
+puzzle books. It's dated 1961.
+
+> x computer
+Your dad's computer is turned on, running Visicalc. You'll have to wait until
+later to play Zork II.
+
+> x dad
+Dad looks a little softer and more gentle than when you were a kid in this
+house, but he still looks tough. He has grey in his mustache, but always dyes
+his hair. He's still wearing his suit, like you remember.
+
+> x national
+These have really piled up over the years. Your dad move some of the old books
+into storage to make room for these.
+
+> take form
+You take the subscription form.
+
+> n
+You walk north.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again. She's holding her usual bottle of Sprite.
+
+> e
+You walk east.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+A whole-roasted chicken is sitting out on the counter to cool.
+
+Uncle Joe is slicing potatoes expertly. He's gotten pretty good at this since he
+started his restaurant.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> x chicken
+A tender and juicy roasted chicken. Uncle Joe sure is getting better at cooking.
+One drumstick is sticking out.
+
+> x drumstick. take it.
+This tender hunk of meat is the entire leg of a chicken.
+
+You take the drumstick.
+
+> talk to joe
+"Hey, Uncle Joe, do you have a second?"
+
+"Sure, CJ, what's up?"
+
+1. "How's work been recently?"
+2. "Do you have any butter, Uncle Joe?"
+3. "Can I help you with the potatoes?"
+4. "Never mind, Uncle Joe."
+> 2
+"Do you have any butter, Uncle Joe?"
+
+"No, I stopped using that years ago. It's margarine for me, now."
+
+1. "How's work been recently?"
+2. "Do you have any butter, Uncle Joe?"
+3. "Can I help you with the potatoes?"
+4. "Never mind, Uncle Joe."
+> 3
+"Can I help you with the potatoes?"
+
+"I think I'm good for now, but feel free to hang out!" he answers cheerfully.
+You spend a bit chatting with him about dinner and the party.
+
+> s
+You walk south.
+
+Pantry
+This is your family's pantry, just a glorified closet with shelves.
+
+The shelves have a box of Count Chocula cereal, a box of oatmeal, and a can of
+yellow wax beans on them.
+
+> x cereal
+This must be left over from Halloween.
+
+> x oatmeal
+Oh, sweet, it's your favorite: maple and brown sugar.
+
+> x
+(I only understood you as far as wanting to examine something.)
+
+> beans
+Nobody in the house likes yellow wax beans, but, on the other hand, no one wants
+to throw this out. Who knows how old this is now.
+
+> n
+You walk north.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+A whole-roasted chicken is sitting out on the counter to cool.
+
+Uncle Joe is slicing potatoes expertly. He's gotten pretty good at this since he
+started his restaurant.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> e
+You walk east.
+
+Outdoors
+Rolling grass stretches all the way to your neighbor's distant fence.
+
+The kitchen is back to the west.
+
+Your maple tree is beautiful in the summer light.
+
+> x maple
+A beautiful maple tree that has been growing for a few years. It's pretty large,
+but it will grow even bigger over time.
+
+> w
+You walk west.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+A whole-roasted chicken is sitting out on the counter to cool.
+
+Uncle Joe is slicing potatoes expertly. He's gotten pretty good at this since he
+started his restaurant.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> w
+You walk west.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again. She's holding her usual bottle of Sprite.
+
+> d
+The stairs seem to get bigger the further down you get. Or have you gotten
+smaller?
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on ABC right now,
+playing an ad for Sprite, the new drink.
+
+> x calendar
+The calendar is paper; they were handing them out at the drugstore. It's March
+5th, 1961.
+
+> x wallpaper
+Your mom bought this just a couple of weeks ago. It was fun helping her put it
+up, and is one of your last memories of her.
+
+> x carpeting
+Now this is the wave of the future! Soft and luxurious.
+
+> x grandma
+Grandma has tight curls of grey hair that bounce when she moves her head. She's
+wearing a green house dress and slippers. She gives you a little wink and goes
+back to watching TV.
+
+> x recliner
+This shiny and new recliner has been Grandma's favorite ever since her surgery.
+
+> x tv
+The TV is currently on ABC. An ad for a new softdrink is playing: Sprite! It
+seems very refreshing, and Grandma looks interested.
+
+Of course, she always lets you change the channel if you want. Too bad there are
+only 3 channels on the dial.
+
+> talk to grandma
+"What is it, dear?" asks your grandmother.
+
+1. "What do you think of the new house?"
+2. "Hey Grandma, what are you watching?"
+3. "Grandma, do you know where the plates are?"
+4. "I can't find Uncle Rob anywhere."
+5. "Grandma, have you seen the good serving dish?"
+6. "That's all I wanted to say, Grandma."
+> 1
+"What do you think of the new house?"
+
+"Oh, I adore it. The central air conditioning is just lovely!"
+
+1. "Hey Grandma, what are you watching?"
+2. "Grandma, do you know where the plates are?"
+3. "I can't find Uncle Rob anywhere."
+4. "Grandma, have you seen the good serving dish?"
+5. "That's all I wanted to say, Grandma."
+> 1
+"Hey Grandma, what are you watching?"
+
+"Coca-Cola made a new drink, it seems. It's called Sprite; isn't that the name
+of a fairy? It looks very interesting, though. I might have to try it," she
+says.
+
+1. "Can I watch with you for a bit?"
+2. "Can I change the channel, Grandma?"
+3. "That's interesting, Grandma."
+> 1
+"Can I watch with you for a bit?"
+
+"I'd love that, CJ," she says. You squeeze in next to her and she puts her arm
+around you.
+
+The kitchen on the show is a lot bigger than your own. And the lady is making
+some very strange food. You'd never thought of cinnamon gelatin before. After
+you watch for a bit, you get up again.
+
+> change channel
+You turn the tv to the next channel, CBS. It's Perry Mason! You like this show,
+but grandma is usually watching Bonanza. Good thing it changed time slots.
+Grandma takes your channel-changing in stride, and settles in to watch the new
+show.
+
+Your Grandma's future has slightly changed.
+
+> u
+You climb up the stairs. They seem to get smaller as you get higher. Or have you
+gotten taller?
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma's autographed poster of Raymond Burr is hanging on the wall.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> x poster
+Grandma is a big Perry Mason fan now, so she paid for this autographed poster of
+Raymond Burr a few years back.
+
+> d
+The stairs seem to get bigger the further down you get. Or have you gotten
+smaller?
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on CBS right now,
+playing Perry Mason..
+
+> change channel
+You turn the tv to the next channel, NBC. It's a cooking show that seems to be
+focusing on all the ways you can use cinnamon. Grandma takes your channel-
+changing in stride, and settles in to watch the new show.
+
+Your Grandma's future has slightly changed.
+
+> u. e. s
+You climb up the stairs. They seem to get smaller as you get higher. Or have you
+gotten taller?
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+You walk east.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+A whole-roasted chicken is sitting out on the counter to cool.
+
+Uncle Joe is slicing potatoes expertly. He's gotten pretty good at this since he
+started his restaurant.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+You walk south.
+
+Pantry
+This is your family's pantry, just a glorified closet with shelves.
+
+The shelves have a can of ground cinnamon, a box of Count Chocula cereal, a box
+of oatmeal, and a can of yellow wax beans on them.
+
+> x cinnamon
+This is a can of French's ground cinnamon.
+
+> take it
+You grab the cinnamon. It seems to resist you a bit. Once you take it, you feel
+your timeline partially stabilize.
+
+> n
+You walk north.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+A whole-roasted chicken is sitting out on the counter to cool.
+
+Uncle Joe is slicing potatoes expertly. He's gotten pretty good at this since he
+started his restaurant.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> w
+You walk west.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> d
+The stairs seem to get bigger the further down you get. Or have you gotten
+smaller?
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+> e
+You walk east.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Uncle Joe is slicing potatoes. He's going pretty slow, and not doing that great
+of a job.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> x gap
+Stuff keeps falling in here for some reason. It's a narrow gap. Right now,
+there's a serving dish stuck in there.
+
+> take dish
+You take the serving dish out of the gap.
+
+> give dish to Joe
+"What happened to this?" he asks incredulously. "Actually, I'd rather not know.
+Is there any way you could clean it up a little for me? I'm not putting food on
+it but it could bear a good wiping."
+
+> talk to Joe
+"Hey, Uncle Joe, do you have a second?"
+
+"Sure, CJ, what's up?"
+
+1. "How's work been recently?"
+2. "Do you have any butter, Uncle Joe?"
+3. "Can I help you with the potatoes?"
+4. "Never mind, Uncle Joe."
+> 2
+"Do you have any butter, Uncle Joe?"
+
+"Yeah, I think I have a stick laying around here somewhere," he says, then grabs
+and tosses you a stick of stick of butter. "There you go!" He stops talking and
+turns back to cooking.
+
+> x butter
+This stuff sure makes food taste good.
+
+> talk to Joe
+"Hey, Uncle Joe, do you have a second?"
+
+"Sure, CJ, what's up?"
+
+1. "How's work been recently?"
+2. "Can I help you with the potatoes?"
+3. "Never mind, Uncle Joe."
+> 1
+"How's work been recently?"
+
+"Gee, I've just been helping out Mr. Holladay in the back, but he's teaching me
+a lot about the grill," says Uncle Joe.
+
+1. "How's work been recently?"
+2. "Can I help you with the potatoes?"
+3. "Never mind, Uncle Joe."
+> 3
+"Never mind, Uncle Joe."
+
+"No problem, kid. See you around!"
+
+> s
+You walk south.
+
+Pantry
+This is your family's pantry, just a glorified closet with shelves.
+
+The shelves have a honey bear, some Cheerios, a jar of peanut butter, some cans
+of peach preserves, and a can of yellow wax beans on them.
+
+> x honey
+One of those new plastic honey bottles shaped like a bear.
+
+> take it
+You take the honey bear off the shelves.
+
+> x cheerios, peanut butter, peach and beans
+The Cheerios: A yellow box of cereal with Rocky and Bullwinkle on it.
+
+The jar of peanut butter: A short glass jar of Skippy brand peanut butter.
+
+The cans of peach preserves: A lot of cans of peach preserves. Grandma sure
+likes to be prepared.
+
+The can of yellow wax beans: Nobody in the house likes yellow wax beans. But you
+saw this in the store and put it in the cart. No one will ever know.
+
+> n and e
+North: You walk north.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Uncle Joe is slicing potatoes. He's going pretty slow, and not doing that great
+of a job.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+East: You walk east.
+
+Outdoors
+Rolling grass stretches out as far as you can see.
+
+The kitchen is back to the west.
+
+A sapling is buried out here.
+
+> x sapling
+This is a small sapling, its roots forming a sphere, more or less.
+
+> take sapling
+You aren't strong enough to pull out the sapling yourself. Someone bigger could
+do it, if you could persuade them.
+
+> w
+You walk west.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Uncle Joe is slicing potatoes. He's going pretty slow, and not doing that great
+of a job.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> talk to Joe
+"Hey, Uncle Joe, do you have a second?"
+
+"Sure, CJ, what's up?"
+
+1. "Hey Uncle Joe, could you help me move that sapling out back?"
+2. "How's work been recently?"
+3. "Can I help you with the potatoes?"
+4. "Never mind, Uncle Joe."
+> 1
+"Hey Uncle Joe, could you help me move that sapling out back?"
+
+He stops chopping for a minute.
+
+"I don't know CJ, I just planted it back there."
+
+1. "I just think it's ugly, that's all."
+2. "I think it's dangerous for the tree to be so close to the house."
+> 2
+"I think it's dangerous for the tree to be so close to the house."
+
+"Hey, thanks for the heads up. Let's go grab it!"
+
+Uncle Joe walks out to the back.
+
+> e
+You walk east.
+
+Outdoors
+Rolling grass stretches out as far as you can see.
+
+The kitchen is back to the west.
+
+Uncle Joe is eyeing the tree critically.
+
+A sapling is buried out here.
+
+> pull sapling
+Together, the two of you yank out the tree, tugging it until it pops out. Uncle
+Joe shakes off some of the dirt, fixes the roots, and says, "Smart thinking,
+kiddo. This could have done some real damage!" He tousles your hair and walks
+back inside.
+
+Outdoors
+Rolling grass stretches out as far as you can see.
+
+The kitchen is back to the west.
+
+You are now carrying a sapling. Something important has changed in the house's
+future.
+
+> w.w.s.
+You walk west.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Uncle Joe is slicing potatoes. He's going pretty slow, and not doing that great
+of a job.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+You walk west.
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+You walk south.
+
+Office
+This is your father's office. It's lined in shelves filled with old classics and
+many back issues of National Geographic, with a memory board on one wall. His
+tall oak desk takes up the most space.
+
+The family room is back to the north.
+
+Your dad curses faintly to himself, then shakes his head at the paper he is
+reading.
+
+> give form to dad
+"Huh," he says, "that actually looks kind of cool. You know, I think I'll sign
+up," he says. "But only if you help me with them."
+
+"Definitely," you say.
+
+He grabs the form from you and tucks it away.
+
+Something has changed in your father's future.
+
+> talk to dad
+Your dad looks up. "Hey, CJ!" he says, smiling. "What's up?"
+
+1. "I've been thinking about our family recently. It's pretty cool."
+2. "Do you know where the plates are?"
+3. "Oh, just wanted to say hi."
+> 1
+"I've been thinking about our family recently. It's pretty cool."
+
+Your dad pauses for a bit. "Yeah, you come from a great group. We're lucky to
+have everybody in the house together." He looks over at the memory board. "Well,
+most people. Your mom was really tough, you know. That's why we were all so
+shocked when she got breast cancer. But before she went, she was the strongest
+one in the house. Had a temper, too. She never hit you or me, but oh, would she
+shout when she was mad."
+
+He looks at the memory board, and adds, "Your grandfather was pretty much the
+same, like two peas in a pod. I heard they had some legendary arguments. But I
+only barely knew him, and by then he had mellowed out a ton. He had cancer, too,
+but it was lung cancer. You should probably get that checked out some day for
+all that stuff," he says. "But you can worry about that when you're older."
+
+The two of you chat for a little bit longer about the rest of your family before
+he gets back to work.
+
+1. "Do you know where the plates are?"
+2. "Oh, just wanted to say hi."
+> 2
+"Oh, just wanted to say hi."
+
+"Hi to you, too, kid. Sorry I've been so busy lately!" he says. It hasn't just
+been lately, of course, but that's just Dad.
+
+> n
+You walk north.
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+> u
+You climb up the stairs. They seem to get smaller as you get higher. Or have you
+gotten taller?
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> s
+You walk south.
+
+Office
+This is your father's office. It's covered in shelves filled with old classics
+and weathered issues of National Geographic, with a memory board on one wall.
+His old wooden desk is here, with his new computer.
+
+The family room is back to the north.
+
+A crossword puzzle book is lying here.
+
+Your dad is sitting at his desk, looking through papers.
+
+> x puzzle book
+This is one of your dad's favorite crossword puzzle books. It looks like he's
+solved every puzzle.
+
+> take it
+You take the crossword puzzle book.
+
+Your dad looks up, and says, "Hey, sorry kid, I already finished that one!"
+
+"It's okay, dad," you say. "I think I can find a use for it."
+
+> n
+You walk north.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> d
+The stairs seem to get bigger the further down you get. Or have you gotten
+smaller?
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+Your cousin Ada is skipping around the garage, chatting to herself and
+occasionally drawing on the whiteboard.
+
+> talk to Ada
+Ada says, "I'm trying to figure out what I want to do next. Some kind of big
+project. I'll let you know if I come up with anything! Anyway, what's up?"
+
+1. "Hey, do you know where Uncle Rob is?"
+2. "Nevermind, Ada!"
+> 2
+"Nevermind, Ada!"
+
+"OK, CJ, see you later!" she says.
+
+> s
+You walk south.
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+> d
+You look the stairs down with trepidation. What would happen? You imagine
+yourself shrinking, becoming younger and younger, scrunching into yourself until
+you become two little cells. Scary!
+
+You will not go any lower.
+
+> u
+You climb up the stairs. They seem to get smaller as you get higher. Or have you
+gotten taller?
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> e
+You walk east.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Plastic tarps are covering parts of the walls and ceilings. Light rain drums on
+them.
+
+Uncle Joe is slicing and dicing potatoes like an expert chef. Which, of course,
+he is.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> e
+You walk east.
+
+Outdoors
+A small row of houses is lined up behind yours. Most of them are clearly still
+recovering from the storm.
+
+From out here you can see the damage to your own house. The lawn has a pretty
+big hole in it, a couple feet across and fairly deep, but otherwise the damage
+is minimal.
+
+The rain is drizzling.
+
+The kitchen is back to the west.
+
+> put sapling in hole
+It fits in quite nicely. You pat the dirt around it and it seems settled in.
+
+You can feel your future change.
+
+> w
+You walk west.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Plastic tarps are covering parts of the walls and ceilings. Light rain drums on
+them.
+
+Uncle Joe is slicing and dicing potatoes like an expert chef. Which, of course,
+he is.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> w
+You walk west.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> x calendar
+This is a digital calendar. It's currently displaying the date December 23,
+2021.
+
+> x tree
+You bought your own tree a few years ago. It's smaller than your family's old
+ones, since it's just you and Joe and Ada now, but it's still beautiful. It's
+glowing in a rainbow of colors.
+
+> x rug
+Apparently this is 'boho-style'.
+
+> s
+You walk south.
+
+Office
+This is your art studio, a spacious room with a single easel in the middle. The
+family memory board takes up a lot of space on one side. You usually use the
+rest of the space to store art.
+
+The family room is back to the north.
+
+A few paintings of a dish towel line the side of the room.
+
+> x board
+The memory board has portraits of all your loved ones who have passed on. Right
+now, that includes your grandparents and your parents.
+
+> x dad
+In this photo, your father is sitting in his room late at night, reading law. He
+looks just as you remember him.
+
+> x paintings
+These are the paintings you haven't sold recently. Most of the paintings are of
+a dish towel since that was the inspiration for your first paintings twenty
+years ago.
+
+> n
+You walk north.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> e
+You walk east.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Uncle Joe is slowly and reflectively slicing potatoes. He has excellent
+technique, but less energy than he once did.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> s
+You walk south.
+
+Pantry
+This is your family's pantry, just a glorified closet with shelves.
+
+The shelves have some phyllo dough, a jar of granola, and a can of yellow wax
+beans on them.
+
+> x dough
+You set it out to warm earlier. Now it's perfect!
+
+> take it
+You take the phyllo dough off the shelves.
+
+> x granola
+You've switched over to organic granola, recently.
+
+> x beans
+Nobody in the house likes yellow wax beans. But the can has lasted longer than
+almost everything else in the house. It'd be a shame to move it now.
+
+> n
+You walk north.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Uncle Joe is slowly and reflectively slicing potatoes. He has excellent
+technique, but less energy than he once did.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> make recipe
+You preheat the oven, unroll the dough, melt the butter, and begin layering. It
+takes a while and leaves you worn out, but it's in the oven. It should be done
+after dinner, when you can let it cool while everybody talks.
+
+> e
+You walk east.
+
+Outdoors
+This plot of land is one of the biggest remaining backyards in the area. A
+pleasant stone fence sections it off.
+
+The kitchen is back to the west.
+
+A tall maple tree provides shade.
+
+> x fence
+This ended up costing more than you budgeted for, but it feels comforting. Kind
+of an earthy, settled feeling.
+
+> x tree
+This is a tall and lovely maple tree, twenty years old.
+
+> w
+You walk west.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Uncle Joe is slowly and reflectively slicing potatoes. He has excellent
+technique, but less energy than he once did.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> w
+You walk west.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+The family room has a bare hardwood floor and white, dusty walls.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> x calendar
+This is less of a calendar and more of a note to yourself. It says: "MOVE OUT:
+April 4th, 2041".
+
+> s
+You walk south.
+
+Office
+This is your former studio, but now the room is empty. It echoes in here. Your
+family's memory board is on the ground. You're not packing it, because it'll go
+in the car with you.
+
+The family room is back to the north.
+
+> x board
+The memory board has portraits of all your loved ones who have passed on. Right
+now, that includes your grandparents, your parents and Uncle Joe.
+
+> x Joe
+This picture of your Uncle Joe was taken at the opening of his first franchise,
+back when he had more hair. He's standing tall, arms crossed, grinning at the
+camera.
+
+> n
+You walk north.
+
+Family Room
+The family room has a bare hardwood floor and white, dusty walls.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> e
+You walk east.
+
+Kitchen
+The kitchen is quiet. A long granite counter runs down one side. A small oven is
+next to it. The backyard is to the east, the pantry is to the south, and the
+family room is to the west.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> s
+You walk south.
+
+Pantry
+This is your family's pantry, just a glorified closet with shelves.
+
+The shelves have a can of yellow wax beans on them.
+
+> x beans
+This can has born witness to over eighty years of history. It may well outlast
+mankind. Certainly you'll never eat it.
+
+> n
+You walk north.
+
+Kitchen
+The kitchen is quiet. A long granite counter runs down one side. A small oven is
+next to it. The backyard is to the east, the pantry is to the south, and the
+family room is to the west.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> e
+You walk east.
+
+Outdoors
+The stone fence around this plot is covered with moss, but the grass is recently
+trimmed.
+
+The kitchen is back to the west.
+
+An old maple tree provides shade here. The treehouse you built for the neighbor
+kids sits in it, with a ladder leading up.
+
+> x tree
+This is a towering, lovely maple tree, forty years old.
+
+> x ladder
+This ladder leads up into the treehouse. It's new, like the rest of the
+treehouse, and has wide steps to help you get up more easily.
+
+> x treehouse
+You wanted to leave a memento for the neighbors, when you realized that you had
+no one left to leave the house to. They've enjoyed it for the last few years.
+
+A ladder leads up into it.
+
+> u
+It's hard going, but you carefully make your way up the ladder.
+
+Treehouse
+This is a small and homey little treehouse. It's not furnished; the kids will
+take care of that, eventually. The back yard is down below.
+
+A pile of plates lies here.
+
+> x plates
+There are just enough plates for everyone to eat dinner together.
+
+> take plates
+You take the plates.
+
+> d
+You carefully negotiate your way down the ladder.
+
+Outdoors
+The stone fence around this plot is covered with moss, but the grass is recently
+trimmed.
+
+The kitchen is back to the west.
+
+An old maple tree provides shade here. The treehouse you built for the neighbor
+kids sits in it, with a ladder leading up.
+
+> w
+You walk west.
+
+Kitchen
+The kitchen is quiet. A long granite counter runs down one side. A small oven is
+next to it. The backyard is to the east, the pantry is to the south, and the
+family room is to the west.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has nothing on it.
+
+> put plates on table
+You put the plates on the table. Your whole timeline feels a bit more settled
+now.
+
+> w
+You walk west.
+
+Family Room
+The family room has a bare hardwood floor and white, dusty walls.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+Your elderly cousin Ada is pacing around the room somewhat wistfully. She still
+hasn't packed.
+
+> talk to Ada
+Ada says, "You know, CJ, I regret never living my passion...making robots! It's
+too late for me to really get into it now, but it inspired me to write about
+them! Here, take this. I only wish my younger self could have seen it."
+
+She hands you a small book.
+
+> x small book
+It says "Robot Empire", by Ada S. It's a children's book
+
+> read it
+It's about a space society of sentient robot ships that battle across an entire
+galaxy, trying to find a mysterious, black-hole orbiting planet said to contain
+the strongest metal in the universe. The main character is constantly upgrading
+itself throughout the story.
+
+> s
+You walk south.
+
+Family Room
+The family room has a bare hardwood floor and white, dusty walls.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> u
+You start going up, but it seems different up there, dark and uncertain. You'll
+take that path one day, but not today.
+
+You will not go any higher.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> d
+The stairs seem to get bigger the further down you get. Or have you gotten
+smaller?
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+Your cousin Ada is skipping around the garage, chatting to herself and
+occasionally drawing on the whiteboard.
+
+> talk to Ada
+Ada says, "I'm trying to figure out what I want to do next. Some kind of big
+project. I'll let you know if I come up with anything! Anyway, what's up?"
+
+1. "Hey, do you want to check out this book on robots?"
+2. "Hey, do you know where Uncle Rob is?"
+3. "Nevermind, Ada!"
+> 1
+"Hey, do you want to check out this book on robots?"
+
+You give young Ada the book.
+
+"Whoa! This story is awesome! I wonder if someone could make a robot in real
+life...you know what, I'm going to try it!"
+
+She immediately starts tinkering around, assembling parts. This looks like it
+might take a while.
+
+Ada's future has changed.
+
+> s
+You walk south.
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+> u
+You climb up the stairs. They seem to get smaller as you get higher. Or have you
+gotten taller?
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The robot prototype Ada's always working on is in the corner.
+
+Your cousin Ada is sketching schematics on the whiteboard.
+
+> x robot prototype
+The original toaster design remains, but there are multiple attachments now.
+
+> talk to Ada
+Ada says, "Sorry, CJ, I'm working on an idea for a robot! I've been kind of
+busy. What do you need?"
+
+1. "So why do you like robots so much anyway?"
+2. "Hey, do you know where Uncle Rob is?"
+3. "Nevermind, Ada!"
+> 1
+"So why do you like robots so much anyway?"
+
+"Robots are cool. You have to know math to make them, and they're kind of like
+biological organisms but if you don't understand how part of the body works you
+can just put whatever you want there instead. Like something that shoots sparks,
+or makes a quacking sound," she says. "Also it helps ease my mind, because if
+we're in a simulation, and I make a simulated human, it's like a double
+simulation and I'm continuing on the chain of existence," she says, and cackles
+madly.
+
+"Oh. I guess that's pretty cool," you say.
+
+"You're darn right it is!" says Ada.
+
+1. "Hey, do you know where Uncle Rob is?"
+2. "Nevermind, Ada!"
+> 2
+"Nevermind, Ada!"
+
+"OK, CJ, see you later!" she says.
+
+> s
+You walk south.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The robot prototype Ada's always working on is in the corner.
+
+Your cousin Ada is pacing around the room, tinkering with spare parts.
+
+> x robot prototype
+The original casing has been stripped off and replaced with shiny steel. It has
+a screen, too.
+
+> x screen
+The screen is inert, for now.
+
+> s
+You walk south.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The robot prototype Ada's always working on is in the corner.
+
+Your cousin Ada is frantically looking through the boxes. "Where is it?" she
+mutters.
+
+> x robot prototype
+The robot shaped like a toaster has been pried open. Wires reach out of it in
+many directions. It is silent.
+
+> x wires
+The robot shaped like a toaster has been pried open. Wires reach out of it in
+many directions. It is silent.
+
+> talk to Ada
+"Sorry, CJ, I've got a major problem right now. What's up?"
+
+1. "Hey, what's wrong? You look upset."
+2. "Hey, do you know where Uncle Rob is?"
+3. "Nevermind, Ada!"
+> 1
+"Hey, what's wrong? You look upset."
+
+Ada says, "Have you seen a battery anywhere? I made a really big battery years
+ago, large enough to power some hefty electronics. I was saving it to power my
+final creation. But I can't find it anywhere! I know I used it for something,
+but I have no idea where it's gone, or when. It's so frustrating!"
+
+"I'll see if I can find anything like that," you say.
+
+She gives you a wan smile. "Thanks!"
+
+1. "Hey, what's wrong? You look upset."
+2. "Hey, do you know where Uncle Rob is?"
+3. "Nevermind, Ada!"
+> 3
+"Nevermind, Ada!"
+
+"OK, CJ, see you later!" she says.
+
+> s
+You walk south.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Music is coming from a boombox.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> take battery
+You take the battery out of the boombox.
+
+The boombox is now silent.
+
+Grandma looks a bit put out. "I was listening to Kim Carnes!" she says. "Oh
+well. At least now I can hear Dallas better."
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The robot prototype Ada's always working on is in the corner.
+
+Your cousin Ada is frantically looking through the boxes. "Where is it?" she
+mutters.
+
+> give battery to Ada
+You hand over the Z-cell battery to Ada.
+
+"You found it!" says Ada, pumping her fist with excitement. "Perfect! You're
+gonna love what I come up with after this. Check in with me later...a lot
+later!"
+
+Ada's future has changed.
+
+> s
+You walk south.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+The family room has a bare hardwood floor and white, dusty walls.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The robot prototype Ada's always working on is in the corner.
+
+Your cousin Ada is finishing up her last bits of work. She still hasn't packed.
+
+> x robot
+The prototype looks finished! Ada must so be so excited!
+
+> talk to Ada
+Ada looks at you and beams. She says, "It's finally finished! My greatest work!
+It's Toaster Bot! Even though it...doesn't really toast anything. But it is
+vaguely toaster-shaped."
+
+She hands you the little toaster robot, then smiles.
+
+"It's not much, but it's the best I could do with the time I have..." she says.
+
+Toaster Bot beeps mysteriously.
+
+> x bot
+This is a cute little robot shaped like a toaster, although all toaster
+functionality was stripped out of it years ago. It doesn't have a lot of
+capabilities, apparently, but it's an honest-to-goodness robot with a screen and
+attachments, and that's pretty impressive.
+
+Ada probably could have improved it, given enough time.
+
+Toaster Bot shakes violently for a second before stopping.
+
+> x screen
+The screen mostly flashes, making different kinds of eyes, like UwU or OwO.
+
+Toaster Bot beeps mysteriously.
+
+> talk to Ada
+She beams at you, and says, "Hey, what's up?"
+
+1. "What should I do with this robot?"
+2. "Hey, do you know where Uncle Rob is?"
+3. "Nevermind, Ada!"
+> 1
+"What should I do with this robot?"
+
+"I dunno, I just remember how you inspired me with that robot story, years ago.
+I always wanted to inspire someone else in the same way," says Ada.
+
+1. "Hey, do you know where Uncle Rob is?"
+2. "Nevermind, Ada!"
+> 2
+"Nevermind, Ada!"
+
+"OK, CJ, see you later!" she says.
+
+> s
+You walk south.
+
+Family Room
+The family room has a bare hardwood floor and white, dusty walls.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Toaster Bot shakes violently for a second before stopping.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Toaster Bot beeps mysteriously.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+Toaster Bot shoots off a tiny shower of sparks.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Toaster Bot beeps mysteriously.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Toaster Bot gurgles and coos in your arms.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Toaster Bot shakes violently for a second before stopping.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+The boombox is silent now.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+Toaster Bot gurgles and coos in your arms.
+
+> d
+The stairs seem to get bigger the further down you get. Or have you gotten
+smaller?
+
+Toaster Bot shakes violently for a second before stopping.
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+Toaster Bot shoots off a tiny shower of sparks.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The robot prototype Ada's always working on is in the corner.
+
+Your cousin Ada is skipping around the garage, chatting to herself and
+occasionally drawing on the whiteboard.
+
+Toaster Bot beeps mysteriously.
+
+> talk to Ada
+Ada says, "I love robots! I'm going to make one. It's kind of hard for me to
+know what to do, though, but I do have a cool idea!"
+
+She messes around with the prototype for a bit, then realizes you're still
+there. "Oh, did you need anything?"
+
+1. "Hey, check out this cool Toaster Robot!"
+2. "Hey, do you know where Uncle Rob is?"
+3. "Nevermind, Ada!"
+> 1
+"Hey, check out this cool Toaster Robot!"
+
+You give young Ada the robot.
+
+"Holy Cow! What is this? I...hey, I think I know how this works! But it doesn't
+really...do much. Hmmm I think I have some ideas!"
+
+She gets to work, grabbing parts and working on a new prototype.
+
+Ada's future has changed.
+
+> s
+You walk south.
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+> u
+You climb up the stairs. They seem to get smaller as you get higher. Or have you
+gotten taller?
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+The boombox is silent now.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The walking robot prototype Ada's always working on in the corner.
+
+Your cousin Ada is staring at the whiteboard, frustrated.
+
+> x walking robot
+The old toaster shape has been replaced with a small humanoid torso. It looks
+like there should be legs at the bottom, but they're missing.
+
+> talk to Ada
+"Oh. Hey CJ. What's up?" she says.
+
+1. "Hey, what's wrong? You seem frustrated."
+2. "Hey, do you know where Uncle Rob is?"
+3. "Nevermind, Ada!"
+> 1
+"Hey, what's wrong? You seem frustrated."
+
+"I wish I had inspiration for the joints," she says. "What I really need is a
+way to study a leg in detail." She sighs. "You got any legs?"
+
+"Uh, I have two, I guess," you say, looking down at yours. "Same as you."
+
+"Well, unless I can borrow them permanently, it's not going to help. If you see
+any other legs, let me know!" she says.
+
+1. "Hey, could you use this drumstick?"
+2. "Hey, what's wrong? You seem frustrated."
+3. "Hey, do you know where Uncle Rob is?"
+4. "Nevermind, Ada!"
+> 1
+"Hey, could you use this drumstick?"
+
+"Oh!" exclaims Ada. "Yes, I could learn a lot about legs from this!"
+
+But then she looks concerned. "But this is only one leg, and it will go bad
+soon. I wish I could have more info on legs, especially in a way that won't
+decay with time. Like a photo or something."
+
+1. "Hey, could you use this drumstick?"
+2. "Hey, what's wrong? You seem frustrated."
+3. "Hey, do you know where Uncle Rob is?"
+4. "Nevermind, Ada!"
+> 4
+"Nevermind, Ada!"
+
+"OK, CJ, see you later!" she says.
+
+> s
+You walk south.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+The boombox is silent now.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> s
+You walk south.
+
+Office
+This is your art studio. Or, at least, it will be. Right now, it's mostly empty,
+except for a single easel in the middle and a pedestal. Your family's memory
+board is here, the only thing you kept from your dad's old office. The shelves
+and most of the books had to be thrown out.
+
+The family room is back to the north.
+
+On the pedestal, you can see a dish towel, artfully arranged.
+
+Your dad is hustling back and forth, finishing the last few tasks before you can
+move in completely.
+
+He looks up and smiles as you walk in before going back to his work.
+
+> take towel
+You take the dish towel off the pedestal.
+
+You feel your future career slightly change.
+
+> wipe dish
+You wipe off most of the dirt with the towel. It looks much better now!
+
+> x dish
+This is the family's antique serving platter. Grandpa got it from the old
+country.
+
+It's bright and clean.
+
+> put drumstick on pedestal
+You put the drumstick on the pedestal.
+
+You feel your future career slightly change.
+
+> n
+You walk north.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> s
+You walk south.
+
+Office
+This is your art studio, a spacious room with a single easel in the middle. The
+family memory board takes up a lot of space on one side. You usually use the
+rest of the space to store art.
+
+The family room is back to the north.
+
+A few paintings of a drumstick line the side of the room.
+
+> x paintings
+These are the paintings you haven't sold recently. Most of the paintings are of
+a drumstick since that was the inspiration for your first paintings twenty years
+ago.
+
+> take paintings
+You take the paintings of a drumstick.
+
+> n
+You walk north.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+The boombox is silent now.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The walking robot prototype Ada's always working on in the corner.
+
+Your cousin Ada is staring at the whiteboard, frustrated.
+
+> talk to Ada
+"Oh. Hey CJ. What's up?" she says.
+
+1. "Hey, are these paintings helpful at all?"
+2. "Hey, what's wrong? You seem frustrated."
+3. "Hey, do you know where Uncle Rob is?"
+4. "Nevermind, Ada!"
+> 1
+"Hey, are these paintings helpful at all?"
+
+You hand over the paintings to Ada.
+
+"This is perfect!" says Ada. "I love it! Let me go throw these in the car to get
+them framed later," she says, running into the house. You hear the front door
+open and then close a couple seconds later.
+
+She rushes back in. "Done! And thanks again! Now I can really get to work."
+
+Ada's future has changed.
+
+> s
+You walk south.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+The boombox is silent now.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+The family room has a bare hardwood floor and white, dusty walls.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The walking robot prototype Ada's always working on in the corner.
+
+Your cousin Ada is finishing up her last bits of work. She still hasn't packed.
+
+> x robot
+The prototype looks finished! Ada must so be so excited!
+
+> talk to Ada
+Ada looks at you and beams. She says, "It's finally finished! My greatest work!
+It's Walkbot!"
+
+She places the walking robot on the ground and nudges it towards you. It
+troddles forward and cuddles your leg before walking to your side. Ada smiles,
+then sighs.
+
+"There's so much more I could have done, given the time," she says.
+
+Walkbot trips a bit but catches itself as you walk.
+
+> talk to Ada
+"Hey, thanks for your help earlier. What do you need?" asks Ada.
+
+1. "What should I do with this robot?"
+2. "Hey, do you know where Uncle Rob is?"
+3. "Nevermind, Ada!"
+> 1
+"What should I do with this robot?"
+
+"Hey, I think people deserve to see this bad boy. Show it around!" says Ada
+proudly.
+
+1. "Hey, do you know where Uncle Rob is?"
+2. "Nevermind, Ada!"
+> 2
+"Nevermind, Ada!"
+
+"OK, CJ, see you later!" she says.
+
+> s
+You walk south.
+
+Family Room
+The family room has a bare hardwood floor and white, dusty walls.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Walkbot follows close behind you as you walk.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+Walkbot walks around in a little circle.
+
+> e
+You walk east.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+Uncle Joe is slowly and reflectively slicing potatoes. He has excellent
+technique, but less energy than he once did.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has some plates on it.
+
+Walkbot runs headlong into a wall, then recalibrates and follows you.
+
+> show walkbot to Joe
+"Whoa!" says Joe. "What's this?"
+
+"Ada made a walking robot," you answer.
+
+"Neat! I don't suppose it knows how to chop potatoes, does it?" he asks,
+teasingly.
+
+"I don't think so, Uncle Joe," you answer.
+
+> w
+You walk west.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+Walkbot follows close behind you as you walk.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Walkbot walks around in a little circle.
+
+> s
+You walk south.
+
+Office
+This is your art studio. Or, at least, it will be. Right now, it's mostly empty,
+except for a single easel in the middle and a pedestal. Your family's memory
+board is here, the only thing you kept from your dad's old office. The shelves
+and most of the books had to be thrown out.
+
+The family room is back to the north.
+
+On the pedestal, you can see a drumstick, artfully arranged.
+
+Your dad is puttering around, making sure that your new studio is ready for you
+to move into.
+
+Walkbot trips a bit but catches itself as you walk.
+
+> show walkbot to dad
+"Is that something Ada made?" asks Dad.
+
+"Yeah, how'd you know?" you ask.
+
+"She's always talking about robotics these days. I'm proud of her," says Dad.
+
+> n
+You walk north.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Walkbot follows close behind you as you walk.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+The boombox is silent now.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+Walkbot walks around in a little circle.
+
+> show walkbot to grandma
+"What a funny little thing!" says Grandma. "Did you buy that?"
+
+"No, Ada made it," you say.
+
+"Well that's marvelous," she says. "I'll have to tell her how proud I am."
+
+> d
+The stairs seem to get bigger the further down you get. Or have you gotten
+smaller?
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+Walkbot walks around in a little circle.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The walking robot prototype Ada's always working on in the corner.
+
+Your cousin Ada is skipping around the garage, chatting to herself and
+occasionally drawing on the whiteboard.
+
+Walkbot trips a bit but catches itself as you walk. Ada sees the walking robot
+following you and gasps.
+
+"Oh my goodness! What an adorable robot! Hello, my name is Ada. What's yours?"
+
+When the robot doesn't respond, she strokes her chin and says, "Huh. Doesn't
+talk. I wonder if I can fix that. Give me some space, I'm gonna get to work!"
+
+She immediately starts tinkering with the robot, pulling some parts out and
+replacing them with others.
+
+Ada's future has changed.
+
+> s
+You walk south.
+
+Family Room
+This family room is huge and brand-new. The walls are covered in green and
+orange floral wallpaper and the floor is soft, yellow shag carpeting.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Grandma is watching TV from her brand new recliner. It's on NBC right now,
+playing a cooking show about cinnamon.
+
+> u
+You climb up the stairs. They seem to get smaller as you get higher. Or have you
+gotten taller?
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+The boombox is silent now.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The android prototype Ada's always working on is here.
+
+Ada is taking a break, looking kind of upset.
+
+> x android
+The prototype's outward appearance looks complete, but it's turned off and has
+wires going into its head.
+
+> talk to Ada
+"Hey, CJ, what's up?" says Ada.
+
+1. "Hey, what's wrong?"
+2. "Hey, do you know where Uncle Rob is?"
+3. "Nevermind, Ada!"
+> 1
+"Hey, what's wrong?"
+
+Ada says, "I'm kind of stuck. I need a source of concentrated knowledge to train
+my robot with. And it can't be digital, I've had enough of that. I'm looking for
+something imperfect, like someone's journals or a finished book of puzzles."
+
+"Hmmm," you say, "sounds like something my dad would have."
+
+"Really? Well, let me know if you find it!" says Ada.
+
+1. "Hey, my dad finished this crossword puzzle book. Could you use it?"
+2. "Hey, what's wrong?"
+3. "Hey, do you know where Uncle Rob is?"
+4. "Nevermind, Ada!"
+> 1
+"Hey, my dad finished this crossword puzzle book. Could you use it?"
+
+You hand over the puzzle book to Ada.
+
+"Wow," says Ada. "This is perfect! And I like that your dad worked on this. The
+data will influence the robot's personality, so he might end up similar to your
+dad. Kind of like brothers!"
+
+Ada's future has changed.
+
+> s
+You walk south.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+> u
+You climb up the stairs. For some reason you feel more tired the higher you get.
+This part of the house looks different, too.
+
+Family Room
+The family room has a bare hardwood floor and white, dusty walls.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+> n
+You walk north.
+
+Garage
+The garage has been converted into a workshop for Ada. A whiteboard is in the
+corner.
+
+The family room is to the south.
+
+The android prototype Ada's always working on is here.
+
+Your cousin Ada is finishing up her last bits of work. She still hasn't packed.
+
+> x android
+The prototype looks finished! Ada must so be so excited!
+
+> talk to Ada
+Ada looks at you and beams. She says, "It's finally finished! My greatest work!
+It's Uncle Rob!"
+
+She presses a button, and Rob lights up.
+
+"Hello, CJ. It's a pleasure to see you. Do you have any food? I am quite
+hungry," says Rob.
+
+Ada smacks her forehead. "Of course! I forgot about dinner. Here, take Rob and
+let me know when everyone else gets here! I'm going to go wash up," she says,
+and walks into the house.
+
+> x Rob
+This is a big, walking, talking robot. It's engraved with the words "Uncle Rob!"
+on it. He has a thick copper mustache.
+
+> x mustache
+This metallic mustache looks quite a bit like your dad's mustache.
+
+> talk to Rob
+Uncle Rob looks at you attentively. "What do you need, CJ?" he asks.
+
+1. "What's it like being sentient?"
+2. "How do you eat food?"
+3. "Do you know any good songs?"
+4. "Nevermind."
+> 1
+"What's it like being sentient?"
+
+"Thanks, CJ! Great question! I've been wondering the same thing. In fact, I'm
+trying to determine my organizing principles in life. I can't decide if Rule 1
+should be 'I must not injure humans' or 'Live, laugh, love.'"
+
+1. "How do you eat food?"
+2. "Do you know any good songs?"
+3. "Nevermind."
+> 1
+"How do you eat food?"
+
+"You know, I honestly don't know. Probably some kind of slow-burn, inefficient
+mass-to-energy converter that requires a massive amount of infrastructure to
+deal with both constant consumption of input and constant excretion of output.
+You know, like you!"
+
+1. "Do you know any good songs?"
+2. "Nevermind."
+> 1
+"Do you know any good songs?"
+
+"Of course! This one's my favorite, from a personal hero of mine: They ruled the
+solar system
+Near ten thousand years before
+In their single starcrossed scout ships
+Mining ast'roids, spinning lore.
+
+Then one true courageous miner
+Spied a spaceship from the stars
+Boarded he that alien liner
+Out beyond the orb of Mars.
+
+Yes, that ship was filled with danger
+Mighty monsters barred his way
+Yet he solved the alien myst'ries
+Mining quite a lode that day.
+
+O, they ruled the solar system
+Near ten thousand years before
+'Til one brave advent'rous spirit
+Brought that mighty ship to shore."
+
+1. "Nevermind."
+> 1
+"Nevermind."
+
+"Never...mind? I always use my mind," he says, brow furrowing.
+
+> s
+You walk south.
+
+Family Room
+The family room has a bare hardwood floor and white, dusty walls.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Uncle Rob follows you.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This family room is decorated with a bright orange rug and walls checkered red
+and white. It's minimally decorated, since you don't use it for watching TV. You
+usually just use your devices to watch things now.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+A beautiful Christmas tree full of lights sits in the corner.
+
+Uncle Rob hums a little ditty to himself.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This cramped family room is dominated by a massive entertainment center and has
+burgundy carpeting. Unlike the rest of the house, it hasn't been hit hard by the
+hurricane.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+Uncle Rob is making notes to himself about human culture.
+
+> d
+The burden of years seems to lift from your shoulders the further down you get.
+This part of the house looks newer, too.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+The boombox is silent now.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+Uncle Rob is glancing around the room amiably.
+
+> e
+You walk east.
+
+Kitchen
+The kitchen is filled with wonderful smells. A long granite counter runs down
+one side. A small oven is next to it. The backyard is to the east, the pantry is
+to the south, and the family room is to the west.
+
+A whole-roasted chicken is sitting out on the counter to cool.
+
+Uncle Joe is slicing potatoes expertly. He's gotten pretty good at this since he
+started his restaurant.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has some plates on it.
+
+Uncle Rob follows you.
+
+> give dish to Joe
+You hand the serving platter to Uncle Joe.
+
+"This looks perfect," he says. "Thanks so much for getting this ready!"
+
+You hear someone knocking at the front door.
+
+> w
+You walk west.
+
+Family Room
+This family room is certainly much more inviting than your college dorm room.
+The brown rug and wood paneling make you feel like you're in a cabin.
+
+There is a calendar on the wall. The office is to the south, the garage is
+north, the kitchen is east, and the stairs go up and down. The front door is to
+the west.
+
+The boombox is silent now.
+
+Grandma is watching TV from her old, busted recliner. It looks like Dallas is
+playing again.
+
+You hear someone knocking at the front door.
+
+Uncle Rob follows you.
+
+> open door
+Look who it is! It's your young cousin Emma!
+
+"We finally made it! I brought a gift for Grandma, and a toy for later," she
+says. She holds up a wrapped present and a dollhouse. She looks at everyone else
+in the room behind you: "Hey grandma! Hey Uncle Rob!" she says.
+
+"Hi, Emma!" says Grandma from her chair. "Come on in! We're just heading in to
+dinner."
+
+Emma walks past you while Uncle Rob helps Grandma up and into the kitchen.
+
+Your dad pokes his head out of the office. "Everyone's here already? Great! I
+can smell the baklava." He walks into the kitchen, and you hear Ada in there,
+too.
+
+> e
+You walk east. Everyone's in the kitchen, seated at the table: Grandma, Dad,
+Emma, Uncle Rob, Uncle Joe, and Ada. They're cheerfully talking and saying hi to
+each other. Uncle Rob in particular seems excited to say hi to everyone.
+
+You take your place at the table while Uncle Joe slices everything up.
+
+Ada stands and says, "Here's to Grandma!"
+
+"To grandma!" you all shout, and sit down to eat.
+
+In the dining half of the kitchen, the big table has been assembled together for
+dinner. Right now the table has a wrapped present, some gravy, some mashed
+potatoes, some french fries, some au gratin potatoes, some baklava, some roast
+chicken, and some plates on it.
+
+Everyone looks happy to talk, with Grandma and Emma looking especially
+interested in chatting to you. Ada, Dad, Uncle Joe, and Uncle Rob are cheerfully
+eating and talking to each other.
+
+> talk to grandma
+"Hey, grandma," you say.
+
+"Yes, dear?" she answers.
+
+1. "Are you going to open your present from Emma, Grandma?"
+2. "Nevermind, Grandma."
+> 1
+"Are you going to open your present from Emma, Grandma?"
+
+"Oh, as long as it doesn't bother anyone," says Grandma.
+
+"Yeah, go for it!" says Uncle Joe. "It's your party, have some fun!"
+
+Grandma unwraps the present, revealing a very strangely-shaped bottle. It
+intersects itself in a bizarre fashion. It's labelled 'Klein'.
+
+"I love it!" says Grandma. Emma grins.
+
+> x bottle
+This is a bottle that intersects itself in bizarre ways.
+
+> x emma
+Emma is your cousin that lives in the next town over, so you only see her on
+holidays and parties. She's around six years old, and is, honestly, a model
+child.
+
+> talk to emma
+"What's up?" asks Emma.
+
+1. "You wouldn't believe the crazy day I had!"
+2. "Where's the rest of your family, Emma?"
+3. "Just wanted to say thanks for coming!"
+> 1
+"You wouldn't believe the crazy day I had!"
+
+"Yeah? What happened?" asks Emma.
+
+"Some random woman I don't know threw me a note card from upstairs. She looked
+familiar, but I couldn't place her," you say.
+
+"Really? What did the note card say?" asks Emma.
+
+You show her the card.
+
+"That gives me an idea," says Emma. She pulls out a card of her own and takes
+notes.
+
+Ada looks over, and says, "Hey, are you guys resolving a spatio-temporal
+paradox?"
+
+"I guess?" says Emma. She runs out of the room. You hear feet on the stairs and
+floorboards creaking above you. You hear a window opening, and a woman shouting,
+"There you go, CJ! See you at dinner!" Then there are footsteps coming down the
+stairs.
+
+Emma comes back in, looking decidedly out of sorts. "You've got to get those
+stairs fixed. Whew!"
+
+> take mashed
+You scoop up a big lump of potatoes and add gravy to it.
+
+> take fries
+You snag a couple of fries. They're still pretty hot!
+
+> take au gratin
+You scoop up a healthy ladle of potatoes and lay it on your plate. The cheese is
+truly delightful.
+
+> take baklava
+Your baklava came out perfect. You pick up a slice that's dripping with honey
+and eat it.
+
+> take chicken
+You grab yourself a couple slices of chicken to eat. It's delicious!
+
+> talk to dad
+"Hey, Dad," you say.
+
+"Yeah, sweetie?"
+
+1. "Are you enjoying the party, Dad?"
+2. "Just wanted to say hi."
+> 1
+"Are you enjoying the party, Dad?"
+
+He smiles. "Yeah, I really am. When was the last time we were together like
+this? It reminds me of the parties we used to have before your grandfather
+passed away. Although the food is a lot better, thanks to Joe. Your baklava is
+pretty great, too!"
+
+1. "Just wanted to say hi."
+> 1
+"Just wanted to say hi."
+
+"Hi to you, too," he says with a smile.
+
+> talk to Rob
+"Hi, Uncle Rob!" you say.
+
+"Greetings, young CJ," he says.
+
+1. "So, have you met everyone yet?"
+2. "Just wanted to say that I hope you're enjoying your first party!"
+> 1
+"So, have you met everyone yet?"
+
+Uncle Rob scratches his copper mustache. "Well, my existence seems to be feeding
+into some kind of ontological loop where I simultaneously have both always
+existed and never existed. So yes, and no, and maybe. But I'm glad to be here!"
+he says as he downs another few bites of au gratin potatoes.
+
+1. "Just wanted to say that I hope you're enjoying your first party!"
+> 1
+"Just wanted to say that I hope you're enjoying your first party!"
+
+"It's been amazing" says Uncle Rob. "And I've been using my puzzle-solving
+skills to the max, like: what's the optimal order to try new food in? It's
+excellent!"
+
+> talk to Ada
+"Hey, Ada," you say.
+
+Ada looks up from consuming a large variety of potatoes. "What's up?" she asks.
+
+1. "By the way, Ada, congratulations on solving the problem of sentient AI."
+2. "Just glad that you're here, that's all."
+> 1
+"By the way, Ada, congratulations on solving the problem of sentient AI."
+
+"Hey, people need hobbies," says Ada. "Besides, I definitely had some help. I
+think. The timeline is pretty confusing, to be honest."
+
+1. "Just glad that you're here, that's all."
+> 1
+"Just glad that you're here, that's all."
+
+"Well I'm definitely glad to be here, too," she says with a smile.
+
+> talk to Emma
+"What's up?" asks Emma.
+
+1. "Where's the rest of your family, Emma?"
+2. "You look a little bored, Emma. Want to go do something fun?"
+3. "Just wanted to say thanks for coming!"
+> 1
+"Where's the rest of your family, Emma?"
+
+She smiles and pats the dollhouse. "Don't worry, CJ, they're in good hands!"
+
+1. "You look a little bored, Emma. Want to go do something fun?"
+2. "Just wanted to say thanks for coming!"
+> 1
+"You look a little bored, Emma. Want to go do something fun?"
+
+She nods. "Yeah, I finished dinner a while ago. Wanna play with this?" She pulls
+out her dollhouse.
+
+"Well," you say, "I'm a little old for that." She looks crestfallen, so you grab
+the dollhouse and add, "But don't worry. Let me just run this downstairs."
+
+     *** You have won! ***     
+
+Would you like to:
+     UNDO the last move,
+     RESTORE a saved position,
+     see a list of AMUSING things to do,
+     QUIT the program,
+     or RESTART from the beginning?
+> amusing
+Have you tried...
+
+...xyzzy?
+
+...ripping the list?
+
+...pushing the easel repeatedly?
+
+...turning off the robots?
+
+...singing in different time periods?
+
+Would you like to:
+     UNDO the last move,
+     RESTORE a saved position,
+     see a list of AMUSING things to do,
+     QUIT the program,
+     or RESTART from the beginning?
+> quit
+Thanks for playing!


### PR DESCRIPTION
This adds 2 new interpreters, written in Go and Lua (LuaJIT).

Both interpreters pass the tests and produce byte-identical output compared to the JS interpreter. The only exception is *aa-exercise**, where the Go interpreter supports optimised tail calls.